### PR TITLE
feat(w2): devcontainer + SKILL.md + P7 TAC updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,66 +1,60 @@
 {
-  "name": "PMOVES.AI Development",
+  "name": "PMOVES.AI",
   "image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
-
   "features": {
-    "ghcr.io/devcontainers/features/node:1": { "version": "22" },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/go:1": { "version": "1.23" }
-  },
-
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "ms-python.python",
-        "ms-azuretools.vscode-docker",
-        "redhat.vscode-yaml",
-        "tamasfe.even-better-toml",
-        "saoudrizwan.claude-dev",
-        "ms-python.debugpy"
-      ],
-      "settings": {
-        "python.defaultInterpreterPath": "/usr/local/bin/python",
-        "editor.formatOnSave": true
-      }
+    "ghcr.io/devcontainers-extra/features/bash-command:1": {
+      "command": "pip install uv && uv --version"
     }
   },
-
-  "postCreateCommand": "pip install uv && uv pip install pyyaml rich typer httpx && make -C pmoves env-setup 2>/dev/null || true && make -C pmoves brand-defaults 2>/dev/null || true",
-
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "editor.formatOnSave": true,
+        "yaml.schemas": {
+          "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml"
+        }
+      },
+      "extensions": [
+        "anthropics.claude-code",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml",
+        "ms-vscode.makefile-tools",
+        "christian-kohler.path-intellisense",
+        "timonwong.shellcheck",
+        "ms-toolsai.jupyter"
+      ]
+    }
+  },
   "forwardPorts": [
     3000,
-    3030,
     4222,
-    6333,
-    7474,
-    7700,
     8054,
     8080,
     8086,
-    8105,
-    9000,
+    8096,
     9090
   ],
-
   "portsAttributes": {
-    "3000": { "label": "Grafana" },
-    "3030": { "label": "TensorZero Gateway" },
-    "4222": { "label": "NATS" },
-    "6333": { "label": "Qdrant" },
-    "7474": { "label": "Neo4j" },
-    "7700": { "label": "Meilisearch" },
-    "8054": { "label": "BoTZ Gateway" },
-    "8080": { "label": "Agent Zero" },
-    "8086": { "label": "Hi-RAG v2" },
-    "8105": { "label": "A2UI Renderer" },
-    "9000": { "label": "MinIO" },
-    "9090": { "label": "Prometheus" }
+    "3000": { "label": "Grafana", "onAutoForward": "silent" },
+    "4222": { "label": "NATS", "onAutoForward": "silent" },
+    "8054": { "label": "BoTZ Gateway", "onAutoForward": "silent" },
+    "8080": { "label": "Agent Zero", "onAutoForward": "notify" },
+    "8086": { "label": "Hi-RAG v2", "onAutoForward": "silent" },
+    "8096": { "label": "Cipher Memory", "onAutoForward": "silent" },
+    "9090": { "label": "Prometheus", "onAutoForward": "silent" }
   },
-
+  "postCreateCommand": "make -C pmoves env-setup && make -C pmoves brand-defaults",
   "containerEnv": {
-    "PMOVES_PROFILE": "student"
+    "PMOVES_PROFILE": "student",
+    "PYTHONIOENCODING": "utf-8"
   },
-
   "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,66 @@
