### PR TITLE
fix(infra): allowlist-based env.shared sanitizer + bootstrap root cause fix

### DIFF
--- a/pmoves/env.shared.example
+++ b/pmoves/env.shared.example
@@ -19,6 +19,26 @@ SSL_CERT_DIR=
 
 # NATS Message Bus - Event-driven coordination backbone
 NATS_URL=nats://nats:pmoves@nats:4222
+NATS_USER=nats
+
+# Meilisearch - Full-text search
+MEILI_API_KEY=
+
+# Neo4j - Graph database
+NEO4J_URL=bolt://neo4j:7687
+
+# Supabase REST (internal docker URL — set by bootstrap)
+SUPABASE_REST_URL=http://supabase-kong:8000/rest/v1
+SUPABASE_BOOT_USER_REFRESH=
+
+# Postgres service password
+SERVICE_PASSWORD_POSTGRES=
+
+# Anthropic base URL (for proxied access)
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+
+# API timeout (ms)
+API_TIMEOUT_MS=3000000
 
 # Agent Zero - Control-plane orchestrator
 AGENT_ZERO_IMAGE=ghcr.io/powerfulmoves/pmoves-agent-zero:pmoves-latest

--- a/pmoves/scripts/bootstrap_env.py
+++ b/pmoves/scripts/bootstrap_env.py
@@ -163,6 +163,41 @@ class EnvFile:
             else:
                 self.comments.append(line)
 
+    def _build_preserve_allowlist(self) -> set:
+        """Build allowlist of keys that may be preserved from the existing file.
+
+        Keys from env.shared.example and bootstrap/registry.json are allowed.
+        This prevents leaked host environment variables (Windows PATH, CUDA_PATH,
+        VSCODE_*, etc.) from surviving rewrites.
+        """
+        allowed: set = set()
+        pmoves_dir = self.path.parent
+
+        # Keys from template (env.shared.example)
+        template = pmoves_dir / (self.path.name + ".example")
+        if template.exists():
+            for line in template.read_text(encoding="utf-8").splitlines():
+                s = line.strip()
+                if s and not s.startswith("#") and "=" in s:
+                    allowed.add(s.split("=", 1)[0].strip())
+
+        # Keys from bootstrap registry
+        registry_path = pmoves_dir / "bootstrap" / "registry.json"
+        if registry_path.exists():
+            try:
+                data = json.loads(registry_path.read_text(encoding="utf-8"))
+                for svc in data.get("services", []):
+                    for var in svc.get("variables", []):
+                        if k := var.get("key"):
+                            allowed.add(k)
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+        # Also allow all currently managed keys (from this run)
+        allowed.update(self.managed_order)
+
+        return allowed
+
     def get(self, key: str) -> Optional[str]:
         raw: Optional[str] = None
         if key in self.managed_values:
@@ -217,8 +252,14 @@ class EnvFile:
             lines.append(f"{key}={value}")
 
         preserved: List[str] = []
+        allowlist = self._build_preserve_allowlist()
         for key in self.original_order:
             if key not in self.managed_order:
+                # Only preserve keys that appear in the canonical allowlist.
+                # This prevents leaked host environment variables (e.g., Windows
+                # PATH, CUDA_PATH, VSCODE_*) from persisting across rewrites.
+                if allowlist and key not in allowlist:
+                    continue
                 preserved.append(f"{key}={self.original_values[key]}")
 
         if preserved or self.comments:

