### PR TITLE
feat(w1): agent theming — render-card, attribution, theme API

### DIFF
--- a/pmoves/services/botz-gateway/main.py
+++ b/pmoves/services/botz-gateway/main.py
@@ -353,6 +353,73 @@ async def list_botz_instances(available_only: bool = False):
             raise HTTPException(status_code=response.status_code, detail=response.text)
 
 
+# ── Agent Theming Endpoints (MUST be before /v1/botz/{botz_id} dynamic route) ──
+
+SIGNATURES_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "config", "agent_signatures.yaml")
+THEMES_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "configs", "agent-themes.yaml")
+
+
+def _load_yaml(path: str) -> dict:
+    """Load YAML file, return empty dict on failure."""
+    try:
+        import yaml
+        with open(path, encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+@app.get("/v1/botz/themes")
+async def list_themes():
+    """List all agent themes (signatures + character mappings)."""
+    sigs = _load_yaml(SIGNATURES_PATH)
+    agents = sigs.get("signatures", sigs)
+    result = {}
+    for agent_id, sig in agents.items():
+        result[agent_id] = {
+            "glyph": sig.get("glyph"),
+            "color": sig.get("color"),
+            "accent": sig.get("accent"),
+            "voice": sig.get("voice"),
+            "display_name": sig.get("display_name"),
+            "resonance": sig.get("resonance", []),
+        }
+    return {"agents": result, "count": len(result)}
+
+
+@app.get("/v1/botz/themes/{agent_id}")
+async def get_theme(agent_id: str):
+    """Get a specific agent's theme (signature + character mapping)."""
+    sigs = _load_yaml(SIGNATURES_PATH)
+    agents = sigs.get("signatures", sigs)
+    sig = agents.get(agent_id) or agents.get(agent_id.replace("_", "-"))
+    if not sig:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found in signatures")
+
+    themes = _load_yaml(THEMES_PATH)
+    mappings = themes.get("service_character_mappings", {})
+    character = {}
+    normalized_id = agent_id.lower().replace("-", "_").replace(" ", "_")
+    for service_key, mapping in mappings.items():
+        sid = service_key.lower().replace("-", "_").replace(" ", "_")
+        if normalized_id in sid or sid in normalized_id:
+            character = mapping
+            break
+
+    return {
+        "agent_id": agent_id,
+        "glyph": sig.get("glyph"),
+        "color": sig.get("color"),
+        "accent": sig.get("accent"),
+        "voice": sig.get("voice"),
+        "display_name": sig.get("display_name"),
+        "resonance": sig.get("resonance", []),
+        "description": sig.get("description"),
+        "co_author": sig.get("co_author"),
+        "character_mapping": character if character else None,
+    }
+
+
 @app.get("/v1/botz/{botz_id}")
 async def get_botz_instance(botz_id: str):
     """Get details of a specific BoTZ instance."""
@@ -530,72 +597,6 @@ async def get_stats():
             logger.error(f"Error fetching stats: {e}")
 
         return stats
-
-
-# ── Agent Theming Endpoints ─────────────────────────────────────────────
-
-SIGNATURES_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "config", "agent_signatures.yaml")
-THEMES_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "configs", "agent-themes.yaml")
-
-
-def _load_yaml(path: str) -> dict:
-    """Load YAML file, return empty dict on failure."""
-    try:
-        import yaml
-        with open(path, encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
-    except Exception:
-        return {}
-
-
-@app.get("/v1/botz/themes")
-async def list_themes():
-    """List all agent themes (signatures + character mappings)."""
-    sigs = _load_yaml(SIGNATURES_PATH)
-    agents = sigs.get("signatures", sigs)
-    result = {}
-    for agent_id, sig in agents.items():
-        result[agent_id] = {
-            "glyph": sig.get("glyph"),
-            "color": sig.get("color"),
-            "accent": sig.get("accent"),
-            "voice": sig.get("voice"),
-            "display_name": sig.get("display_name"),
-            "resonance": sig.get("resonance", []),
-        }
-    return {"agents": result, "count": len(result)}
-
-
-@app.get("/v1/botz/themes/{agent_id}")
-async def get_theme(agent_id: str):
-    """Get a specific agent's theme (signature + character mapping)."""
-    sigs = _load_yaml(SIGNATURES_PATH)
-    agents = sigs.get("signatures", sigs)
-    sig = agents.get(agent_id) or agents.get(agent_id.replace("_", "-"))
-    if not sig:
-        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found in signatures")
-
-    themes = _load_yaml(THEMES_PATH)
-    mappings = themes.get("service_character_mappings", {})
-    character = {}
-    for service_key, mapping in mappings.items():
-        sid = service_key.lower().replace("-", "_").replace(" ", "_")
-        if agent_id in sid or sid in agent_id:
-            character = mapping
-            break
-
-    return {
-        "agent_id": agent_id,
-        "glyph": sig.get("glyph"),
-        "color": sig.get("color"),
-        "accent": sig.get("accent"),
-        "voice": sig.get("voice"),
-        "display_name": sig.get("display_name"),
-        "resonance": sig.get("resonance", []),
-        "description": sig.get("description"),
-        "co_author": sig.get("co_author"),
-        "character_mapping": character if character else None,
-    }
 
 
 if __name__ == "__main__":

--- a/pmoves/services/botz-gateway/main.py
+++ b/pmoves/services/botz-gateway/main.py
@@ -13,6 +13,7 @@ import os
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Optional, List, Dict, Any
 from contextlib import asynccontextmanager
 from uuid import UUID, uuid4
@@ -36,9 +37,15 @@ TENSORZERO_URL = os.getenv("TENSORZERO_URL", "http://tensorzero:3030")
 HEARTBEAT_INTERVAL = int(os.getenv("BOTZ_HEARTBEAT_INTERVAL", "30"))
 STALE_THRESHOLD_MINUTES = int(os.getenv("BOTZ_STALE_THRESHOLD", "5"))
 
+# Theme data paths (relative to service or repo root)
+_REPO_ROOT = Path(__file__).parent.parent.parent  # pmoves/services/botz-gateway -> pmoves
+SIGNATURES_PATH = _REPO_ROOT / "config" / "agent_signatures.yaml"
+THEMES_PATH = _REPO_ROOT / "configs" / "agent-themes.yaml"
+
 # Global state
 nc: Optional[NATS] = None
 supabase_headers: Dict[str, str] = {}
+_theme_cache: Dict[str, Any] = {}  # Lazy-loaded theme data
 
 
 # Pydantic models
@@ -597,6 +604,158 @@ async def get_stats():
             logger.error(f"Error fetching stats: {e}")
 
         return stats
+
+
+# ── Agent Theme Endpoints ────────────────────────────────────────────────────
+
+
+def _load_theme_data() -> Dict[str, Any]:
+    """Lazy-load and cache agent signatures + themes from YAML files."""
+    if _theme_cache:
+        return _theme_cache
+
+    try:
+        import yaml
+    except ImportError:
+        logger.warning("PyYAML not installed — theme endpoints unavailable")
+        return {}
+
+    signatures = {}
+    if SIGNATURES_PATH.exists():
+        with open(SIGNATURES_PATH, encoding="utf-8") as f:
+            sig_data = yaml.safe_load(f) or {}
+        for entry in sig_data.get("signatures", sig_data.get("agents", [])):
+            if isinstance(entry, dict) and "agent_id" in entry:
+                signatures[entry["agent_id"]] = entry
+
+    packs = {}
+    mappings = {}
+    if THEMES_PATH.exists():
+        with open(THEMES_PATH, encoding="utf-8") as f:
+            theme_data = yaml.safe_load(f) or {}
+        packs = theme_data.get("theme_packs", {})
+        mappings = theme_data.get("agent_character_mappings", theme_data.get("mappings", {}))
+
+    _theme_cache["signatures"] = signatures
+    _theme_cache["packs"] = packs
+    _theme_cache["mappings"] = mappings
+    return _theme_cache
+
+
+@app.get("/v1/botz/themes")
+async def list_themes():
+    """List all agent themes (signatures + character mappings)."""
+    data = _load_theme_data()
+    sigs = data.get("signatures", {})
+
+    themes = []
+    mappings = data.get("mappings", {})
+    for agent_id, sig in sigs.items():
+        entry = {
+            "agent_id": agent_id,
+            "glyph": sig.get("glyph"),
+            "color": sig.get("color"),
+            "accent": sig.get("accent"),
+            "voice": sig.get("voice"),
+            "resonance": sig.get("resonance", []),
+        }
+        mapping = mappings.get(agent_id.replace("_", "-"), {})
+        if mapping:
+            entry["characters"] = {
+                "primary": mapping.get("primary", {}).get("name"),
+                "secondary": mapping.get("secondary", {}).get("name"),
+            }
+        themes.append(entry)
+
+    return {"themes": themes, "theme_packs": list(data.get("packs", {}).keys())}
+
+
+@app.get("/v1/botz/themes/{agent_id}")
+async def get_agent_theme(agent_id: str):
+    """Get specific agent theme (glyph, color, voice, character mapping)."""
+    data = _load_theme_data()
+    sigs = data.get("signatures", {})
+
+    # Normalize: try as-is, then underscore variant
+    sig = sigs.get(agent_id) or sigs.get(agent_id.replace("-", "_"))
+    if not sig:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found in signatures")
+
+    theme = {
+        "agent_id": sig.get("agent_id", agent_id),
+        "glyph": sig.get("glyph"),
+        "color": sig.get("color"),
+        "accent": sig.get("accent"),
+        "voice": sig.get("voice"),
+        "resonance": sig.get("resonance", []),
+        "description": sig.get("description"),
+        "co_author": sig.get("co_author"),
+    }
+
+    mappings = data.get("mappings", {})
+    mapping = mappings.get(agent_id.replace("_", "-"), mappings.get(agent_id, {}))
+    if mapping:
+        theme["characters"] = mapping
+
+    return theme
+
+
+class WhoamiRequest(BaseModel):
+    instance_id: Optional[str] = None
+    runner_host: Optional[str] = None
+
+
+@app.post("/v1/botz/themes/whoami")
+async def whoami(req: WhoamiRequest):
+    """Return current agent identity based on instance registration."""
+    data = _load_theme_data()
+    sigs = data.get("signatures", {})
+
+    # Try to match by instance_id or runner_host in Supabase
+    agent_id = None
+    if req.instance_id or req.runner_host:
+        try:
+            async with httpx.AsyncClient() as client:
+                params = {}
+                if req.instance_id:
+                    params["instance_id"] = f"eq.{req.instance_id}"
+                elif req.runner_host:
+                    params["runner_host"] = f"eq.{req.runner_host}"
+
+                response = await client.get(
+                    f"{SUPABASE_URL}/rest/v1/botz_instances",
+                    headers=supabase_headers,
+                    params=params,
+                )
+                if response.status_code == 200:
+                    instances = response.json()
+                    if instances:
+                        botz_name = instances[0].get("botz_name", "")
+                        # Map botz_name to agent_id pattern
+                        agent_id = botz_name.replace("-", "_")
+        except Exception as e:
+            logger.warning(f"Supabase lookup failed for whoami: {e}")
+
+    if not agent_id:
+        # Fallback: return default agent based on hostname
+        hostname = os.environ.get("HOSTNAME", os.environ.get("COMPUTERNAME", "unknown"))
+        # Try to match hostname patterns to known agents
+        for aid in sigs:
+            if hostname.lower() in aid:
+                agent_id = aid
+                break
+
+    if agent_id and agent_id in sigs:
+        sig = sigs[agent_id]
+        return {
+            "agent_id": agent_id,
+            "glyph": sig.get("glyph"),
+            "color": sig.get("color"),
+            "voice": sig.get("voice"),
+            "resonance": sig.get("resonance", []),
+        }
+
+    return {"agent_id": None, "message": "No agent identity matched"}
 
 
 if __name__ == "__main__":

--- a/pmoves/services/botz-gateway/main.py
+++ b/pmoves/services/botz-gateway/main.py
@@ -552,7 +552,7 @@ def _load_yaml(path: str) -> dict:
 async def list_themes():
     """List all agent themes (signatures + character mappings)."""
     sigs = _load_yaml(SIGNATURES_PATH)
-    agents = sigs.get("agents", sigs)
+    agents = sigs.get("signatures", sigs)
     result = {}
     for agent_id, sig in agents.items():
         result[agent_id] = {
@@ -570,7 +570,7 @@ async def list_themes():
 async def get_theme(agent_id: str):
     """Get a specific agent's theme (signature + character mapping)."""
     sigs = _load_yaml(SIGNATURES_PATH)
-    agents = sigs.get("agents", sigs)
+    agents = sigs.get("signatures", sigs)
     sig = agents.get(agent_id) or agents.get(agent_id.replace("_", "-"))
     if not sig:
         raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found in signatures")

--- a/pmoves/services/botz-gateway/main.py
+++ b/pmoves/services/botz-gateway/main.py
@@ -380,7 +380,7 @@ def _load_yaml(path: str) -> dict:
 async def list_themes():
     """List all agent themes (signatures + character mappings)."""
     sigs = _load_yaml(SIGNATURES_PATH)
-    agents = sigs.get("signatures", sigs)
+    agents = sigs.get("signatures", {})
     result = {}
     for agent_id, sig in agents.items():
         result[agent_id] = {
@@ -398,7 +398,7 @@ async def list_themes():
 async def get_theme(agent_id: str):
     """Get a specific agent's theme (signature + character mapping)."""
     sigs = _load_yaml(SIGNATURES_PATH)
-    agents = sigs.get("signatures", sigs)
+    agents = sigs.get("signatures", {})
     sig = agents.get(agent_id) or agents.get(agent_id.replace("_", "-"))
     if not sig:
         raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found in signatures")

--- a/pmoves/services/botz-gateway/main.py
+++ b/pmoves/services/botz-gateway/main.py
@@ -532,6 +532,72 @@ async def get_stats():
         return stats
 
 
+# ── Agent Theming Endpoints ─────────────────────────────────────────────
+
+SIGNATURES_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "config", "agent_signatures.yaml")
+THEMES_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "configs", "agent-themes.yaml")
+
+
+def _load_yaml(path: str) -> dict:
+    """Load YAML file, return empty dict on failure."""
+    try:
+        import yaml
+        with open(path, encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+@app.get("/v1/botz/themes")
+async def list_themes():
+    """List all agent themes (signatures + character mappings)."""
+    sigs = _load_yaml(SIGNATURES_PATH)
+    agents = sigs.get("agents", sigs)
+    result = {}
+    for agent_id, sig in agents.items():
+        result[agent_id] = {
+            "glyph": sig.get("glyph"),
+            "color": sig.get("color"),
+            "accent": sig.get("accent"),
+            "voice": sig.get("voice"),
+            "display_name": sig.get("display_name"),
+            "resonance": sig.get("resonance", []),
+        }
+    return {"agents": result, "count": len(result)}
+
+
+@app.get("/v1/botz/themes/{agent_id}")
+async def get_theme(agent_id: str):
+    """Get a specific agent's theme (signature + character mapping)."""
+    sigs = _load_yaml(SIGNATURES_PATH)
+    agents = sigs.get("agents", sigs)
+    sig = agents.get(agent_id) or agents.get(agent_id.replace("_", "-"))
+    if not sig:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found in signatures")
+
+    themes = _load_yaml(THEMES_PATH)
+    mappings = themes.get("service_character_mappings", {})
+    character = {}
+    for service_key, mapping in mappings.items():
+        sid = service_key.lower().replace("-", "_").replace(" ", "_")
+        if agent_id in sid or sid in agent_id:
+            character = mapping
+            break
+
+    return {
+        "agent_id": agent_id,
+        "glyph": sig.get("glyph"),
+        "color": sig.get("color"),
+        "accent": sig.get("accent"),
+        "voice": sig.get("voice"),
+        "display_name": sig.get("display_name"),
+        "resonance": sig.get("resonance", []),
+        "description": sig.get("description"),
+        "co_author": sig.get("co_author"),
+        "character_mapping": character if character else None,
+    }
+
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8054)

--- a/pmoves/tools/agent_taxonomy_helper.py
+++ b/pmoves/tools/agent_taxonomy_helper.py
@@ -32,6 +32,8 @@ except ImportError:
 
 
 REGISTRY_PATH = Path(__file__).parent.parent / "config" / "agent_registry.yaml"
+SIGNATURES_PATH = Path(__file__).parent.parent / "config" / "agent_signatures.yaml"
+THEMES_PATH = Path(__file__).parent.parent / "configs" / "agent-themes.yaml"
 
 # Type effectiveness matrix (attacker → target → effectiveness)
 TYPE_EFFECTIVENESS = {
@@ -494,6 +496,166 @@ def _mermaid_nats(agents):
     print("\n".join(lines))
 
 
+def _load_signatures():
+    """Load agent signatures YAML."""
+    if yaml is None or not SIGNATURES_PATH.exists():
+        return {}
+    with open(SIGNATURES_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("agents", data)
+
+
+def _load_themes():
+    """Load agent themes YAML."""
+    if yaml is None or not THEMES_PATH.exists():
+        return {}
+    with open(THEMES_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _hex_to_ansi(hex_color: str) -> str:
+    """Convert #RRGGBB to ANSI 24-bit color escape."""
+    hex_color = hex_color.lstrip("#")
+    if len(hex_color) != 6:
+        return ""
+    r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
+    return f"\033[38;2;{r};{g};{b}m"
+
+
+def _reset() -> str:
+    return "\033[0m"
+
+
+def _bold() -> str:
+    return "\033[1m"
+
+
+def _dim() -> str:
+    return "\033[2m"
+
+
+def _find_character_mapping(themes: dict, agent_id: str) -> dict:
+    """Find character mapping for an agent across all theme packs."""
+    mappings = themes.get("service_character_mappings", {})
+    for service_key, mapping in mappings.items():
+        # Match by agent_id or service name
+        sid = service_key.lower().replace("-", "_").replace(" ", "_")
+        if agent_id in sid or sid in agent_id:
+            return mapping
+    return {}
+
+
+def cmd_render_card(registry, args):
+    """Render a themed agent card with signature colors and character mapping."""
+    agents = registry.get("agents", {})
+    signatures = _load_signatures()
+    themes = _load_themes()
+
+    agent_id = args.name.lower().replace("-", "_").replace(" ", "_")
+    agent = agents.get(agent_id)
+
+    # Try signature lookup by agent_id or with hyphens
+    sig_id = agent_id.replace("_", "-")
+    sig = signatures.get(sig_id) or signatures.get(agent_id)
+
+    if not agent and not sig:
+        # Fuzzy match
+        all_keys = set(agents.keys()) | set(signatures.keys())
+        matches = [k for k in all_keys if agent_id in k]
+        if matches:
+            key = matches[0]
+            agent = agents.get(key) or agents.get(key.replace("-", "_"))
+            sig = signatures.get(key) or signatures.get(key.replace("_", "-"))
+            agent_id = key
+        else:
+            print(f"Agent '{args.name}' not found.", file=sys.stderr)
+            print(f"Registry agents: {', '.join(sorted(agents.keys()))}", file=sys.stderr)
+            print(f"Signature agents: {', '.join(sorted(signatures.keys()))}", file=sys.stderr)
+            sys.exit(1)
+
+    fmt = args.format
+
+    if fmt == "json":
+        card = {"agent_id": agent_id}
+        if sig:
+            card.update(sig)
+        if agent:
+            card["registry"] = agent
+        char_map = _find_character_mapping(themes, agent_id)
+        if char_map:
+            card["character_mapping"] = char_map
+        print(json.dumps(card, indent=2))
+        return
+
+    # Terminal (ANSI) rendering
+    glyph = (sig or {}).get("glyph", "?")
+    color = (sig or {}).get("color", "#FFFFFF")
+    accent = (sig or {}).get("accent", "#CCCCCC")
+    voice = (sig or {}).get("voice", "unknown")
+    resonance = (sig or {}).get("resonance", [])
+    co_author = (sig or {}).get("co_author", "")
+    description = (sig or agent or {}).get("description", "")
+    display_name = (sig or {}).get("display_name", "") or (agent or {}).get("name", agent_id)
+
+    c = _hex_to_ansi(color)
+    a = _hex_to_ansi(accent)
+    b = _bold()
+    d = _dim()
+    r = _reset()
+
+    char_map = _find_character_mapping(themes, agent_id)
+    primary_char = char_map.get("primary", "")
+    secondary_char = char_map.get("secondary", "")
+    rationale = char_map.get("rationale", "")
+
+    width = 46
+    border = f"{c}{'═' * width}{r}"
+    line = f"{c}{'─' * width}{r}"
+
+    print(f"{c}╔{border}╗{r}")
+    print(f"{c}║{r}  {c}{b}{glyph}  {display_name}{r}{' ' * (width - len(display_name) - 5)}{c}║{r}")
+    print(f"{c}║{r}  {d}{color}{r}{' ' * (width - len(color) - 2)}{c}║{r}")
+    print(f"{c}╠{line}╣{r}")
+    print(f"{c}║{r}  {a}Voice:{r}      {voice}{' ' * (width - len(voice) - 14)}{c}║{r}")
+
+    if resonance:
+        res_str = ", ".join(resonance[:4])
+        print(f"{c}║{r}  {a}Resonance:{r}  {res_str}{' ' * max(0, width - len(res_str) - 14)}{c}║{r}")
+
+    if agent:
+        port = agent.get("port", "—")
+        cls = agent.get("class", "—")
+        stage = agent.get("evolution_stage", "base")
+        print(f"{c}║{r}  {a}Class:{r}      {cls}{' ' * (width - len(str(cls)) - 14)}{c}║{r}")
+        print(f"{c}║{r}  {a}Port:{r}       {port}{' ' * (width - len(str(port)) - 14)}{c}║{r}")
+        print(f"{c}║{r}  {a}Stage:{r}      {stage}{' ' * (width - len(str(stage)) - 14)}{c}║{r}")
+
+    if primary_char or secondary_char:
+        print(f"{c}╠{line}╣{r}")
+        if primary_char:
+            print(f"{c}║{r}  {b}Primary:{r}    {primary_char}{' ' * max(0, width - len(primary_char) - 14)}{c}║{r}")
+        if secondary_char:
+            print(f"{c}║{r}  {b}Secondary:{r}  {secondary_char}{' ' * max(0, width - len(secondary_char) - 14)}{c}║{r}")
+
+    if description:
+        print(f"{c}╠{line}╣{r}")
+        words = description.split()
+        lines = []
+        current = ""
+        for w in words:
+            if len(current) + len(w) + 1 <= width - 4:
+                current = f"{current} {w}" if current else w
+            else:
+                lines.append(current)
+                current = w
+        if current:
+            lines.append(current)
+        for ln in lines:
+            print(f"{c}║{r}  {d}{ln}{r}{' ' * max(0, width - len(ln) - 2)}{c}║{r}")
+
+    print(f"{c}╚{border}╝{r}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="PMOVES Agent Taxonomy Helper",
@@ -518,6 +680,9 @@ def main():
     mermaid_parser.add_argument("--style", choices=["topology", "tac", "nats"],
                                 default="topology", help="Diagram style (default: topology)")
 
+    card_parser = subparsers.add_parser("render-card", help="Render themed agent card (ANSI/JSON)")
+    card_parser.add_argument("name", help="Agent ID or name (fuzzy match)")
+
     args = parser.parse_args()
 
     if not args.command:
@@ -532,6 +697,7 @@ def main():
         "connections": cmd_connections,
         "types": cmd_types,
         "mermaid": cmd_mermaid,
+        "render-card": cmd_render_card,
     }
 
     commands[args.command](registry, args)

--- a/pmoves/tools/agent_taxonomy_helper.py
+++ b/pmoves/tools/agent_taxonomy_helper.py
@@ -262,9 +262,12 @@ def _load_signatures():
         data = yaml.safe_load(f) or {}
     # Index by agent_id for fast lookup
     sigs = {}
-    for entry in data.get("signatures", data.get("agents", [])):
-        if isinstance(entry, dict) and "agent_id" in entry:
-            sigs[entry["agent_id"]] = entry
+    sigs_data = data.get("signatures", data.get("agents", {}))
+    if isinstance(sigs_data, dict):
+        for agent_id, entry in sigs_data.items():
+            if isinstance(entry, dict):
+                entry.setdefault("agent_id", agent_id)
+                sigs[agent_id] = entry
     return sigs
 
 

--- a/pmoves/tools/agent_taxonomy_helper.py
+++ b/pmoves/tools/agent_taxonomy_helper.py
@@ -254,6 +254,192 @@ def cmd_types(registry, args):
     print("★★ = Super effective  ★  = Effective  ·  = Neutral")
 
 
+def _load_signatures():
+    """Load agent signatures YAML."""
+    if yaml is None or not SIGNATURES_PATH.exists():
+        return {}
+    with open(SIGNATURES_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    # Index by agent_id for fast lookup
+    sigs = {}
+    for entry in data.get("signatures", data.get("agents", [])):
+        if isinstance(entry, dict) and "agent_id" in entry:
+            sigs[entry["agent_id"]] = entry
+    return sigs
+
+
+def _load_themes():
+    """Load agent themes YAML."""
+    if yaml is None or not THEMES_PATH.exists():
+        return {}, {}
+    with open(THEMES_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    packs = data.get("theme_packs", {})
+    mappings = data.get("agent_character_mappings", data.get("mappings", {}))
+    return packs, mappings
+
+
+# ANSI 24-bit color helpers
+def _fg(hex_color: str, text: str) -> str:
+    """Wrap text in 24-bit ANSI foreground color from hex (#RRGGBB)."""
+    h = hex_color.lstrip("#")
+    if len(h) != 6:
+        return text
+    r, g, b = int(h[:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return f"\033[38;2;{r};{g};{b}m{text}\033[0m"
+
+
+def _bg(hex_color: str, text: str) -> str:
+    """Wrap text in 24-bit ANSI background color from hex (#RRGGBB)."""
+    h = hex_color.lstrip("#")
+    if len(h) != 6:
+        return text
+    r, g, b = int(h[:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return f"\033[48;2;{r};{g};{b}m{text}\033[0m"
+
+
+def _color_swatch(hex_color: str, width: int = 4) -> str:
+    """Render a colored swatch block."""
+    return _bg(hex_color, " " * width)
+
+
+def cmd_render_card(registry, args):
+    """Render a themed agent identity card with ANSI colors."""
+    sigs = _load_signatures()
+    packs, mappings = _load_themes()
+    agents = registry.get("agents", {})
+
+    agent_id = args.name.lower().replace("-", "_").replace(" ", "_")
+
+    # Try exact match, then fuzzy
+    sig = sigs.get(agent_id) or sigs.get(args.name)
+    if not sig:
+        # Fuzzy match on agent_id
+        matches = [k for k in sigs if agent_id in k]
+        if matches:
+            sig = sigs[matches[0]]
+            agent_id = matches[0]
+        else:
+            print(f"Agent '{args.name}' not found in signatures. Available: {', '.join(sorted(sigs.keys()))}", file=sys.stderr)
+            sys.exit(1)
+
+    glyph = sig.get("glyph", "?")
+    color = sig.get("color", "#FFFFFF")
+    accent = sig.get("accent", color)
+    voice = sig.get("voice", "unknown")
+    resonance = sig.get("resonance", [])
+    co_author = sig.get("co_author", "")
+    description = sig.get("description", "")
+
+    fmt = args.format
+
+    if fmt == "json":
+        card = {
+            "agent_id": agent_id,
+            "glyph": glyph,
+            "color": color,
+            "accent": accent,
+            "voice": voice,
+            "resonance": resonance,
+            "description": description,
+        }
+        # Merge theme mapping if available
+        mapping = mappings.get(agent_id.replace("_", "-"), {})
+        if mapping:
+            card["theme"] = mapping
+        print(json.dumps(card, indent=2))
+        return
+
+    if fmt == "markdown":
+        print(f"## {glyph} {agent_id}")
+        print(f"- **Color:** `{color}` / `{accent}`")
+        print(f"- **Voice:** {voice}")
+        print(f"- **Resonance:** {', '.join(resonance)}")
+        if description:
+            print(f"- **Description:** {description}")
+        mapping = mappings.get(agent_id.replace("_", "-"), {})
+        if mapping:
+            primary = mapping.get("primary", {})
+            secondary = mapping.get("secondary", {})
+            if primary:
+                print(f"- **Primary character:** {primary.get('name', '?')} ({primary.get('pack', '?')})")
+            if secondary:
+                print(f"- **Secondary character:** {secondary.get('name', '?')} ({secondary.get('pack', '?')})")
+        return
+
+    # Terminal (ANSI) format — default
+    W = 46
+    border_color = color
+
+    def line(content="", pad_char=" "):
+        """Render a bordered line."""
+        visible_len = len(content.encode("ascii", errors="ignore"))  # rough
+        # For accurate length, strip ANSI codes
+        import re
+        clean = re.sub(r'\033\[[0-9;]*m', '', content)
+        padding = W - 2 - len(clean)
+        if padding < 0:
+            padding = 0
+        return _fg(border_color, "║") + " " + content + pad_char * padding + " " + _fg(border_color, "║")
+
+    print(_fg(border_color, "╔" + "═" * (W) + "╗"))
+    # Title line with glyph
+    title = f"{_fg(color, glyph)}  {_fg(accent, agent_id)}"
+    print(line(title))
+    print(_fg(border_color, "╠" + "═" * (W) + "╣"))
+
+    # Color swatches
+    swatch_line = f"Color: {_color_swatch(color)}  {color}   Accent: {_color_swatch(accent)}  {accent}"
+    print(line(swatch_line))
+    print(line(f"Voice:     {voice}"))
+    print(line(f"Resonance: {', '.join(resonance[:4])}"))
+
+    # Theme character mapping
+    mapping = mappings.get(agent_id.replace("_", "-"), {})
+    if mapping:
+        print(_fg(border_color, "╠" + "─" * (W) + "╣"))
+        primary = mapping.get("primary", {})
+        secondary = mapping.get("secondary", {})
+        if primary:
+            print(line(f"Primary:   {primary.get('name', '?')} ({primary.get('pack', '?')})"))
+        if secondary:
+            print(line(f"Secondary: {secondary.get('name', '?')} ({secondary.get('pack', '?')})"))
+        rationale = mapping.get("rationale", "")
+        if rationale:
+            # Word-wrap rationale
+            words = rationale.split()
+            current = ""
+            for w in words:
+                if len(current) + len(w) + 1 <= W - 4:
+                    current = f"{current} {w}" if current else w
+                else:
+                    print(line(f"  {current}"))
+                    current = w
+            if current:
+                print(line(f"  {current}"))
+
+    # Description
+    if description:
+        print(_fg(border_color, "╠" + "─" * (W) + "╣"))
+        words = description.split()
+        current = ""
+        for w in words:
+            if len(current) + len(w) + 1 <= W - 4:
+                current = f"{current} {w}" if current else w
+            else:
+                print(line(f"{current}"))
+                current = w
+        if current:
+            print(line(f"{current}"))
+
+    # Attribution line
+    if co_author:
+        print(_fg(border_color, "╠" + "─" * (W) + "╣"))
+        print(line(f"Co-Author: {co_author[:W-14]}"))
+
+    print(_fg(border_color, "╚" + "═" * (W) + "╝"))
+
+
 SUBSYSTEM_MAP = {
     "AGENT_ZERO_CORE": {
         "label": "Agent Zero Core — The Matrix",
@@ -496,166 +682,6 @@ def _mermaid_nats(agents):
     print("\n".join(lines))
 
 
-def _load_signatures():
-    """Load agent signatures YAML."""
-    if yaml is None or not SIGNATURES_PATH.exists():
-        return {}
-    with open(SIGNATURES_PATH, encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
-    return data.get("signatures", data)
-
-
-def _load_themes():
-    """Load agent themes YAML."""
-    if yaml is None or not THEMES_PATH.exists():
-        return {}
-    with open(THEMES_PATH, encoding="utf-8") as f:
-        return yaml.safe_load(f) or {}
-
-
-def _hex_to_ansi(hex_color: str) -> str:
-    """Convert #RRGGBB to ANSI 24-bit color escape."""
-    hex_color = hex_color.lstrip("#")
-    if len(hex_color) != 6:
-        return ""
-    r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
-    return f"\033[38;2;{r};{g};{b}m"
-
-
-def _reset() -> str:
-    return "\033[0m"
-
-
-def _bold() -> str:
-    return "\033[1m"
-
-
-def _dim() -> str:
-    return "\033[2m"
-
-
-def _find_character_mapping(themes: dict, agent_id: str) -> dict:
-    """Find character mapping for an agent across all theme packs."""
-    mappings = themes.get("service_character_mappings", {})
-    for service_key, mapping in mappings.items():
-        # Match by agent_id or service name
-        sid = service_key.lower().replace("-", "_").replace(" ", "_")
-        if agent_id in sid or sid in agent_id:
-            return mapping
-    return {}
-
-
-def cmd_render_card(registry, args):
-    """Render a themed agent card with signature colors and character mapping."""
-    agents = registry.get("agents", {})
-    signatures = _load_signatures()
-    themes = _load_themes()
-
-    agent_id = args.name.lower().replace("-", "_").replace(" ", "_")
-    agent = agents.get(agent_id)
-
-    # Try signature lookup by agent_id or with hyphens
-    sig_id = agent_id.replace("_", "-")
-    sig = signatures.get(sig_id) or signatures.get(agent_id)
-
-    if not agent and not sig:
-        # Fuzzy match
-        all_keys = set(agents.keys()) | set(signatures.keys())
-        matches = [k for k in all_keys if agent_id in k]
-        if matches:
-            key = matches[0]
-            agent = agents.get(key) or agents.get(key.replace("-", "_"))
-            sig = signatures.get(key) or signatures.get(key.replace("_", "-"))
-            agent_id = key
-        else:
-            print(f"Agent '{args.name}' not found.", file=sys.stderr)
-            print(f"Registry agents: {', '.join(sorted(agents.keys()))}", file=sys.stderr)
-            print(f"Signature agents: {', '.join(sorted(signatures.keys()))}", file=sys.stderr)
-            sys.exit(1)
-
-    fmt = args.format
-
-    if fmt == "json":
-        card = {"agent_id": agent_id}
-        if sig:
-            card.update(sig)
-        if agent:
-            card["registry"] = agent
-        char_map = _find_character_mapping(themes, agent_id)
-        if char_map:
-            card["character_mapping"] = char_map
-        print(json.dumps(card, indent=2))
-        return
-
-    # Terminal (ANSI) rendering
-    glyph = (sig or {}).get("glyph", "?")
-    color = (sig or {}).get("color", "#FFFFFF")
-    accent = (sig or {}).get("accent", "#CCCCCC")
-    voice = (sig or {}).get("voice", "unknown")
-    resonance = (sig or {}).get("resonance", [])
-    co_author = (sig or {}).get("co_author", "")
-    description = (sig or agent or {}).get("description", "")
-    display_name = (sig or {}).get("display_name", "") or (agent or {}).get("name", agent_id)
-
-    c = _hex_to_ansi(color)
-    a = _hex_to_ansi(accent)
-    b = _bold()
-    d = _dim()
-    r = _reset()
-
-    char_map = _find_character_mapping(themes, agent_id)
-    primary_char = char_map.get("primary", "")
-    secondary_char = char_map.get("secondary", "")
-    rationale = char_map.get("rationale", "")
-
-    width = 46
-    border = f"{c}{'═' * width}{r}"
-    line = f"{c}{'─' * width}{r}"
-
-    print(f"{c}╔{border}╗{r}")
-    print(f"{c}║{r}  {c}{b}{glyph}  {display_name}{r}{' ' * (width - len(display_name) - 5)}{c}║{r}")
-    print(f"{c}║{r}  {d}{color}{r}{' ' * (width - len(color) - 2)}{c}║{r}")
-    print(f"{c}╠{line}╣{r}")
-    print(f"{c}║{r}  {a}Voice:{r}      {voice}{' ' * (width - len(voice) - 14)}{c}║{r}")
-
-    if resonance:
-        res_str = ", ".join(resonance[:4])
-        print(f"{c}║{r}  {a}Resonance:{r}  {res_str}{' ' * max(0, width - len(res_str) - 14)}{c}║{r}")
-
-    if agent:
-        port = agent.get("port", "—")
-        cls = agent.get("class", "—")
-        stage = agent.get("evolution_stage", "base")
-        print(f"{c}║{r}  {a}Class:{r}      {cls}{' ' * (width - len(str(cls)) - 14)}{c}║{r}")
-        print(f"{c}║{r}  {a}Port:{r}       {port}{' ' * (width - len(str(port)) - 14)}{c}║{r}")
-        print(f"{c}║{r}  {a}Stage:{r}      {stage}{' ' * (width - len(str(stage)) - 14)}{c}║{r}")
-
-    if primary_char or secondary_char:
-        print(f"{c}╠{line}╣{r}")
-        if primary_char:
-            print(f"{c}║{r}  {b}Primary:{r}    {primary_char}{' ' * max(0, width - len(primary_char) - 14)}{c}║{r}")
-        if secondary_char:
-            print(f"{c}║{r}  {b}Secondary:{r}  {secondary_char}{' ' * max(0, width - len(secondary_char) - 14)}{c}║{r}")
-
-    if description:
-        print(f"{c}╠{line}╣{r}")
-        words = description.split()
-        lines = []
-        current = ""
-        for w in words:
-            if len(current) + len(w) + 1 <= width - 4:
-                current = f"{current} {w}" if current else w
-            else:
-                lines.append(current)
-                current = w
-        if current:
-            lines.append(current)
-        for ln in lines:
-            print(f"{c}║{r}  {d}{ln}{r}{' ' * max(0, width - len(ln) - 2)}{c}║{r}")
-
-    print(f"{c}╚{border}╝{r}")
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="PMOVES Agent Taxonomy Helper",
@@ -680,8 +706,8 @@ def main():
     mermaid_parser.add_argument("--style", choices=["topology", "tac", "nats"],
                                 default="topology", help="Diagram style (default: topology)")
 
-    card_parser = subparsers.add_parser("render-card", help="Render themed agent card (ANSI/JSON)")
-    card_parser.add_argument("name", help="Agent ID or name (fuzzy match)")
+    card_parser = subparsers.add_parser("render-card", help="Render themed agent identity card")
+    card_parser.add_argument("name", help="Agent ID (e.g., claude-opus, 4090-claude)")
 
     args = parser.parse_args()
 

--- a/pmoves/tools/agent_taxonomy_helper.py
+++ b/pmoves/tools/agent_taxonomy_helper.py
@@ -502,7 +502,7 @@ def _load_signatures():
         return {}
     with open(SIGNATURES_PATH, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
-    return data.get("agents", data)
+    return data.get("signatures", data)
 
 
 def _load_themes():

--- a/pmoves/tools/chit_terminal_viz.py
+++ b/pmoves/tools/chit_terminal_viz.py
@@ -25,6 +25,33 @@ from typing import Dict, List, Optional, Tuple
 SPARK_CHARS = " ▁▂▃▄▅▆▇█"
 BRAILLE_BASE = 0x2800  # Unicode braille pattern base
 
+SIGNATURES_PATH = Path(__file__).parent.parent / "config" / "agent_signatures.yaml"
+
+
+def _load_agent_sig(agent_id: str) -> Optional[Dict]:
+    """Load a single agent signature by ID from agent_signatures.yaml."""
+    try:
+        import yaml
+    except ImportError:
+        return None
+    if not SIGNATURES_PATH.exists():
+        return None
+    with open(SIGNATURES_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    for entry in data.get("signatures", data.get("agents", [])):
+        if isinstance(entry, dict) and entry.get("agent_id") == agent_id:
+            return entry
+    return None
+
+
+def _ansi_fg(hex_color: str, text: str) -> str:
+    """24-bit ANSI foreground color."""
+    h = hex_color.lstrip("#")
+    if len(h) != 6:
+        return text
+    r, g, b = int(h[:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return f"\033[38;2;{r};{g};{b}m{text}\033[0m"
+
 
 def sparkline(values: List[float], width: Optional[int] = None) -> str:
     """Render values as a sparkline string."""
@@ -164,46 +191,25 @@ def constellation_map(
     return "\n".join(lines)
 
 
-SIGNATURES_PATH = Path(__file__).parent.parent / "config" / "agent_signatures.yaml"
+def render_cgp_summary(cgp: Dict, agent_sig: Optional[Dict] = None) -> str:
+    """Render a CGP packet summary in terminal.
 
-
-def _load_agent_signature(agent_id: str) -> Optional[Dict]:
-    """Load a single agent's signature from agent_signatures.yaml."""
-    if not SIGNATURES_PATH.exists():
-        return None
-    try:
-        import yaml
-    except ImportError:
-        return None
-    with open(SIGNATURES_PATH, encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
-    agents = data.get("signatures", data)
-    return agents.get(agent_id) or agents.get(agent_id.replace("_", "-"))
-
-
-def _agent_attribution_line(sig: Dict) -> str:
-    """Format agent attribution line: ◆ Claude Opus | #7C3AED | analytical"""
-    glyph = sig.get("glyph", "?")
-    name = sig.get("display_name", "Unknown")
-    color = sig.get("color", "#FFFFFF")
-    voice = sig.get("voice", "")
-    return f"{glyph} {name} | {color} | {voice}"
-
-
-def render_cgp_summary(cgp: Dict, agent_id: Optional[str] = None) -> str:
-    """Render a CGP packet summary in terminal."""
-    attribution = ""
-    if agent_id:
-        sig = _load_agent_signature(agent_id)
-        if sig:
-            attribution = _agent_attribution_line(sig)
-
-    header_line = attribution if attribution else "CGP v2 Packet Summary"
+    If agent_sig is provided, shows agent attribution with glyph and color.
+    """
     lines = [
         "╔══════════════════════════════════════╗",
-        f"║  {header_line:<36}  ║",
+        "║     CGP v2 Packet Summary            ║",
         "╚══════════════════════════════════════╝",
     ]
+
+    # Agent attribution line
+    if agent_sig:
+        glyph = agent_sig.get("glyph", "?")
+        color = agent_sig.get("color", "#FFFFFF")
+        aid = agent_sig.get("agent_id", "unknown")
+        voice = agent_sig.get("voice", "")
+        attr_line = f"  {_ansi_fg(color, glyph)} {aid} | {color} | {voice}"
+        lines.append(attr_line)
 
     payload = cgp.get("payload", {})
 
@@ -248,9 +254,16 @@ def main() -> int:
         help="Visualization mode",
     )
     parser.add_argument("--input", "-i", help="Input JSON file")
-    parser.add_argument("--agent", "-a", help="Agent ID for attribution (reads agent_signatures.yaml)")
+    parser.add_argument("--agent", help="Agent ID for themed rendering (e.g., claude-opus)")
 
     args = parser.parse_args()
+
+    # Load agent signature if requested
+    agent_sig = None
+    if args.agent:
+        agent_sig = _load_agent_sig(args.agent)
+        if not agent_sig:
+            print(f"Warning: Agent '{args.agent}' not found in signatures", file=sys.stderr)
 
     # Read input
     if args.input:
@@ -273,11 +286,20 @@ def main() -> int:
             "checksum": "abc123def456789",
         }
 
+    # Use agent glyph as point marker when available
+    point_marker = None
+    if agent_sig:
+        point_marker = agent_sig.get("glyph")
+
     if args.mode == "cgp":
-        print(render_cgp_summary(data, agent_id=args.agent))
+        print(render_cgp_summary(data, agent_sig=agent_sig))
     elif args.mode == "sparkline":
         values = data if isinstance(data, list) else data.get("values", [])
-        print(sparkline(values))
+        result = sparkline(values)
+        if agent_sig:
+            color = agent_sig.get("color", "#FFFFFF")
+            result = _ansi_fg(color, result)
+        print(result)
     elif args.mode == "poincare":
         points = data.get("points", [(0.3, -0.4)])
         labels = data.get("labels", [])

--- a/pmoves/tools/chit_terminal_viz.py
+++ b/pmoves/tools/chit_terminal_viz.py
@@ -38,8 +38,12 @@ def _load_agent_sig(agent_id: str) -> Optional[Dict]:
         return None
     with open(SIGNATURES_PATH, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
-    for entry in data.get("signatures", data.get("agents", [])):
-        if isinstance(entry, dict) and entry.get("agent_id") == agent_id:
+    sigs = data.get("signatures", data.get("agents", {}))
+    if isinstance(sigs, dict):
+        # Dict keyed by agent_id (canonical format)
+        if agent_id in sigs:
+            entry = sigs[agent_id]
+            entry.setdefault("agent_id", agent_id)
             return entry
     return None
 
@@ -208,7 +212,9 @@ def render_cgp_summary(cgp: Dict, agent_sig: Optional[Dict] = None) -> str:
         color = agent_sig.get("color", "#FFFFFF")
         aid = agent_sig.get("agent_id", "unknown")
         voice = agent_sig.get("voice", "")
-        attr_line = f"  {_ansi_fg(color, glyph)} {aid} | {color} | {voice}"
+        # Truncate to box width (38 inner chars minus 2 padding = 36 visible)
+        attr_text = f"{aid} | {color} | {voice}"[:34]
+        attr_line = f"  {_ansi_fg(color, glyph)} {attr_text}"
         lines.append(attr_line)
 
     payload = cgp.get("payload", {})

--- a/pmoves/tools/chit_terminal_viz.py
+++ b/pmoves/tools/chit_terminal_viz.py
@@ -15,7 +15,9 @@ Usage:
 import argparse
 import json
 import math
+import os
 import sys
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 
@@ -162,11 +164,44 @@ def constellation_map(
     return "\n".join(lines)
 
 
-def render_cgp_summary(cgp: Dict) -> str:
+SIGNATURES_PATH = Path(__file__).parent.parent / "config" / "agent_signatures.yaml"
+
+
+def _load_agent_signature(agent_id: str) -> Optional[Dict]:
+    """Load a single agent's signature from agent_signatures.yaml."""
+    if not SIGNATURES_PATH.exists():
+        return None
+    try:
+        import yaml
+    except ImportError:
+        return None
+    with open(SIGNATURES_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    agents = data.get("agents", data)
+    return agents.get(agent_id) or agents.get(agent_id.replace("_", "-"))
+
+
+def _agent_attribution_line(sig: Dict) -> str:
+    """Format agent attribution line: ◆ Claude Opus | #7C3AED | analytical"""
+    glyph = sig.get("glyph", "?")
+    name = sig.get("display_name", "Unknown")
+    color = sig.get("color", "#FFFFFF")
+    voice = sig.get("voice", "")
+    return f"{glyph} {name} | {color} | {voice}"
+
+
+def render_cgp_summary(cgp: Dict, agent_id: Optional[str] = None) -> str:
     """Render a CGP packet summary in terminal."""
+    attribution = ""
+    if agent_id:
+        sig = _load_agent_signature(agent_id)
+        if sig:
+            attribution = _agent_attribution_line(sig)
+
+    header_line = attribution if attribution else "CGP v2 Packet Summary"
     lines = [
         "╔══════════════════════════════════════╗",
-        "║     CGP v2 Packet Summary            ║",
+        f"║  {header_line:<36}  ║",
         "╚══════════════════════════════════════╝",
     ]
 
@@ -213,6 +248,7 @@ def main() -> int:
         help="Visualization mode",
     )
     parser.add_argument("--input", "-i", help="Input JSON file")
+    parser.add_argument("--agent", "-a", help="Agent ID for attribution (reads agent_signatures.yaml)")
 
     args = parser.parse_args()
 
@@ -238,7 +274,7 @@ def main() -> int:
         }
 
     if args.mode == "cgp":
-        print(render_cgp_summary(data))
+        print(render_cgp_summary(data, agent_id=args.agent))
     elif args.mode == "sparkline":
         values = data if isinstance(data, list) else data.get("values", [])
         print(sparkline(values))

--- a/pmoves/tools/chit_terminal_viz.py
+++ b/pmoves/tools/chit_terminal_viz.py
@@ -177,7 +177,7 @@ def _load_agent_signature(agent_id: str) -> Optional[Dict]:
         return None
     with open(SIGNATURES_PATH, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
-    agents = data.get("agents", data)
+    agents = data.get("signatures", data)
     return agents.get(agent_id) or agents.get(agent_id.replace("_", "-"))
 
 


### PR DESCRIPTION
## Summary
Wire existing agent signature/theme data into Python CLI tools and BoTZ Gateway API for cross-machine theming.

## W1 Agent Theming — Python-Side Wiring (4090 Node)

### agent_taxonomy_helper.py — `render-card` command
- Reads `agent_signatures.yaml` (glyph, color, voice) + `agent-themes.yaml` (character mappings)
- ANSI 24-bit color terminal output with color swatches, character mapping, word-wrapped description
- JSON and markdown output modes (`--format json|markdown`)

### chit_terminal_viz.py — `--agent` flag
- Load agent signature for themed rendering across all viz modes
- CGP summary shows attribution line: `◆ claude-opus | #7C3AED | analytical`
- Sparkline mode tints output with agent color

### botz-gateway/main.py — Theme API
- `GET /v1/botz/themes` — list all agents with glyph, color, character mappings
- `GET /v1/botz/themes/{agent_id}` — specific agent theme (normalized ID lookup)
- `POST /v1/botz/themes/whoami` — resolve agent identity from Supabase registration or hostname

## Test plan
- [ ] `python pmoves/tools/agent_taxonomy_helper.py render-card claude-opus` renders ANSI card
- [ ] `python pmoves/tools/agent_taxonomy_helper.py render-card claude-opus --format json` outputs valid JSON
- [ ] `python pmoves/tools/chit_terminal_viz.py --agent claude-opus` shows attribution in CGP summary
- [ ] `curl localhost:8054/v1/botz/themes` returns all agent themes
- [ ] `curl localhost:8054/v1/botz/themes/claude-opus` returns specific theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent theming API endpoints to retrieve and manage agent themes with signature-based lookups.
  * Introduced `render-card` CLI command to display formatted agent identity cards with custom styling.
  * Enhanced terminal visualization with agent metadata, ANSI color support, and themed character attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->