+{
+  "name": "PMOVES.AI Development",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
+
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "22" },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/go:1": { "version": "1.23" }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml",
+        "tamasfe.even-better-toml",
+        "saoudrizwan.claude-dev",
+        "ms-python.debugpy"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "editor.formatOnSave": true
+      }
+    }
+  },
+
+  "postCreateCommand": "pip install uv && uv pip install pyyaml rich typer httpx && make -C pmoves env-setup 2>/dev/null || true && make -C pmoves brand-defaults 2>/dev/null || true",
+
+  "forwardPorts": [
+    3000,
+    3030,
+    4222,
+    6333,
+    7474,
+    7700,
+    8054,
+    8080,
+    8086,
+    8105,
+    9000,
+    9090
+  ],
+
+  "portsAttributes": {
+    "3000": { "label": "Grafana" },
+    "3030": { "label": "TensorZero Gateway" },
+    "4222": { "label": "NATS" },
+    "6333": { "label": "Qdrant" },
+    "7474": { "label": "Neo4j" },
+    "7700": { "label": "Meilisearch" },
+    "8054": { "label": "BoTZ Gateway" },
+    "8080": { "label": "Agent Zero" },
+    "8086": { "label": "Hi-RAG v2" },
+    "8105": { "label": "A2UI Renderer" },
+    "9000": { "label": "MinIO" },
+    "9090": { "label": "Prometheus" }
+  },
+
+  "containerEnv": {
+    "PMOVES_PROFILE": "student"
+  },
+
+  "remoteUser": "vscode"
+}

--- a/pbnj/pinokio/api/pmoves-services/SKILL.md
+++ b/pbnj/pinokio/api/pmoves-services/SKILL.md
@@ -1,46 +1,61 @@
 ---
-name: pmoves-services
-description: Docker Compose profile controller for PMOVES.AI production services
-category: infrastructure
-version: "1.0"
+name: PMOVES Services Launcher
+description: Docker Compose profile controller for PMOVES.AI services via Pinokio
+keywords: docker, compose, services, launcher, profiles
+version: 1.0.0
+category: Infrastructure/Launcher
 ---
 
 # PMOVES Services Launcher
 
+**Category**: Infrastructure/Launcher
+**Version**: 1.0.0
+**Status**: Active
+
 ## Overview
 
-Pinokio launcher for PMOVES.AI Docker Compose service profiles. Provides one-click install, start, stop, and monitoring for the full PMOVES.AI stack.
+Pinokio launcher for the PMOVES.AI Docker Compose service stack. Provides one-click install, start, stop, reset, and update for core services, monitoring, voice, and external integrations.
 
 ## Capabilities
 
-- **Install**: Bootstrap environment (env-setup, brand-defaults, Docker pull)
-- **Start Core**: Agent Zero, Archon, BoTZ Gateway, data stores (Qdrant, Neo4j, Meilisearch, MinIO)
-- **Start Voice**: Ultimate-TTS-Studio, Flute-Gateway
-- **Start External**: Hi-RAG, DeepResearch, SupaSerch
-- **Start Monitoring**: Prometheus, Grafana, Loki
-- **Status**: Health check all running services
-- **Reset**: Remove virtual environments and cached data
+- Start/stop Docker Compose profiles (core, monitoring, voice, external)
+- Install prerequisites (Docker, env setup, brand defaults)
+- Reset service state and volumes
+- Update launcher scripts and service images
+- Real-time service status display
 
-## Service Profiles
+## Scripts
 
-| Profile | Services | GPU Required |
-|---------|----------|-------------|
-| `core` | Agent Zero, Archon, BoTZ, NATS, data stores | No |
-| `voice` | Ultimate-TTS-Studio, Flute-Gateway | Yes (CUDA) |
-| `external` | Hi-RAG v2, DeepResearch, SupaSerch | Optional |
-| `monitoring` | Prometheus, Grafana, Loki, cAdvisor | No |
+| Script | Purpose |
+|--------|---------|
+| `install.js` | Bootstrap Docker, env-setup, brand-defaults |
+| `start-core.js` | Start core services (Agent Zero, NATS, Supabase, Hi-RAG) |
+| `start-monitoring.js` | Start Prometheus, Grafana, Loki stack |
+| `start-voice.js` | Start Flute-Gateway, Ultimate-TTS-Studio |
+| `start-external.js` | Start external integrations (Discord, Jellyfin, etc.) |
+| `status.js` | Display service health status |
+| `stop.js` | Stop all running services |
+| `reset.js` | Reset dependencies and volumes |
+| `update.js` | Pull latest images and scripts |
+| `pinokio.js` | Dynamic UI generator (sidebar menu) |
 
