### PR TITLE
feat(embeddings): prosodic embedding pipeline + cross-dimensional query

### DIFF
--- a/pmoves/services/extract-worker/worker.py
+++ b/pmoves/services/extract-worker/worker.py
@@ -24,6 +24,8 @@ MEILI_API_KEY = os.environ.get("MEILI_API_KEY","")
 SUPA = os.environ.get("SUPA_REST_URL","http://postgrest:3000")
 EMBEDDING_BACKEND = os.environ.get("EMBEDDING_BACKEND", "sentence-transformers").lower()
 USE_NAMED_VECTORS = os.environ.get("QDRANT_USE_NAMED_VECTORS", "false").lower() in ("1", "true", "yes")
+PROSODIC_EMBED_ENABLED = os.environ.get("PROSODIC_EMBED_ENABLED", "false").lower() in ("1", "true", "yes")
+PROSODIC_EMBED_DIM = int(os.environ.get("PROSODIC_EMBED_DIM", "512"))  # CLAP default
 
 app = FastAPI(title="PMOVES Extract Worker", version="1.0.0")
 
@@ -46,8 +48,37 @@ def _meili(method: str, path: str, **kwargs):
 def _build_vectors_config(dim: int):
     """Build vectors_config for Qdrant — named or unnamed based on feature flag."""
     if USE_NAMED_VECTORS:
-        return {"semantic": VectorParams(size=dim, distance=Distance.COSINE)}
+        cfg = {"semantic": VectorParams(size=dim, distance=Distance.COSINE)}
+        if PROSODIC_EMBED_ENABLED:
+            cfg["prosodic"] = VectorParams(size=PROSODIC_EMBED_DIM, distance=Distance.COSINE)
+        return cfg
     return VectorParams(size=dim, distance=Distance.COSINE)
+
+
+# ── Prosodic embedding (CLAP text-to-audio alignment) ──
+_clap_model = None
+
+def _embed_prosodic(texts: List[str]):
+    """Compute prosodic embeddings via CLAP text encoder.
+
+    Returns numpy array of shape (len(texts), PROSODIC_EMBED_DIM) or None
+    if CLAP is unavailable. CLAP maps text into the same space as audio,
+    capturing prosodic/acoustic character rather than semantic meaning.
+    """
+    if not PROSODIC_EMBED_ENABLED:
+        return None
+    global _clap_model
+    try:
+        if _clap_model is None:
+            from laion_clap import CLAP_Module  # type: ignore
+            _clap_model = CLAP_Module(enable_fusion=True)
+            _clap_model.load_ckpt()
+        emb = _clap_model.get_text_embedding(texts, use_tensor=False)
+        return np.asarray(emb, dtype=float)
+    except ImportError:
+        return None
+    except Exception:
+        return None
 
 
 def _get_collection_dim(info) -> int | None:
@@ -150,6 +181,7 @@ def ingest(body: Dict[str, Any] = Body(...)):
             if chunks:
                 texts = [c.get('text','') for c in chunks]
                 vecs = _embed(texts)
+                prosodic_vecs = _embed_prosodic(texts) if USE_NAMED_VECTORS else None
                 embeddings_processed_total.inc(len(texts))
 
                 qc = QdrantClient(url=QDRANT_URL, timeout=30.0)
@@ -164,7 +196,12 @@ def ingest(body: Dict[str, Any] = Body(...)):
                     else:
                         ns = (chunk.get("namespace") or "pmoves").strip()
                         point_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{ns}:{chunk_id}"))
-                    vec_data = {"semantic": v.tolist()} if USE_NAMED_VECTORS else v.tolist()
+                    if USE_NAMED_VECTORS:
+                        vec_data = {"semantic": v.tolist()}
+                        if prosodic_vecs is not None:
+                            vec_data["prosodic"] = prosodic_vecs[i].tolist()
+                    else:
+                        vec_data = v.tolist()
                     points.append(PointStruct(id=point_id, vector=vec_data, payload=chunk))
 
                 qc.upsert(collection_name=COLL, points=points)

