### PR TITLE
fix(ui/security): close P2 vulnerabilities — JWT fail-closed, path redaction, identity hardening

### DIFF
--- a/pmoves/ui/app/api/audit/summary/route.ts
+++ b/pmoves/ui/app/api/audit/summary/route.ts
@@ -358,7 +358,7 @@ export async function GET(request: NextRequest) {
       generatedAt: new Date().toISOString(),
       warnings,
       productionAudit: {
-        source: dashboardMarkdown ? dashboardPath : null,
+        source: dashboardMarkdown ? path.basename(dashboardPath) : null,
         lastUpdated: dashboardMarkdown ? parseLabelValue(dashboardMarkdown, "Last Updated") : null,
         branch: dashboardMarkdown ? parseLabelValue(dashboardMarkdown, "Branch") : null,
         commit: dashboardMarkdown ? parseLabelValue(dashboardMarkdown, "Commit") : null,
@@ -366,16 +366,16 @@ export async function GET(request: NextRequest) {
         activeBlockers: dashboardMarkdown ? parseActiveBlockers(dashboardMarkdown) : [],
       },
       releaseGates: {
-        source: releaseGateMarkdown ? releaseGatePath : null,
+        source: releaseGateMarkdown && releaseGatePath ? path.basename(releaseGatePath) : null,
         items: releaseGateMarkdown ? parseReleaseGateRows(releaseGateMarkdown) : [],
       },
       planning: {
         roadmap: {
-          source: roadmapMarkdown ? roadmapPath : null,
+          source: roadmapMarkdown ? path.basename(roadmapPath) : null,
           lastUpdated: roadmapMarkdown ? parsePlanLastUpdated(roadmapMarkdown) : null,
         },
         nextSteps: {
-          source: nextStepsMarkdown ? nextStepsPath : null,
+          source: nextStepsMarkdown ? path.basename(nextStepsPath) : null,
           lastUpdated: nextStepsMarkdown ? parsePlanLastUpdated(nextStepsMarkdown) : null,
         },
       },

--- a/pmoves/ui/app/api/health/ingest-smoke/route.ts
+++ b/pmoves/ui/app/api/health/ingest-smoke/route.ts
@@ -59,7 +59,8 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const ownerId = (await getBootUserId()) || request.headers.get('x-owner-id') || '';
+  // Security: identity from boot user only, never from request headers
+  const ownerId = (await getBootUserId()) || '';
   if (!ownerId) {
     return NextResponse.json({ error: 'ownerId not resolvable' }, { status: 400 });
   }
@@ -70,11 +71,11 @@ export async function POST(request: NextRequest) {
   try {
     await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3001'}/api/uploads/presign`, { method: 'OPTIONS' });
     // OPTIONS noop to warm middleware; ignored
-  } catch {}
+  } catch { /* presign warmup is best-effort */ }
   try {
     // storage.buckets is only available via PostgREST; use RPC via SQL if needed.
     // Here we rely on UI upload flow to create buckets; if missing, we proceed anyway.
-  } catch {}
+  } catch { /* bucket check is best-effort */ }
   const uploadId = randomUUID();
   const key = `${DEFAULT_NAMESPACE}/users/${ownerId}/uploads/${uploadId}/smoke.txt`;
 

--- a/pmoves/ui/lib/supabaseClient.ts
+++ b/pmoves/ui/lib/supabaseClient.ts
@@ -131,7 +131,8 @@ function decodeJwtExp(token: string | undefined): number | null {
 
 export const isBootJwtExpired = (graceSeconds = 0): boolean => {
   const exp = decodeJwtExp(resolveBootJwt());
-  if (!exp) return false;
+  // Security: treat missing exp claim as expired (fail-closed)
+  if (!exp) return true;
   const now = Math.floor(Date.now() / 1000);
   return now + graceSeconds >= exp;
 };


### PR DESCRIPTION
## Summary
- **Fix `isBootJwtExpired` fail-open**: JWTs without `exp` claim now treated as expired (fail-closed security posture)
- **Redact filesystem paths**: `/api/audit/summary` now returns only filenames via `path.basename()` instead of full absolute paths
- **Remove `x-owner-id` fallback**: `/api/health/ingest-smoke` identity comes from boot user only, never from request headers

## P2 Findings Addressed
| # | Finding | File |
|---|---------|------|
| 8 | `isBootJwtExpired` returns false for no-exp JWT | `lib/supabaseClient.ts` |
| 9 | `/api/audit/summary` returns absolute filesystem paths | `app/api/audit/summary/route.ts` |
| 10 | `/api/health/ingest-smoke` accepts `x-owner-id` header | `app/api/health/ingest-smoke/route.ts` |

## Test plan
- [ ] `npm run typecheck` passes (confirmed)
- [ ] Boot JWT without `exp` claim is now treated as expired
- [ ] `/api/audit/summary` response contains only filenames, not paths
- [ ] `/api/health/ingest-smoke` ignores `x-owner-id` header

**Depends on:** PR #969 (`fix/ui-security-auth`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)