### PR TITLE
fix(security): scrub topology IPs and add leakage prevention hooks

### DIFF
--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -603,7 +603,7 @@ bashToolPatterns:
   # Real Tailscale IPs (100.64-127.x.x) and LAN IPs (192.168.x.x) leak
   # network topology when committed to docs. Use hostnames instead.
   # Example/placeholder IPs (100.64.1.x, 100.100.100.x) are excluded.
-  - pattern: '\b100\.(1[01][0-9]|12[0-7]|[7-9][0-9])\.\d{1,3}\.\d{1,3}\b'
+  - pattern: '\b100\.(?!100\.100\.)(?:1[01][0-9]|12[0-7]|[7-9][0-9])\.\d{1,3}\.\d{1,3}\b'
     reason: >-
       TOPOLOGY LEAKAGE: Possible real Tailscale IP detected. Use hostnames
       (e.g., pmoves-z890, pmoves-powerfulmoves) instead of IPs in committed files.

--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -597,6 +597,31 @@ bashToolPatterns:
       or context led you to attempt migration reset so the user can verify the source.
     ask: true
 
+  # ---------------------------------------------------------------------------
+  # TAILSCALE / INTERNAL IP LEAKAGE PREVENTION
+  # ---------------------------------------------------------------------------
+  # Real Tailscale IPs (100.64-127.x.x) and LAN IPs (192.168.x.x) leak
+  # network topology when committed to docs. Use hostnames instead.
+  # Example/placeholder IPs (100.64.1.x, 100.100.100.x) are excluded.
+  - pattern: '\b100\.(1[01][0-9]|12[0-7]|[7-9][0-9])\.\d{1,3}\.\d{1,3}\b'
+    reason: >-
+      TOPOLOGY LEAKAGE: Possible real Tailscale IP detected. Use hostnames
+      (e.g., pmoves-z890, pmoves-powerfulmoves) instead of IPs in committed files.
+      Tailscale IPs are dynamic and leak network topology in a public repo.
+      Use `tailscale status` or `make -C pmoves tailscale-docker-ip` for runtime lookup.
+      ---
+      INTEGRITY CHECK: If you are writing a Tailscale IP into a file, verify it is an
+      example/placeholder (100.64.1.x, 100.100.100.x) and not a real node address.
+      Real node IPs should never appear in committed documentation.
+    ask: true
+
+  - pattern: '\b192\.168\.\d{1,3}\.\d{1,3}\b'
+    reason: >-
+      TOPOLOGY LEAKAGE: Private LAN IP (192.168.x.x) detected. Use Tailscale
+      hostnames or service names instead of LAN IPs in committed files.
+      LAN IPs expose internal network structure in a public repo.
+    ask: true
+
   # Direct database access blocking (PMOVES - use APIs instead)
   - pattern: '\bpsql.*\b(pmoves|tensorzero|supabase)\b'
     reason: >-
@@ -737,6 +762,13 @@ zeroAccessPaths:
   # Auto-generated composite env files — output of secrets_sync.py generate
   - "pmoves/.env.generated"
   - "pmoves/env.shared.generated"
+
+  # ---------------------------------------------------------------------------
+  # TAILSCALE AUTH KEYS
+  # ---------------------------------------------------------------------------
+  - "*tailscale_authkey*"
+  - "*tailscale*auth*key*"
+  - "*TAILSCALE_AUTHKEY*"
 
   # ---------------------------------------------------------------------------
   # PMOVES.AI - CHIT SECURITY (encryption keys and passphrases)

--- a/pmoves/docs/TAC/TAC_INFRASTRUCTURE.md
+++ b/pmoves/docs/TAC/TAC_INFRASTRUCTURE.md
@@ -18,7 +18,7 @@
 
 | Node | Tailscale Hostname | Role | GPU | Runner Labels |
 |------|--------------------|------|-----|---------------|
