### PR TITLE
feat(geometry): embedding provenance in CGP schema + NATS subjects

### DIFF
--- a/.claude/context/geometry-nats-subjects.md
+++ b/.claude/context/geometry-nats-subjects.md
@@ -231,6 +231,61 @@ geometry.<type>.<event>.v1      # Core geometry events
 
 ---
 
+## Embedding Provenance Events
+
+### Model Resolution
+
+**`embedding.model.resolved.v1`**
+- **Direction:** Published by any embedding service at startup → Consumed by model-registry, observability
+- **Purpose:** Announce which embedding model a service resolved from the registry
+- **Payload:**
+  ```json
+  {
+    "service": "hi-rag-v2",
+    "model_type": "embedding",
+    "model_id": "qwen3-embedding-4b",
+    "resolution_source": "model-registry",
+    "timestamp": "2026-03-18T12:00:00Z"
+  }
+  ```
+
+### Dimension Indexed
+
+**`embedding.dimension.indexed.v1`**
+- **Direction:** Published by extract-worker → Consumed by Hi-RAG v2, evo-controller
+- **Purpose:** Announce a new named vector dimension has been indexed to Qdrant
+- **Payload:**
+  ```json
+  {
+    "collection": "pmoves_chunks_v2",
+    "vector_name": "prosodic",
+    "dimensions": 512,
+    "model_id": "laion-clap",
+    "chunks_indexed": 150,
+    "timestamp": "2026-03-18T12:00:00Z"
+  }
+  ```
+
+### Cross-Dimensional Divergence Signal
+
+**`embedding.divergence.signal.v1`**
+- **Direction:** Published by Hi-RAG v2 cross-dimensional query → Consumed by evo-controller, analytics
+- **Purpose:** Signal when semantic and prosodic rankings diverge significantly for a query
+- **Payload:**
+  ```json
+  {
+    "query": "agent orchestration patterns",
+    "divergence": 0.72,
+    "semantic_top_ids": ["chunk-abc", "chunk-def"],
+    "prosodic_top_ids": ["chunk-xyz", "chunk-ghi"],
+    "namespace": "pmoves-docs",
+    "timestamp": "2026-03-18T12:00:00Z"
+  }
+  ```
+- **Threshold:** Only published when divergence > 0.3 (configurable via `DIVERGENCE_SIGNAL_THRESHOLD`)
+
+---
+
 ## Research Events (CGP-Enhanced)
 
 ### DeepResearch Result with CGP

--- a/.claude/context/nats-subjects.md
+++ b/.claude/context/nats-subjects.md
@@ -1143,6 +1143,16 @@ nats server report connections
   }
   ```
 
+## Embedding Provenance Subjects
+
+> **See also:** Full definitions in [geometry-nats-subjects.md](./geometry-nats-subjects.md#embedding-provenance-events)
+
+| Subject | Publisher | Consumer | Purpose |
+|---------|-----------|----------|---------|
+| `embedding.model.resolved.v1` | Any embedding service | model-registry, observability | Model resolution announcement at startup |
+| `embedding.dimension.indexed.v1` | extract-worker | Hi-RAG v2, evo-controller | New named vector dimension indexed to Qdrant |
+| `embedding.divergence.signal.v1` | Hi-RAG v2 | evo-controller, analytics | Cross-dimensional divergence exceeds threshold |
+
 ## GPU Mesh & Model Lifecycle Subjects
 
 ### GPU Orchestrator → Model Registry

--- a/pmoves/contracts/schemas/geometry/cgp.v2.schema.json
+++ b/pmoves/contracts/schemas/geometry/cgp.v2.schema.json
@@ -414,6 +414,18 @@
           "type": ["object", "null"],
           "additionalProperties": true
         },
+        "embedding_meta": {
+          "type": ["object", "null"],
+          "description": "Embedding model provenance — which model produced which vector for this point",
+          "properties": {
+            "model_id": { "type": "string", "description": "HuggingFace or provider model identifier" },
+            "model_registry_id": { "type": "string", "description": "UUID from model-registry service" },
+            "vector_name": { "type": "string", "description": "Named vector key in Qdrant (e.g. semantic, prosodic)" },
+            "dimensions": { "type": "integer", "minimum": 1, "description": "Embedding vector dimensionality" },
+            "provider": { "type": "string", "description": "Serving provider (tensorzero, ollama, sentence-transformers)" }
+          },
+          "additionalProperties": true
+        },
         "contributor": {
           "$ref": "#/$defs/contributor",
           "description": "Point-level attribution for individual economic events"


### PR DESCRIPTION
## Summary
- Add `embedding_meta` field to CGP v2 point schema — each point carries model provenance
- Define 3 new NATS subjects for embedding lifecycle events
- "Pearl on the string" — the GEOMETRY bus now knows which model produced which embedding

## CGP Schema Extension
```json
"embedding_meta": {
  "model_id": "qwen3-embedding-4b",
  "model_registry_id": "uuid",
  "vector_name": "semantic",
  "dimensions": 4096,
  "provider": "tensorzero"
}
```
Added to `point` definition in `cgp.v2.schema.json`. Backward compatible (`additionalProperties: true`).

## NATS Subjects
| Subject | When |
|---------|------|
| `embedding.model.resolved.v1` | Service resolves model from registry at startup |
| `embedding.dimension.indexed.v1` | New named vector indexed to Qdrant |
| `embedding.divergence.signal.v1` | Cross-dimensional divergence > threshold |

## Test plan
- [ ] CGP v2 schema validates (`python -c "import json; json.load(open(...))"` — verified)
- [ ] Existing CGP packets without `embedding_meta` still validate (additionalProperties: true)
- [ ] NATS subjects documented in both geometry-nats-subjects.md and nats-subjects.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation for Embedding Provenance Subjects, defining event types for model resolution, dimension indexing, and divergence signals.

* **New Features**
  * Extended geometric points with optional embedding metadata, including model identification, vector properties, and provider information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->