### PR TITLE
fix(ui/tests): add Response polyfill for jsdom resilience tests

### DIFF
--- a/pmoves/ui/lib/__tests__/resilience.test.ts
+++ b/pmoves/ui/lib/__tests__/resilience.test.ts
@@ -8,6 +8,28 @@
 import { retry, CircuitBreaker, resilientFetch } from '../resilience';
 
 // ---------------------------------------------------------------------------
+// Polyfills for jsdom (lacks fetch API Response class)
+// ---------------------------------------------------------------------------
+if (typeof globalThis.Response === 'undefined') {
+  globalThis.Response = class Response {
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly headers: Headers;
+    private _body: string;
+    constructor(body?: string | null, init?: { status?: number; statusText?: string }) {
+      this._body = body ?? '';
+      this.status = init?.status ?? 200;
+      this.statusText = init?.statusText ?? 'OK';
+      this.ok = this.status >= 200 && this.status < 300;
+      this.headers = new Headers();
+    }
+    async text() { return this._body; }
+    async json() { return JSON.parse(this._body); }
+  } as unknown as typeof Response;
+}
+
+// ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The `resilientFetch()` tests from PR #977 use the `Response` class which is unavailable in jsdom. Adds a minimal polyfill so all 3 resilientFetch tests pass in CI.

## Test plan
- [ ] `npm run test` — all 495 tests pass (3 were failing without this polyfill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test infrastructure to improve environment compatibility and test execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->