### PR TITLE
fix(infra): add pmoves_data to extract-worker for Qdrant/Meilisearch

### DIFF
--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -1323,6 +1323,7 @@ services:
     - pmoves_app
     - pmoves_bus
     - pmoves_api  # reach supabase-kong for REST API
+    - pmoves_data  # reach qdrant + meilisearch + minio
     - pmoves_external  # HuggingFace model downloads at runtime
     extra_hosts:
     - host.docker.internal:host-gateway


### PR DESCRIPTION
## Summary
Extract-worker depends on qdrant + meilisearch + minio (all on pmoves_data network) but was missing pmoves_data from its network list. Added it.

Also discovered: Qdrant client 1.15.1 vs server 1.10.0 version mismatch causing silent vector insert failures. Tracked as follow-up.

## Test plan
- [x] extract-worker can resolve qdrant hostname
- [x] /ingest returns ok:true with chunks > 0

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to enhance data service accessibility within the application stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->