--- a/pmoves/tools/sanitize_env_shared.py
+++ b/pmoves/tools/sanitize_env_shared.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Sanitize env.shared using allowlist from env.shared.example + registry.json.
+
+Only keeps variables whose keys appear in the canonical template or registry.
+Everything else (leaked Windows env, stale vars) gets dropped.
+
+Usage:
+    python3 pmoves/tools/sanitize_env_shared.py [--dry-run]
+"""
+import json
+import sys
+from pathlib import Path
+
+PMOVES_ROOT = Path(__file__).resolve().parents[1]
+
+
+def build_allowlist() -> set:
+    """Build canonical variable allowlist from template + registry."""
+    allowed = set()
+
+    # 1. Keys from env.shared.example (the committed template)
+    template = PMOVES_ROOT / "env.shared.example"
+    if template.exists():
+        for line in template.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and "=" in stripped:
+                key = stripped.split("=", 1)[0].strip()
+                if key:
+                    allowed.add(key)
+
+    # 2. Keys from bootstrap/registry.json (all service variables)
+    registry = PMOVES_ROOT / "bootstrap" / "registry.json"
+    if registry.exists():
+        data = json.loads(registry.read_text(encoding="utf-8"))
+        for service in data.get("services", []):
+            for var in service.get("variables", []):
+                key = var.get("key", "")
+                if key:
+                    allowed.add(key)
+
+    # 3. Keys from all env.tier-* files (tier-specific vars)
+    for tier_file in PMOVES_ROOT.glob("env.tier-*"):
+        if tier_file.name.endswith(".example"):
+            continue
+        for line in tier_file.read_text(encoding="utf-8", errors="replace").splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and "=" in stripped:
+                key = stripped.split("=", 1)[0].strip()
+                if key:
+                    allowed.add(key)
+
+    # 4. Always allow these infrastructure vars
+    allowed.update({
+        "SSL_CERT_FILE", "SSL_CERT_DIR",
+        "DOCKED_MODE", "TOPOLOGY_MODE", "PARENT_SYSTEM", "PARENT_VERSION",
+    })
+
+    return allowed
+
+
+def sanitize(env_path: Path, dry_run: bool = False) -> dict:
+    """Keep only allowlisted keys, comments, and blank lines."""
+    if not env_path.exists():
+        print(f"env.shared not found at {env_path}")
+        return {"error": "not found"}
+
+    allowed = build_allowlist()
+    lines = env_path.read_text(encoding="utf-8", errors="replace").splitlines()
+
+    kept = []
+    removed = []
+
+    for line in lines:
+        stripped = line.strip()
+        # Keep blank lines, comments, and managed-by headers
+        if not stripped or stripped.startswith("#"):
+            kept.append(line)
+            continue
+        # Check key against allowlist
+        if "=" in stripped:
+            key = stripped.split("=", 1)[0].strip()
+            if key in allowed:
+                kept.append(line)
+                continue
+        # Not in allowlist — remove
+        removed.append(stripped)
+
+    if dry_run:
+        print(f"Allowlist: {len(allowed)} canonical keys")
+        print(f"Would keep {len(kept)} lines, remove {len(removed)} lines")
+        for r in removed[:15]:
+            print(f"  - {r[:80]}")
+        if len(removed) > 15:
+            print(f"  ... and {len(removed) - 15} more")
+        return {"removed": len(removed), "kept": len(kept)}
+
+    env_path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    print(f"Sanitized: kept {len(kept)} lines, removed {len(removed)} non-allowlisted vars")
+    if removed:
+        print(f"Removed (first 10):")
+        for r in removed[:10]:
+            print(f"  - {r[:80]}")
+        if len(removed) > 10:
+            print(f"  ... and {len(removed) - 10} more")
+
+    return {"removed": len(removed), "kept": len(kept)}
+
+
+if __name__ == "__main__":
+    dry_run = "--dry-run" in sys.argv
+    env_path = PMOVES_ROOT / "env.shared"
+    sanitize(env_path, dry_run=dry_run)


### PR DESCRIPTION
## Summary
Two-layer defense against Windows environment leaks in env.shared:

1. **Sanitizer tool** (`pmoves/tools/sanitize_env_shared.py`): Allowlist approach — only keeps keys from `env.shared.example` + `registry.json`. Everything else gets dropped.

2. **Bootstrap root cause fix** (`pmoves/scripts/bootstrap_env.py`): `_build_preserve_allowlist()` filters preserved entries during rewrite. Leaked host vars no longer persist across bootstrap runs.

3. **Template additions** (`pmoves/env.shared.example`): Added 8 legitimate vars that were in env.shared but missing from template.

## Root Cause
`bootstrap_env.py` reads ALL existing env.shared lines into `original_values` and preserves non-managed keys on rewrite. If Windows env vars leaked in (via Docker Desktop env inheritance or `os.environ` capture), they persisted forever — causing MinIO credential failures, shell parse errors, and SSL_CERT_FILE crashes.

## Test plan
- [x] `python3 tools/sanitize_env_shared.py --dry-run` shows only host env leaks
- [x] `python3 tools/sanitize_env_shared.py` removes 15 leaked vars, keeps 418 lines
- [x] `grep SSL_CERT env.shared` shows empty values (blanket fix preserved)
- [ ] `make env-setup` regenerates env.shared without Windows vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new environment variables to configuration template (NATS_USER, MEILI_API_KEY, NEO4J_URL, SUPABASE_REST_URL, SUPABASE_BOOT_USER_REFRESH, SERVICE_PASSWORD_POSTGRES, ANTHROPIC_BASE_URL, API_TIMEOUT_MS).
  * Enhanced environment file management to properly preserve and validate configurations during setup.
  * Added utility for sanitizing environment files with dry-run support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->