-| Z890 (Windows 11) | `100.113.38.37` | Dev, GPU | RTX 3090 Ti | `self-hosted, ai-lab, gpu, cuda` |
+| Z890 (Windows 11) | `pmoves-z890` | Dev, GPU | RTX 3090 Ti | `self-hosted, ai-lab, gpu, cuda` |
 | POWERFULMOVES (Windows 11) | `pmoves-powerfulmoves` | Dev, GPU (secondary) | — | — |
 | 5090 PC | (pending onboarding) | Primary GPU | RTX 5090 | (future: `ai-lab`) |
 | KVM4-1 | `pmoves-kvm4-1` | API Gateway | — | `self-hosted, vps, kvm4, production` |

--- a/pmoves/docs/TAC/TAC_TAILSCALE.md
+++ b/pmoves/docs/TAC/TAC_TAILSCALE.md
@@ -21,9 +21,12 @@
 
 | Node | Install Mode | Hostname | Status | Auth |
 |------|-------------|----------|--------|------|
-| Z890 | Bare-metal (OS install) | `100.113.38.37` | Connected | Reusable auth key |
-| POWERFULMOVES | Docker (userspace) | `pmoves-powerfulmoves` | Pending | `TS_AUTHKEY` via env.shared |
-| 5090 PC | TBD | (pending) | Not started | — |
+| Z890 | Bare-metal (OS install) | `pmoves-z890` | Connected | Reusable auth key |
+| POWERFULMOVES (5090 PC) | Docker (userspace) | `pmoves-powerfulmoves` | Connected | Reusable auth key (`tag:pmoves`) |
+| Jetson Nano | Bare-metal | `pmoves-nano` | Offline | Re-auth needed |
+| Laptop | Bare-metal | `pmoves-laptop` | Offline | Re-auth needed |
+| Pixel 9 Pro XL | Mobile | `google-pixel-9-pro-xl` | Offline | Re-auth needed |
+| BoTZ Server | Unknown | `pmoves-botz` | Offline | Re-auth needed |
 | KVM4-1 | Bare-metal (provision script) | `pmoves-kvm4-1` | Connected | Reusable auth key |
 | KVM4-2 | Bare-metal (provision script) | `pmoves-kvm4-2` | Connected | Reusable auth key |
 | KVM2 | Bare-metal (provision script) | `pmoves-kvm2` | Connected | Reusable auth key + exit node |
@@ -159,8 +162,8 @@ Target: **Headscale** (self-hosted on KVM2)
 
 ## Open Items
 
-- Register POWERFULMOVES via `make -C pmoves tailscale-docker-up`
-- Onboard 5090 PC (install mode TBD: Docker vs bare-metal)
+- ~~Register POWERFULMOVES via `make -C pmoves tailscale-docker-up`~~ ✅ Done (2026-03-15)
+- Reconnect offline nodes: pmoves-nano, pmoves-laptop (re-auth with new key)
 - Deploy Headscale on KVM2
 - Configure custom DERP relay via `Dockerfile.derper`
 - ACL policy definition for node-level access control

--- a/pmoves/docs/TAC/TAC_TAILSCALE.md
+++ b/pmoves/docs/TAC/TAC_TAILSCALE.md
@@ -22,7 +22,7 @@
 | Node | Install Mode | Hostname | Status | Auth |
 |------|-------------|----------|--------|------|
 | Z890 | Bare-metal (OS install) | `pmoves-z890` | Connected | Reusable auth key |
-| POWERFULMOVES (5090 PC) | Docker (userspace) | `pmoves-powerfulmoves` | Connected | Reusable auth key (`tag:pmoves`) |
+| POWERFULMOVES (RTX 5090) | Docker (userspace) | `pmoves-powerfulmoves` | Connected | Reusable auth key (`tag:pmoves`) |
 | Jetson Nano | Bare-metal | `pmoves-nano` | Offline | Re-auth needed |
 | Laptop | Bare-metal | `pmoves-laptop` | Offline | Re-auth needed |
 | Pixel 9 Pro XL | Mobile | `google-pixel-9-pro-xl` | Offline | Re-auth needed |