-## Agent Interpreter Integration
+## Docker Compose Profiles
 
-This launcher is discoverable by Pinokio 7 Agent Interpreter. Use the sidebar to select which profile to start, or let the AI assistant recommend profiles based on your task.
+| Profile | Services | Ports |
+|---------|----------|-------|
+| `agents` | Agent Zero, Archon, Mesh Agent | 8080, 8091 |
+| `workers` | Extract, LangExtract, media analyzers | 8083, 8084 |
+| `monitoring` | Prometheus, Grafana, Loki | 9090, 3000, 3100 |
+| `gpu` | GPU-enabled services | varies |
+| `yt` | PMOVES.YT ingestion | 8077 |
 
-## Ports
+## Integration Points
 
-| Port | Service |
-|------|---------|
-| 8080 | Agent Zero API |
-| 8054 | BoTZ Gateway |
-| 8086 | Hi-RAG v2 |
-| 3030 | TensorZero |
-| 3000 | Grafana |
-| 9090 | Prometheus |
+- **Make targets**: `make -C pmoves up`, `make -C pmoves verify-all`
+- **Health checks**: All services expose `/healthz`
+- **NATS**: Event bus at port 4222
+
+## See Also
+
+- [pmoves-remote](../pmoves-remote/SKILL.md) — Remote service discovery
+- [PMOVES.AI CLAUDE.md](../../../../.claude/CLAUDE.md) — Full architecture context

--- a/pbnj/pinokio/api/pmoves-services/SKILL.md
+++ b/pbnj/pinokio/api/pmoves-services/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: pmoves-services
+description: Docker Compose profile controller for PMOVES.AI production services
+category: infrastructure
+version: "1.0"
+---
+
+# PMOVES Services Launcher
+
+## Overview
+
+Pinokio launcher for PMOVES.AI Docker Compose service profiles. Provides one-click install, start, stop, and monitoring for the full PMOVES.AI stack.
+
+## Capabilities
+
+- **Install**: Bootstrap environment (env-setup, brand-defaults, Docker pull)
+- **Start Core**: Agent Zero, Archon, BoTZ Gateway, data stores (Qdrant, Neo4j, Meilisearch, MinIO)
+- **Start Voice**: Ultimate-TTS-Studio, Flute-Gateway
+- **Start External**: Hi-RAG, DeepResearch, SupaSerch
+- **Start Monitoring**: Prometheus, Grafana, Loki
+- **Status**: Health check all running services
+- **Reset**: Remove virtual environments and cached data
+
+## Service Profiles
+
+| Profile | Services | GPU Required |
+|---------|----------|-------------|
+| `core` | Agent Zero, Archon, BoTZ, NATS, data stores | No |
+| `voice` | Ultimate-TTS-Studio, Flute-Gateway | Yes (CUDA) |
+| `external` | Hi-RAG v2, DeepResearch, SupaSerch | Optional |
+| `monitoring` | Prometheus, Grafana, Loki, cAdvisor | No |
+
+## Agent Interpreter Integration
+
+This launcher is discoverable by Pinokio 7 Agent Interpreter. Use the sidebar to select which profile to start, or let the AI assistant recommend profiles based on your task.
+
+## Ports
+
+| Port | Service |
+|------|---------|
+| 8080 | Agent Zero API |
+| 8054 | BoTZ Gateway |
+| 8086 | Hi-RAG v2 |
+| 3030 | TensorZero |
+| 3000 | Grafana |
+| 9090 | Prometheus |

--- a/pmoves/configs/tac_trees/pinokio-p7.tac.yaml
+++ b/pmoves/configs/tac_trees/pinokio-p7.tac.yaml
@@ -199,9 +199,32 @@ root:
             type: manual
             expect: "SKILL.md in pmoves-services describes Docker profile start/stop"
           context: "pbnj/pinokio/api/pmoves-services/"
-          agent_hint: z890-claude
-          status: pending
+          agent_hint: 4090-claude
+          status: done
+          completed: "2026-03-20"
           depends_on: [p7.skillmd.format]
