### PR TITLE
fix(chit): auto-generate CHIT_PASSPHRASE + align gateway KDF

### DIFF
--- a/pmoves/services/gateway/gateway/api/chit.py
+++ b/pmoves/services/gateway/gateway/api/chit.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Optional, Sequence
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field, ConfigDict, model_validator
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # type: ignore
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC  # type: ignore
+from cryptography.hazmat.primitives import hashes as _hashes  # type: ignore
 
 from pmoves.chit import CGP_SPEC_VERSION
 from services.common.env import get_secret
@@ -68,7 +70,8 @@ def decrypt_anchor(const: Dict[str, Any]) -> None:
     if not CHIT_DECRYPT_ANCHORS:
         raise HTTPException(status_code=400, detail="Encrypted anchor but CHIT_DECRYPT_ANCHORS=false")
     iv = base64.b64decode(enc["iv"]); salt = base64.b64decode(enc["salt"]); ct = base64.b64decode(enc["ct"])
-    key = hashlib.scrypt(CHIT_PASSPHRASE.encode(), salt=salt, n=2**14, r=8, p=1, dklen=32)
+    kdf = PBKDF2HMAC(algorithm=_hashes.SHA256(), length=32, salt=salt, iterations=600_000)
+    key = kdf.derive(CHIT_PASSPHRASE.encode("utf-8"))
     aead = AESGCM(key); aad = canon({"id": const.get("id","")})
     try:
         pt = aead.decrypt(iv, ct, aad)

--- a/pmoves/tools/brand_defaults.py
+++ b/pmoves/tools/brand_defaults.py
@@ -321,6 +321,11 @@ def upsert_env(path: Path, env_gen_path: Path, pairs: dict[str, str]) -> None:
     # Agent Zero defaults: MCP secret, JetStream, model routing.
     text = _ensure_agent_zero_defaults(text)
 
+    # CHIT passphrase: auto-generate if blank (HMAC signing + anchor encryption key).
+    chit_pass = _get_kv(text, "CHIT_PASSPHRASE")
+    if _is_blank_or_placeholder(chit_pass):
+        text = _set_kv(text, "CHIT_PASSPHRASE", _strong_random(48))
+
     path.write_text(text, encoding="utf-8")
 
     # Mirror NEO4J_AUTH into .env.generated for compose-only consumers.


### PR DESCRIPTION
## Summary
- **brand_defaults.py**: Auto-generate `CHIT_PASSPHRASE` (48-byte urlsafe token) during `make env-setup`, closing the gap where this key required manual provisioning
- **gateway/api/chit.py**: Replace `hashlib.scrypt` KDF with `PBKDF2HMAC(SHA256, 600K iterations)` for anchor decryption, aligning with the canonical `chit_security.py` implementation — fixes interoperability bug where anchors encrypted by `encrypt_anchors()` could not be decrypted by the gateway

## Context
Investigation revealed 4 gaps in CHIT passphrase flow:
1. `brand_defaults.py` did not generate `CHIT_PASSPHRASE` (fixed)
2. Gateway used scrypt KDF vs chit_security's PBKDF2 (fixed)
3. UNFCU cipher router has no CHIT integration (separate task)
4. `CHIT_REQUIRE_SIGNATURE` defaults false everywhere (by design for dev)

## Test plan
- [ ] Run `python pmoves/tools/brand_defaults.py --env-file /tmp/test.env` and verify `CHIT_PASSPHRASE` is generated
- [ ] Verify `py_compile` passes on both modified files
- [ ] Existing CHIT contract CI check should pass (schema validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Enhanced encryption key derivation algorithm for improved security.

* **Improvements**
  * Automatic generation of encryption credentials during setup, streamlining the configuration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->