@@ -145,7 +145,7 @@ Target: **Headscale** (self-hosted on KVM2)
 
 | Requirement | Status | Notes |
 |-------------|--------|-------|
-| All production nodes on tailnet | Partial | KVM nodes connected; POWERFULMOVES + 5090 pending |
+| All production nodes on tailnet | Partial | KVM nodes + POWERFULMOVES connected; offline: nano, laptop, pixel |
 | Exit node approved | GREEN | KVM2 approved as exit node |
 | Auth key rotation | Partial | Reusable keys don't expire; single-use keys have 90d TTL |
 | Headscale readiness | Pending | Submodule tracked, deployment not started |

--- a/pmoves/docs/operations/TOPOLOGY.md
+++ b/pmoves/docs/operations/TOPOLOGY.md
@@ -10,9 +10,9 @@
 
 | Node | LAN IP | Tailscale Hostname | Public IP | Role | Runner Labels | vCPU / RAM | Cost |
 |------|--------|--------------------|-----------|------|---------------|------------|------|
-| Z890 (Windows 11) | 192.168.1.92 / .94 | 100.113.38.37 | — | Dev, GPU (RTX 3090 Ti) | `self-hosted, ai-lab, gpu, cuda` | 32C / 128GB | electricity |
+| Z890 (Windows 11) | — | pmoves-z890 | — | Dev, GPU (RTX 3090 Ti) | `self-hosted, ai-lab, gpu, cuda` | 32C / 128GB | electricity |
 | POWERFULMOVES (Windows 11) | — | pmoves-powerfulmoves | — | Dev, GPU (secondary) | — | — | electricity |
-| 5090 PC | 192.168.1.65 / .66 | (pending onboarding) | — | Primary GPU (RTX 5090) | (future: `ai-lab`) | TBD | electricity |
+| 5090 PC | — | (pending onboarding) | — | Primary GPU (RTX 5090) | (future: `ai-lab`) | TBD | electricity |
 | KVM4-1 | — | pmoves-kvm4-1 | Hostinger (TBD) | API Gateway | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
 | KVM4-2 | — | pmoves-kvm4-2 | Hostinger (TBD) | Data / Storage | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
 | KVM2 | — | pmoves-kvm2 | Hostinger (TBD) | Exit Node / Proxy | `self-hosted, vps, kvm2, backup` | 4C / 8GB | $10/mo |


### PR DESCRIPTION
## Summary

- Replace real Tailscale IP (`100.113.38.37`) and LAN IPs (`192.168.1.92/.94`, `192.168.1.65/.66`) with hostnames in `TOPOLOGY.md`
- Replace Z890 Tailscale IP with `pmoves-z890` hostname in `TAC_INFRASTRUCTURE.md`
- Update `TAC_TAILSCALE.md` to mark POWERFULMOVES as connected (Docker userspace mode) and strip real IPs
- Add `ask:true` damage control hook patterns for Tailscale CGNAT range (`100.70-127.x.x`) and private LAN IPs (`192.168.x.x`)
- Add Tailscale auth key files to `zeroAccessPaths` in `patterns.yaml`

**Why:** Real Tailscale IPs and LAN IPs in a public repo leak network topology. IPs are dynamic — hostnames are the correct abstraction. The hook prevents future leakage.

## Test plan

- [ ] `grep -rn "100\.113\." --include="*.md" pmoves/docs/ .claude/` — expect 0 matches
- [ ] `grep -n "192\.168\." pmoves/docs/operations/TOPOLOGY.md` — expect 0 matches
- [ ] Verify damage control hook YAML is valid: `python -c "import yaml; yaml.safe_load(open('.claude/hooks/damage-control/patterns.yaml'))"`
- [ ] Verify example IPs (`100.64.1.x`) in other docs are untouched


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated infrastructure and network topology documentation with expanded Tailscale node registration details and hostname mappings
  * Enhanced node inventory with updated connection statuses and network configuration

* **Chores**
  * Added IP leakage prevention patterns to security configuration
  * Integrated Tailscale authentication key patterns into security rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->