### PR TITLE
fix(pr-trim): nitpick review step + PYTHONIOENCODING for Windows

### DIFF
--- a/.claude/commands/pr-trim.md
+++ b/.claude/commands/pr-trim.md
@@ -21,9 +21,27 @@ Trim a single PR: analyze threads, apply fixes interactively, resolve addressed 
    - Read the file and line referenced
    - Apply the fix
    - Explain the change to the user
-5. After all actionable threads are addressed, commit + push
-6. Run `make -C pmoves pr-trim-resolve PR=<number> RESOLVE_ACTIONABLE=1`
-7. Unless `--no-trail`: `make -C pmoves sign-trail SUMMARY="PR Hedge Trim: resolved K threads on PR #N"`
+5. For each **nitpick** thread:
+   - Read the suggestion carefully
+   - Evaluate: is it a valid improvement or purely stylistic preference?
+   - If valid improvement: apply the fix and note what was changed
+   - If stylistic only: skip but log the learning for `/chit:review-sweep`
+   - Record all nitpick learnings (applied or skipped) for the trail entry
+6. After all actionable + nitpick threads are addressed, commit + push
+7. Run `make -C pmoves pr-trim-resolve PR=<number> RESOLVE_ACTIONABLE=1`
+8. Unless `--no-trail`: `make -C pmoves sign-trail SUMMARY="PR Hedge Trim: resolved K threads on PR #N"`
+
+### Comment coverage
+
+The default `pr-trim-analyze` fetches review comments (inline threads). Some CodeRabbit
+feedback appears as **issue-level comments** or **review body comments** instead. To
+ensure full coverage:
+
+1. After step 2 (read classification JSON), also fetch:
+   - `gh api repos/{owner}/{repo}/issues/{PR}/comments` — issue-level comments
+   - `gh api repos/{owner}/{repo}/pulls/{PR}/reviews` — review events (summary body)
+2. Scan these for CodeRabbit-authored entries not already in the classification
+3. Classify any new threads found and merge them into the working set
 
 ### Batch mode (`--batch`)
 

--- a/pmoves/mk/preflight.mk
+++ b/pmoves/mk/preflight.mk
@@ -1,4 +1,8 @@
 .PHONY: env-bootstrap-lite env-setup env-check preflight flight-check flight-check-retro preflight-retro showtime bringup-showtime smoke-showtime showtime-links showtime-links-open showtime-links-strict submodule-integrity submodule-layer-validate submodule-layer-validate-one submodule-layer-validate-all submodule-layer-validate-all-strict submodule-layer-validate-strict submodule-branch-policy-check audit-layers audit-layers-static audit-layers-runtime ci-runners-check ci-runners-check-strict ci-runners-map ci-runners-map-strict ci-runners-lockdown ci-runners-lockdown-strict ci-runners-local-cert-up ci-runners-local-cert-down ci-runners-local-cert-status ci-queue-sitrep ci-queue-drain-nonpr ci-queue-drain-nonpr-apply skill-registry-validate auth-alignment auth-alignment-strict topology-chit-gate topology-chit-gate-strict pr-monitor pr-monitor-strict pr-monitor-chit-packet pr-trim-analyze pr-trim-resolve pr-trim-report pr-trim floos-status floos-pr-monitor-validate floos-pr-monitor-resolve floos-pr-monitor-run-dry chit-flow-pr-monitor chit-flow-pr-monitor-strict ports-resolve sign-trail
+
+# Force UTF-8 output on Windows (cp1252 chokes on Unicode/emoji in pr-trim et al.)
+export PYTHONIOENCODING ?= utf-8
+
 RETRO_THEME_QUICK ?= cb
 RETRO_THEME_FULL ?= galaxy
 RETRO_FLAGS ?=


### PR DESCRIPTION
## Summary
- **pr-trim skill**: Add step 5 for nitpick thread evaluation — apply valid improvements, log stylistic preferences for `/chit:review-sweep`
- **pr-trim skill**: Add comment coverage section to fetch issue-level and review-body comments missed by default analyzer
- **preflight.mk**: Export `PYTHONIOENCODING=utf-8` to prevent `UnicodeEncodeError: 'charmap' codec can't encode` on Windows cp1252

## Context
These fixes came from the PR trim sessions on #1039, #1040, #1041 where:
1. Nitpick threads were skipped entirely (no evaluation step existed)
2. Some CodeRabbit feedback appeared as issue-level comments, invisible to the thread analyzer
3. `make pr-trim-analyze` crashed on Windows due to emoji/Unicode in output

## Test plan
- [ ] `make -C pmoves pr-trim-analyze PR=1039` completes without UnicodeEncodeError
- [ ] `/pr-trim 1039 --dry-run` shows nitpick threads in classification table
- [ ] Issue-level comments from CodeRabbit are included in analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced pull request workflow documentation with improved nitpick review handling and expanded comment classification capabilities.

* **Chores**
  * Improved UTF-8 character encoding configuration for Python build tools across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->