### PR TITLE
fix(tts): disable GRADIO_MCP_SERVER + Qdrant v1.14.1

### DIFF
--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -2702,7 +2702,7 @@ services:
     environment:
       - GRADIO_SERVER_NAME=0.0.0.0
       - GRADIO_SERVER_PORT=7861
-      - GRADIO_MCP_SERVER=true
+      - GRADIO_MCP_SERVER=false  # Requires gradio[mcp] extra - enable after image rebuild
       # WSL2/CUDA compatibility settings
       - CUDA_FORCE_PTX_JIT=1
       - CUDA_DEVICE_ORDER=PCI_BUS_ID

--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -1015,7 +1015,7 @@ services:
   # =============================================================================
 
   qdrant:
-    image: qdrant/qdrant:v1.10.0
+    image: qdrant/qdrant:v1.14.1
     restart: unless-stopped
     cap_drop:
       - ALL


### PR DESCRIPTION
## Summary
- Qdrant v1.10.0 -> v1.14.1 (client 1.15.1 compatibility)
- Disable GRADIO_MCP_SERVER=true (needs gradio[mcp] extra, not in image)
- TTS Studio now healthy at :7861
- Note: gradio MCP can be added to BoTZ/Gateway instead

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data store to version 1.14.1.
  * Adjusted server configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->