--- a/pmoves/services/hi-rag-gateway-v2/app.py
+++ b/pmoves/services/hi-rag-gateway-v2/app.py
@@ -1603,6 +1603,91 @@ def hirag_query(req: QueryReq = Body(...), request: Request = None, _=Depends(re
         "hits": base,
     }
 
+@app.post("/hirag/query/cross-dimensional")
+def hirag_cross_dimensional(body: Dict[str, Any] = Body(...), request: Request = None, _=Depends(require_tailscale)):
+    """Query both semantic and prosodic vector spaces, return divergence signal.
+
+    When QDRANT_USE_NAMED_VECTORS is enabled and the collection has a "prosodic"
+    named vector, this endpoint searches both spaces independently and computes
+    rank divergence — a measure of how differently the two embedding lenses
+    see the same content.
+
+    High divergence = content where meaning and sound disagree (interesting signal).
+    """
+    query = body.get("query", "")
+    k = int(body.get("k", 10))
+    namespace = body.get("namespace", "pmoves")
+    if not query:
+        raise HTTPException(400, "query is required")
+    if not USE_NAMED_VECTORS:
+        raise HTTPException(501, "Cross-dimensional query requires QDRANT_USE_NAMED_VECTORS=true")
+
+    # Embed in semantic space
+    semantic_vec = embed_query(query)
+    must = [FieldCondition(key="namespace", match=MatchValue(value=namespace))]
+    qfilter = Filter(must=must)
+
+    # Search semantic space
+    semantic_hits = _qdrant_search(
+        collection_name=COLL, query_vector=semantic_vec,
+        limit=k * 3, query_filter=qfilter,
+        with_payload=True, with_vectors=False,
+        vector_name=SEMANTIC_VECTOR_NAME,
+    )
+
+    # Try prosodic space (may not exist or have data)
+    prosodic_hits = []
+    has_prosodic = False
+    try:
+        prosodic_hits = _qdrant_search(
+            collection_name=COLL, query_vector=semantic_vec,
+            limit=k * 3, query_filter=qfilter,
+            with_payload=True, with_vectors=False,
+            vector_name="prosodic",
+        )
+        has_prosodic = True
+    except Exception:
+        pass  # prosodic vector may not exist in collection
+
+    # Compute rank divergence: Kendall tau-like distance between rankings
+    def _extract_ids(hits):
+        return [getattr(h, "id", None) or (h.payload or {}).get("chunk_id") for h in hits]
+
+    sem_ids = _extract_ids(semantic_hits)
+    pro_ids = _extract_ids(prosodic_hits) if has_prosodic else []
+
+    divergence = 0.0
+    if sem_ids and pro_ids:
+        # Jaccard distance of top-k sets
+        sem_set = set(sem_ids[:k])
+        pro_set = set(pro_ids[:k])
+        intersection = sem_set & pro_set
+        union = sem_set | pro_set
+        divergence = 1.0 - (len(intersection) / len(union)) if union else 0.0
+
+    # Format results
+    def _format_hits(hits, limit):
+        out = []
+        for h in hits[:limit]:
+            payload = h.payload or {}
+            out.append({
+                "chunk_id": payload.get("chunk_id") or h.id,
+                "text": payload.get("text", "")[:500],
+                "score": float(h.score),
+                "source": payload.get("source", ""),
+            })
+        return out
+
+    return {
+        "query": query,
+        "semantic_results": _format_hits(semantic_hits, k),
+        "prosodic_results": _format_hits(prosodic_hits, k) if has_prosodic else [],
+        "has_prosodic": has_prosodic,
+        "divergence": round(divergence, 4),
+        "k": k,
+    }
+
+
 @app.post("/hirag/admin/refresh")
 def hirag_admin_refresh(_=Depends(require_admin_tailscale)):
     refresh_warm_dictionary()


### PR DESCRIPTION
## Summary
- CLAP-based prosodic embeddings as second dimension alongside semantic text embeddings
- New `/hirag/query/cross-dimensional` endpoint that queries both spaces and computes rank divergence
- "Dark matter" signal: divergence reveals where meaning and sound disagree

## Architecture
```
Content "How to configure agents" →
  semantic embed: [0.12, -0.34, ...]  ← what it means
  prosodic embed: [0.56, 0.78, ...]   ← how it sounds/flows
  
Same point, two vectors, one payload. Compare rankings = divergence signal.
```

## Changes
**Extract-worker:**
- `PROSODIC_EMBED_ENABLED` env flag (default: false)
- `_embed_prosodic()`: CLAP text encoder (`laion_clap.CLAP_Module`)
- Collection schema includes `"prosodic"` named vector when enabled
- Upsert builds multi-vector dict: `{"semantic": [...], "prosodic": [...]}`

**Hi-RAG v2:**
- `POST /hirag/query/cross-dimensional` — new endpoint
- Searches semantic + prosodic spaces independently
- Jaccard-based rank divergence (0.0 = identical rankings, 1.0 = completely different)
- Graceful: returns `has_prosodic: false` when prosodic vectors unavailable

## Depends on
- PR #1010 (`feat/qdrant-named-vectors`) — base branch

## Test plan
- [ ] `python -m py_compile` both files (verified)
- [ ] Set `QDRANT_USE_NAMED_VECTORS=true` + `PROSODIC_EMBED_ENABLED=false` → verify semantic-only indexing unchanged
- [ ] Set `PROSODIC_EMBED_ENABLED=true` with `laion_clap` installed → verify dual vectors indexed
- [ ] `POST /hirag/query/cross-dimensional` with prosodic data → verify divergence score returned
- [ ] `POST /hirag/query/cross-dimensional` without prosodic data → verify `has_prosodic: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)