### PR TITLE
fix(security): bind admin ports to localhost, harden git pull

### DIFF
--- a/pbnj/pinokio/api/pmoves-services/update.js
+++ b/pbnj/pinokio/api/pmoves-services/update.js
@@ -5,7 +5,7 @@ module.exports = {
       params: {
         path: "../..",
         message: [
-          "git pull origin main",
+          "git pull --verify-signatures origin main",
           "git submodule update --init --recursive"
         ]
       }

--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -639,7 +639,7 @@ services:
     - KONG_PROXY_ERROR_LOG=/dev/stderr
     - KONG_ADMIN_ERROR_LOG=/dev/stderr
     - KONG_PROXY_LISTEN=0.0.0.0:8000
-    - KONG_ADMIN_LISTEN=0.0.0.0:8001
+    - KONG_ADMIN_LISTEN=127.0.0.1:8001
     # JWT plugin
     - KONG_PLUGINS=bundled,jwt
     - KONG_NGINX_PROXY_PROXY_BUFFERS=8 16k
@@ -660,7 +660,7 @@ services:
         condition: service_healthy
     ports:
     - ${SUPABASE_KONG_PROXY_PORT:-8000}:8000
-    - ${SUPABASE_KONG_ADMIN_PORT:-8001}:8001
+    - 127.0.0.1:${SUPABASE_KONG_ADMIN_PORT:-8001}:8001
     networks:
     - pmoves_api
     - pmoves_data
@@ -1090,7 +1090,7 @@ services:
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}
     - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
     ports:
-    - ${NEO4J_HTTP_PORT:-7474}:7474
+    - 127.0.0.1:${NEO4J_HTTP_PORT:-7474}:7474
     - ${NEO4J_BOLT_PORT:-7687}:7687
     volumes:
     - neo4j-data:/data
@@ -1119,7 +1119,7 @@ services:
     - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
     ports:
     - ${MINIO_PORT:-9000}:9000
-    - ${MINIO_CONSOLE_PORT:-9001}:9001
+    - 127.0.0.1:${MINIO_CONSOLE_PORT:-9001}:9001
     volumes:
     - minio-data:/data
     networks:


### PR DESCRIPTION
## Summary
- Bind Kong admin (8001), MinIO console (9001), Neo4j HTTP (7474) to `127.0.0.1` only
- Prevents LAN-Wide-Web auto-discovery of admin interfaces with default credentials
- Add `--verify-signatures` to Pinokio `update.js` git pull

## Problem
P7 LAN-Wide-Web auto-discovers ALL localhost servers and makes them available as `https://<PORT>.localhost` to any machine on the LAN. With ports bound to `0.0.0.0`:
- Kong admin API: unauthenticated, can inject routes/modify JWT rules
- MinIO console: `minioadmin:minioadmin` default creds → full S3 access
- Neo4j browser: graph database access with env-default password

## Fix
```yaml
# Before (all interfaces)
- ${SUPABASE_KONG_ADMIN_PORT:-8001}:8001
# After (localhost only)  
- 127.0.0.1:${SUPABASE_KONG_ADMIN_PORT:-8001}:8001
```

Kong also gets `KONG_ADMIN_LISTEN=127.0.0.1:8001` (container-internal binding).

## Test plan
- [ ] `docker compose up -d supabase-kong` → verify `curl http://localhost:8001` works
- [ ] From LAN machine → verify `curl http://<HOST-IP>:8001` refused
- [ ] `docker compose up -d minio` → verify console accessible only from localhost
- [ ] Pinokio update.js → verify `--verify-signatures` in git pull command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Added signature verification to update processes
  * Restricted service accessibility to local connections only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->