### PR TITLE
fix(infra): add pmoves_data network to 3 services missing MinIO access

### DIFF
--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -1368,6 +1368,7 @@ services:
     networks:
     - pmoves_app
     - pmoves_bus
+    - pmoves_data  # MinIO access (minio:9000)
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8092/healthz', timeout=5)"]
       interval: 30s
@@ -1455,6 +1456,7 @@ services:
     - pmoves_app
     - pmoves_bus
     - pmoves_api
+    - pmoves_data  # MinIO access (minio:9000)
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz', timeout=5)"]
       interval: 30s
@@ -1622,6 +1624,7 @@ services:
     - pmoves_app
     - pmoves_api
     - pmoves_bus
+    - pmoves_data      # MinIO access (minio:9000)
     - pmoves_external  # Required for YouTube API access
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8077/healthz', timeout=5)"]


### PR DESCRIPTION
## Summary
Cross-tier network audit found **3 services** that reference `minio:9000` in their environment but are NOT on the `pmoves_data` network where MinIO lives. Without this network, DNS resolution for `minio` fails silently.

## Services Fixed

| Service | Had Networks | Added | Reason |
|---------|-------------|-------|--------|
| `pdf-ingest` | `pmoves_app`, `pmoves_bus` | **`pmoves_data`** | `MINIO_ENDPOINT=minio:9000` |
| `transcribe-backend` | `pmoves_app`, `pmoves_bus`, `pmoves_api` | **`pmoves_data`** | `MINIO_ENDPOINT=minio:9000` |
| `pmoves-yt` | `pmoves_app`, `pmoves_api`, `pmoves_bus`, `pmoves_external` | **`pmoves_data`** | `MINIO_ENDPOINT=minio:9000` |

## Root Cause
When the 5-tier network model was introduced (`pmoves_data`, `pmoves_api`, `pmoves_app`, `pmoves_bus`, `pmoves_external`), these worker services were not updated to include `pmoves_data` for MinIO access.

## Test plan
- [ ] `docker compose config --quiet` passes (validated)
- [ ] After `docker compose up`, pdf-ingest can reach `minio:9000`
- [ ] After `docker compose up`, transcribe-backend can reach `minio:9000`
- [ ] After `docker compose up`, pmoves-yt can reach `minio:9000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved inter-service network connectivity for enhanced data access and sharing capabilities across system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->