+
+        - id: p7.skillmd.cipher-beats
+          task: "Cipher Beats SKILL.md created"
+          action:
+            type: grep
+            target: "pbnj/pinokio/api/pmoves-cipher-beats/SKILL.md"
+            pattern: "cipher-beats"
+          context: "pbnj/pinokio/api/pmoves-cipher-beats/"
+          agent_hint: 4090-claude
+          status: done
+          completed: "2026-03-19"
+
+        - id: p7.skillmd.holographic-blocks
+          task: "Holographic Blocks SKILL.md created"
+          action:
+            type: grep
+            target: "pbnj/pinokio/api/pmoves-holographic-blocks/SKILL.md"
+            pattern: "holographic-blocks"
+          context: "pbnj/pinokio/api/pmoves-holographic-blocks/"
+          agent_hint: 4090-claude
+          status: done
+          completed: "2026-03-19"
 
     # =========================================================================
     # Phase 7: NATS Integration (Future)

--- a/pmoves/configs/tac_trees/pinokio-p7.tac.yaml
+++ b/pmoves/configs/tac_trees/pinokio-p7.tac.yaml
@@ -199,32 +199,9 @@ root:
             type: manual
             expect: "SKILL.md in pmoves-services describes Docker profile start/stop"
           context: "pbnj/pinokio/api/pmoves-services/"
-          agent_hint: 4090-claude
-          status: done
-          completed: "2026-03-20"
+          agent_hint: z890-claude
+          status: pending
           depends_on: [p7.skillmd.format]
-
-        - id: p7.skillmd.cipher-beats
-          task: "Cipher Beats SKILL.md created"
-          action:
-            type: grep
-            target: "pbnj/pinokio/api/pmoves-cipher-beats/SKILL.md"
-            pattern: "cipher-beats"
-          context: "pbnj/pinokio/api/pmoves-cipher-beats/"
-          agent_hint: 4090-claude
-          status: done
-          completed: "2026-03-19"
-
-        - id: p7.skillmd.holographic-blocks
-          task: "Holographic Blocks SKILL.md created"
-          action:
-            type: grep
-            target: "pbnj/pinokio/api/pmoves-holographic-blocks/SKILL.md"
-            pattern: "holographic-blocks"
-          context: "pbnj/pinokio/api/pmoves-holographic-blocks/"
-          agent_hint: 4090-claude
-          status: done
-          completed: "2026-03-19"
 
     # =========================================================================
     # Phase 7: NATS Integration (Future)


### PR DESCRIPTION
## Summary
Add root devcontainer config, SKILL.md files for Pinokio service discovery, and TAC tree progress updates.

## W2 P7 IDE & Codespace Setup (4090 Node)

### .devcontainer/devcontainer.json
- Python 3.12 base image with Node.js 22, Docker-in-Docker, gh CLI, uv
- Extensions: Claude Code, Python, Docker, YAML, Jupyter, shellcheck, Makefile
- 7 essential ports forwarded (Grafana, NATS, BoTZ, Agent Zero, Hi-RAG, Cipher, Prometheus)
- `PMOVES_PROFILE=student` for tiered service selection
- `PYTHONIOENCODING=utf-8` for Windows compatibility

### SKILL.md for P7 Discovery
- `pbnj/pinokio/api/pmoves-services/SKILL.md` — Docker Compose profile controller with service tables
- `pbnj/pinokio/api/pmoves-remote/SKILL.md` — Remote service discovery via Tailscale mesh

### P7 TAC Tree Updates
- `p7.interpreter.services` → done (SKILL.md created)
- `p7.skillmd.services` → done (both pmoves-services and pmoves-remote)

## Test plan
- [ ] `python -m json.tool .devcontainer/devcontainer.json` validates JSON
- [ ] `ls pbnj/pinokio/api/pmoves-services/SKILL.md pbnj/pinokio/api/pmoves-remote/SKILL.md` both exist
- [ ] TAC tree items marked done with timestamped notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)