### PR TITLE
fix(infra): blanket SSL_CERT_FILE fix via env.shared

### DIFF
--- a/pmoves/bootstrap/registry.json
+++ b/pmoves/bootstrap/registry.json
@@ -152,6 +152,24 @@
       "description": "Secrets reused across PMOVES services (Supabase, providers, integrations).",
       "variables": [
         {
+          "key": "SSL_CERT_FILE",
+          "file": "pmoves/env.shared",
+          "prompt": null,
+          "default": "",
+          "help": "Clear Windows SSL cert path leak in Docker containers. Always empty.",
+          "required": false,
+          "sensitive": false
+        },
+        {
+          "key": "SSL_CERT_DIR",
+          "file": "pmoves/env.shared",
+          "prompt": null,
+          "default": "",
+          "help": "Clear Windows SSL cert dir leak in Docker containers. Always empty.",
+          "required": false,
+          "sensitive": false
+        },
+        {
           "key": "SUPABASE_URL",
           "file": "pmoves/env.shared",
           "prompt": "Remote Supabase base URL",

--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -1473,9 +1473,6 @@ services:
     - USE_CUDA=${USE_CUDA:-true}
     - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
     - FFW_PROVIDER=${FFW_PROVIDER:-faster-whisper}
-    # Clear Windows host SSL paths that leak into containers via Docker env inheritance
-    - SSL_CERT_FILE=
-    - SSL_CERT_DIR=
     - WHISPER_MODEL=${WHISPER_MODEL:-small}
     - WHISPER_LANGUAGE=${WHISPER_LANGUAGE:-en}
     deploy:
@@ -1728,8 +1725,6 @@ services:
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}
     - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
-    # Prevent Windows SSL_CERT_FILE env leak
-    - SSL_CERT_FILE=
     extra_hosts:
     - host.docker.internal:host-gateway
     ports:
@@ -1874,8 +1869,6 @@ services:
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}
     - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
-    # Prevent Windows SSL_CERT_FILE env leak
-    - SSL_CERT_FILE=
     gpus: all
     deploy:
       resources:
@@ -1998,8 +1991,6 @@ services:
     - A0_SET_browser_model_provider=openai
     - A0_SET_browser_model_name=agent_zero
     - A0_SET_browser_model_api_base=http://tensorzero-gateway:3000/openai/v1
-    # Prevent Windows SSL_CERT_FILE env leak (Windows path not valid in Linux container)
-    - SSL_CERT_FILE=
     depends_on:
       nats:
         condition: service_healthy
@@ -2069,8 +2060,6 @@ services:
       - GH_APP_ID=${GH_APP_ID:-}
       - GH_APP_SEC=${GH_APP_SEC:-}
       - GH_APP_INSTALLATION_ID=${GH_APP_INSTALLATION_ID:-}
-      # Prevent Windows SSL_CERT_FILE env leak
-      - SSL_CERT_FILE=
     depends_on:
       nats:
         condition: service_healthy
@@ -2467,9 +2456,6 @@ services:
     environment:
     - OLLAMA_HOST=0.0.0.0:11434
     - OLLAMA_MODELS=/root/.ollama/models
-    # Override Windows SSL cert paths leaked via env inheritance (x509 failures)
-    - SSL_CERT_FILE=
-    - SSL_CERT_DIR=
     - DOCKED_MODE=${DOCKED_MODE:-true}
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}

--- a/pmoves/env.shared.example
+++ b/pmoves/env.shared.example
@@ -11,6 +11,12 @@
 # CORE INFRASTRUCTURE
 # ============================================================================
 
+# Prevent Windows SSL_CERT_FILE env leak into Linux containers.
+# Docker Desktop on Windows inherits host env vars; this clears the
+# invalid Windows cert path inside containers. Safe no-op on Linux/macOS.
+SSL_CERT_FILE=
+SSL_CERT_DIR=
+
 # NATS Message Bus - Event-driven coordination backbone
 NATS_URL=nats://nats:pmoves@nats:4222
 


### PR DESCRIPTION
## Summary
- Move `SSL_CERT_FILE=` and `SSL_CERT_DIR=` to `env.shared` (blanket fix for all 83 services)
- Remove 6 per-service `SSL_CERT_FILE=` lines from `docker-compose.yml`
- Add bootstrap registry entries so `make env-setup` auto-populates

**Why:** Docker Desktop on Windows inherits host env vars into containers. The Windows `SSL_CERT_FILE` path is invalid inside Linux containers, causing Python `httpx`/`ssl` crashes. Previously fixed per-service (6 of 83); now fixed globally.

**Mechanism:** Makefile `DC` variable includes `--env-file env.shared`, which Docker Compose passes to all service containers. Setting `SSL_CERT_FILE=` (empty) overrides the leaked Windows value.

## Test plan
- [ ] `docker compose config --quiet` passes
- [ ] `grep -c 'SSL_CERT_FILE=' pmoves/docker-compose.yml` returns 0
- [ ] `grep 'SSL_CERT_FILE=' pmoves/env.shared.example` returns the new line
- [ ] All services healthy after `make up-all-new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)