### PR TITLE
fix(review): address 12 CodeRabbit findings from PRs #1066, #1069

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -110,7 +110,7 @@ PMOVES.AI is a **production-ready multi-agent orchestration platform** featuring
 - **See:** `.claude/context/flute-gateway.md` for API reference
 
 **Ultimate-TTS-Studio** [Port 7860 native, 7861 Docker]
-- Multi-engine TTS with 13 engines (Kokoro, F5-TTS, KittenTTS, VoxCPM, Higgs Audio, Fish Speech S2 Pro, Chatterbox Turbo, Qwen3 TTS, IndexTTS, IndexTTS2, VibeVoice, Fish Speech, ChatterboxTTS)
+- Multi-engine TTS with 14 engines (KittenTTS, Kokoro TTS, F5-TTS, IndexTTS, IndexTTS2, Fish Speech S1, Fish Speech S2 Pro, VoxCPM, Higgs Audio, ChatterboxTTS, Chatterbox Turbo, Chatterbox Multilingual, Qwen Voice Design, VibeVoice)
 - Gradio web interface for interactive synthesis
 - GPU-accelerated (CUDA 12.4), runs natively via Pinokio (NOT Docker)
 - Health: `GET http://localhost:7860/gradio_api/info`

--- a/.claude/commands/tts/test-engine.md
+++ b/.claude/commands/tts/test-engine.md
@@ -3,12 +3,12 @@ Test a single TTS engine with optional GPU metrics tracking via GPU Orchestrator
 ## Usage
 
 ```
-/tts:test-engine <engine_id> [--synth] [--metrics]
+/tts:test-engine <engine_id> [--load-only] [--metrics]
 ```
 
 **Arguments:**
 - `engine_id` — Engine to test (e.g., `kitten_tts`, `indextts2`, `kokoro`)
-- `--synth` — Also run synthesis (default: load-only)
+- `--load-only` — Only test model loading, skip synthesis
 - `--metrics` — Capture GPU VRAM before/after via GPU Orchestrator (port 8200)
 
 ## Implementation
@@ -18,7 +18,7 @@ Test a single TTS engine with optional GPU metrics tracking via GPU Orchestrator
 python -X utf8 pmoves/tools/test_all_tts_engines.py --engine {{args.engine_id}} --load-only {{#if args.metrics}}--metrics{{/if}}
 ```
 
-### Load + synthesize test
+### Load + synthesize test (default when --load-only is omitted)
 ```bash
 python -X utf8 pmoves/tools/test_all_tts_engines.py --engine {{args.engine_id}} {{#if args.metrics}}--metrics{{/if}}
 ```
@@ -37,7 +37,7 @@ python -c "import yaml; d=yaml.safe_load(open('pmoves/configs/tts-engine-capabil
 | `kokoro` | Kokoro TTS | preset-voices | ~800MB |
 | `higgs` | Higgs Audio | preset-voices | ~1500MB |
 | `f5_tts` | F5-TTS | voice-cloning | ~2000MB |
-| `fish` | Fish Speech | voice-cloning | ~1500MB |
+| `fish` | Fish Speech S1 | voice-cloning | ~1500MB |
 | `fish_s2` | Fish Speech S2 Pro | voice-cloning | ~2000MB |
 | `voxcpm` | VoxCPM | voice-cloning | ~2000MB |
 | `indextts` | IndexTTS | voice-cloning | ~1200MB |
@@ -45,7 +45,7 @@ python -c "import yaml; d=yaml.safe_load(open('pmoves/configs/tts-engine-capabil
 | `chatterbox` | ChatterboxTTS | multilingual | ~2000MB |
 | `chatterbox_turbo` | Chatterbox Turbo | multilingual | ~1500MB |
 | `chatterbox_multilingual` | Chatterbox Multilingual | multilingual | ~2500MB |
-| `qwen` | Qwen3 TTS | multilingual | ~2500MB |
+| `qwen` | Qwen Voice Design | multilingual | ~2500MB |
 | `vibevoice` | VibeVoice | podcast | ~3000MB |
 
 ## GPU Metrics Output (--metrics)
@@ -70,7 +70,7 @@ Falls back gracefully if GPU Orchestrator is offline.
 /tts:test-engine kitten_tts --metrics
 
 # Full load + synthesis test with metrics
-/tts:test-engine indextts2 --synth --metrics
+/tts:test-engine indextts2 --metrics
 
 # Sequential sweep to gauge cumulative GPU load
 /tts:test-engine kitten_tts --metrics

--- a/pmoves/configs/tac_trees/voice-agents.tac.yaml
+++ b/pmoves/configs/tac_trees/voice-agents.tac.yaml
@@ -195,13 +195,13 @@ root:
           agent_hint: codex
 
         - id: va.flute.predict-api
-          task: "UltimateTTSProvider uses predict API (not event API)"
+          task: "UltimateTTSProvider uses Gradio 4.x call API"
           action:
             type: grep
             target: "pmoves/services/flute-gateway/providers/ultimate_tts.py"
-            pattern: "predict_api_url"
-            expect: "Uses /api/ predict endpoint, not /gradio_api/call/ event endpoint"
-          context: "Event API SSE/WebSocket breaks with newer Gradio versions"
+            pattern: "gradio_api/call"
+            expect: "Uses /gradio_api/call/ endpoint (Gradio 4.x), not legacy /api/ predict endpoint"
+          context: "Gradio 4.x migrated from /api/ to /gradio_api/call/ event API"
           agent_hint: codex
 
         - id: va.flute.host-url

--- a/pmoves/configs/tts-engine-capabilities.yaml
+++ b/pmoves/configs/tts-engine-capabilities.yaml
@@ -145,7 +145,7 @@ engines:
     persona_default: archon-narrator
 
   fish:
-    name: Fish Speech
+    name: Fish Speech S1
     category: voice-cloning
     voice_cloning: true
     expressive_dimensions:
@@ -449,7 +449,7 @@ engines:
     persona_default: polyglot-agent
 
   qwen:
-    name: Qwen3 TTS
+    name: Qwen Voice Design
     category: multilingual
     voice_cloning: true
     models:

--- a/pmoves/monitoring/grafana/dashboards/messaging-gateway.json
+++ b/pmoves/monitoring/grafana/dashboards/messaging-gateway.json
@@ -1,10 +1,10 @@
 {
-  "title": "Messaging Gateway",
-  "description": "Multi-platform messaging gateway - API requests, NATS message handling, and platform message delivery",
+  "title": "Cast TTS Gateway",
+  "description": "Google Cast TTS gateway — request metrics, latency, device discovery, circuit breaker, cache, and voice profiles",
   "schemaVersion": 38,
   "version": 1,
-  "uid": "messaging-gateway",
-  "tags": ["messaging", "gateway", "nats", "api"],
+  "uid": "cast-tts-gateway",
+  "tags": ["cast", "tts", "voice", "gateway"],
   "refresh": "10s",
   "panels": [
     {
@@ -16,8 +16,8 @@
     {
       "type": "stat",
       "title": "Service Status",
-      "gridPos": { "x": 0, "y": 1, "w": 5, "h": 4 },
-      "targets": [{ "expr": "up{job=\"messaging-gateway\"}", "legendFormat": "Status" }],
+      "gridPos": { "x": 0, "y": 1, "w": 4, "h": 4 },
+      "targets": [{ "expr": "up{job=\"cast-tts-gateway\"}", "legendFormat": "Status" }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
       "fieldConfig": {
         "defaults": {
@@ -30,64 +30,72 @@
     },
     {
       "type": "stat",
-      "title": "Total API Requests",
-      "gridPos": { "x": 5, "y": 1, "w": 5, "h": 4 },
-      "targets": [{ "expr": "sum(messaging_gateway_api_requests_total)", "legendFormat": "Requests" }],
+      "title": "Total Requests",
+      "gridPos": { "x": 4, "y": 1, "w": 4, "h": 4 },
+      "targets": [{ "expr": "sum(cast_tts_requests_total)", "legendFormat": "Requests" }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
       "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "blue", "value": 0 }] } } }
     },
     {
       "type": "stat",
-      "title": "Total Messages Sent",
-      "gridPos": { "x": 10, "y": 1, "w": 5, "h": 4 },
-      "targets": [{ "expr": "sum(messaging_gateway_messages_sent_total)", "legendFormat": "Messages" }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
-      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": 0 }] } } }
-    },
-    {
-      "type": "stat",
       "title": "P95 Latency",
-      "gridPos": { "x": 15, "y": 1, "w": 4, "h": 4 },
-      "targets": [{ "expr": "histogram_quantile(0.95, sum(rate(messaging_gateway_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "P95" }],
+      "gridPos": { "x": 8, "y": 1, "w": 4, "h": 4 },
+      "targets": [{ "expr": "histogram_quantile(0.95, sum(rate(cast_tts_latency_seconds_bucket[5m])) by (le))", "legendFormat": "P95" }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
       "fieldConfig": { "defaults": { "unit": "s", "decimals": 3, "thresholds": { "steps": [{ "color": "green", "value": 0 }, { "color": "yellow", "value": 0.5 }, { "color": "red", "value": 2 }] } } }
     },
     {
       "type": "stat",
       "title": "Error Rate",
-      "gridPos": { "x": 19, "y": 1, "w": 5, "h": 4 },
-      "targets": [{ "expr": "sum(rate(messaging_gateway_api_requests_total{status=~\"4..|5..\"}[5m]))", "legendFormat": "Errors" }],
+      "gridPos": { "x": 12, "y": 1, "w": 4, "h": 4 },
+      "targets": [{ "expr": "sum(rate(cast_tts_requests_total{status!=\"200\"}[5m]))", "legendFormat": "Errors/s" }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
       "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 2, "thresholds": { "steps": [{ "color": "green", "value": 0 }, { "color": "yellow", "value": 0.1 }, { "color": "red", "value": 1 }] } } }
     },
     {
+      "type": "stat",
+      "title": "Device Discoveries",
+      "gridPos": { "x": 16, "y": 1, "w": 4, "h": 4 },
+      "targets": [{ "expr": "cast_device_discoveries_total", "legendFormat": "Discoveries" }],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "purple", "value": 0 }] } } }
+    },
+    {
+      "type": "stat",
+      "title": "Cache Hit Rate",
+      "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
+      "targets": [{ "expr": "sum(cast_cache_operations_total{operation=\"hit\"}) / (sum(cast_cache_operations_total{operation=\"hit\"}) + sum(cast_cache_operations_total{operation=\"miss\"})) * 100", "legendFormat": "Hit %" }],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": { "defaults": { "unit": "percent", "decimals": 1, "thresholds": { "steps": [{ "color": "red", "value": 0 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] } } }
+    },
+    {
       "type": "row",
-      "title": "API Request Metrics",
+      "title": "Request Metrics",
       "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
       "collapsed": false
     },
     {
       "type": "timeseries",
-      "title": "API Request Rate by Endpoint",
-      "gridPos": { "x": 0, "y": 6, "w": 12, "h": 8 },
+      "title": "Request Rate by Method",
+      "gridPos": { "x": 0, "y": 6, "w": 8, "h": 8 },
       "targets": [
-        { "expr": "sum(rate(messaging_gateway_api_requests_total[5m])) by (endpoint)", "legendFormat": "{{endpoint}}" }
+        { "expr": "sum(rate(cast_tts_requests_total[5m])) by (method)", "legendFormat": "{{method}}" }
       ],
       "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 30 } } }
     },
     {
       "type": "timeseries",
-      "title": "API Request Rate by Status",
-      "gridPos": { "x": 12, "y": 6, "w": 12, "h": 8 },
+      "title": "Request Rate by Status",
+      "gridPos": { "x": 8, "y": 6, "w": 8, "h": 8 },
       "targets": [
-        { "expr": "sum(rate(messaging_gateway_api_requests_total{status=~\"2..\"}[5m]))", "legendFormat": "Success (2xx)" },
-        { "expr": "sum(rate(messaging_gateway_api_requests_total{status=~\"4..\"}[5m]))", "legendFormat": "Client Error (4xx)" },
-        { "expr": "sum(rate(messaging_gateway_api_requests_total{status=~\"5..\"}[5m]))", "legendFormat": "Server Error (5xx)" }
+        { "expr": "sum(rate(cast_tts_requests_total{status=\"200\"}[5m]))", "legendFormat": "Success (200)" },
+        { "expr": "sum(rate(cast_tts_requests_total{status=~\"4..\"}[5m]))", "legendFormat": "Client Error (4xx)" },
+        { "expr": "sum(rate(cast_tts_requests_total{status=~\"5..\"}[5m]))", "legendFormat": "Server Error (5xx)" }
       ],
       "fieldConfig": {
         "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 30 } },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Success (2xx)" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "Success (200)" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
           { "matcher": { "id": "byName", "options": "Client Error (4xx)" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
           { "matcher": { "id": "byName", "options": "Server Error (5xx)" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
         ]
@@ -95,125 +103,98 @@
     },
     {
       "type": "timeseries",
-      "title": "API Requests Total by Endpoint",
-      "gridPos": { "x": 0, "y": 14, "w": 12, "h": 8 },
+      "title": "Latency Percentiles",
+      "gridPos": { "x": 16, "y": 6, "w": 8, "h": 8 },
       "targets": [
-        { "expr": "sum(rate(messaging_gateway_api_requests_total[5m])) by (endpoint)", "legendFormat": "{{endpoint}}" }
+        { "expr": "histogram_quantile(0.50, sum(rate(cast_tts_latency_seconds_bucket[5m])) by (le))", "legendFormat": "P50" },
+        { "expr": "histogram_quantile(0.95, sum(rate(cast_tts_latency_seconds_bucket[5m])) by (le))", "legendFormat": "P95" },
+        { "expr": "histogram_quantile(0.99, sum(rate(cast_tts_latency_seconds_bucket[5m])) by (le))", "legendFormat": "P99" }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 30 } } }
-    },
-    {
-      "type": "timeseries",
-      "title": "API Success Rate",
-      "gridPos": { "x": 12, "y": 14, "w": 12, "h": 8 },
-      "targets": [
-        { "expr": "sum(rate(messaging_gateway_api_requests_total{status=~\"2..\"}[5m])) / sum(rate(messaging_gateway_api_requests_total[5m])) * 100", "legendFormat": "Success %" }
-      ],
-      "fieldConfig": {
-        "defaults": { "unit": "percent", "decimals": 2, "custom": { "drawStyle": "line", "fillOpacity": 30 }, "thresholds": { "steps": [{ "color": "red", "value": 0 }, { "color": "yellow", "value": 95 }, { "color": "green", "value": 99 }] } }
-      }
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "fillOpacity": 10 } } }
     },
     {
       "type": "row",
-      "title": "Messaging Metrics",
-      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 1 },
+      "title": "Voice Pipeline",
+      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 1 },
       "collapsed": false
     },
     {
       "type": "timeseries",
-      "title": "Messages Sent by Platform and Status",
-      "gridPos": { "x": 0, "y": 23, "w": 12, "h": 8 },
+      "title": "Fallback Provider Usage",
+      "gridPos": { "x": 0, "y": 15, "w": 8, "h": 8 },
       "targets": [
-        { "expr": "sum(rate(messaging_gateway_messages_sent_total[5m])) by (platform, status)", "legendFormat": "{{platform}} - {{status}}" }
-      ],
-      "fieldConfig": {
-        "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 30 } },
-        "overrides": [
-          { "matcher": { "id": "byName", "options": "/.* - success.*/" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "/.* - failed.*/" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
-        ]
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "Messages Sent Rate",
-      "gridPos": { "x": 12, "y": 23, "w": 12, "h": 8 },
-      "targets": [
-        { "expr": "sum(rate(messaging_gateway_messages_sent_total{status=\"success\"}[5m]))", "legendFormat": "Success" },
-        { "expr": "sum(rate(messaging_gateway_messages_sent_total{status=\"failed\"}[5m]))", "legendFormat": "Failed" }
-      ],
-      "fieldConfig": {
-        "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 30 } },
-        "overrides": [
-          { "matcher": { "id": "byName", "options": "Success" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
-          { "matcher": { "id": "byName", "options": "Failed" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
-        ]
-      }
-    },
-    {
-      "type": "timeseries",
-      "title": "NATS Messages Received by Subject",
-      "gridPos": { "x": 0, "y": 31, "w": 12, "h": 8 },
-      "targets": [
-        { "expr": "sum(rate(messaging_gateway_nats_messages_received_total[5m])) by (subject)", "legendFormat": "{{subject}}" }
+        { "expr": "sum(rate(cast_fallback_provider_usage_total[5m])) by (provider, status)", "legendFormat": "{{provider}} ({{status}})" }
       ],
       "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 30 } } }
     },
     {
       "type": "timeseries",
-      "title": "Message Delivery Success Rate",
-      "gridPos": { "x": 12, "y": 31, "w": 12, "h": 8 },
+      "title": "Voice Profile Usage",
+      "gridPos": { "x": 8, "y": 15, "w": 8, "h": 8 },
       "targets": [
-        { "expr": "sum(rate(messaging_gateway_messages_sent_total{status=\"success\"}[5m])) / sum(rate(messaging_gateway_messages_sent_total[5m])) * 100", "legendFormat": "Delivery Success %" }
+        { "expr": "sum(rate(cast_voice_profile_usage_total[5m])) by (profile)", "legendFormat": "{{profile}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 30 } } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Operations",
+      "gridPos": { "x": 16, "y": 15, "w": 8, "h": 8 },
+      "targets": [
+        { "expr": "sum(rate(cast_cache_operations_total{operation=\"hit\"}[5m]))", "legendFormat": "Hit" },
+        { "expr": "sum(rate(cast_cache_operations_total{operation=\"miss\"}[5m]))", "legendFormat": "Miss" },
+        { "expr": "sum(rate(cast_cache_operations_total{operation=\"evict\"}[5m]))", "legendFormat": "Evict" }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "percent", "decimals": 2, "custom": { "drawStyle": "line", "fillOpacity": 30 }, "thresholds": { "steps": [{ "color": "red", "value": 0 }, { "color": "yellow", "value": 95 }, { "color": "green", "value": 99 }] } }
+        "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 30 } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Hit" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "Miss" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "Evict" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
       }
     },
     {
       "type": "row",
-      "title": "Latency Analysis",
-      "gridPos": { "x": 0, "y": 39, "w": 24, "h": 1 },
+      "title": "Reliability",
+      "gridPos": { "x": 0, "y": 23, "w": 24, "h": 1 },
       "collapsed": false
     },
     {
       "type": "timeseries",
-      "title": "Request Duration Percentiles",
-      "gridPos": { "x": 0, "y": 40, "w": 12, "h": 8 },
+      "title": "Circuit Breaker Transitions",
+      "gridPos": { "x": 0, "y": 24, "w": 8, "h": 8 },
       "targets": [
-        { "expr": "histogram_quantile(0.50, sum(rate(messaging_gateway_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "P50" },
-        { "expr": "histogram_quantile(0.95, sum(rate(messaging_gateway_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "P95" },
-        { "expr": "histogram_quantile(0.99, sum(rate(messaging_gateway_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "P99" }
+        { "expr": "sum(rate(cast_circuit_breaker_transitions_total[5m])) by (from_state, to_state)", "legendFormat": "{{from_state}} → {{to_state}}" }
       ],
-      "fieldConfig": { "defaults": { "unit": "s", "custom": { "fillOpacity": 10 } } }
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 30 } } }
     },
     {
       "type": "timeseries",
-      "title": "Request Duration by Endpoint",
-      "gridPos": { "x": 12, "y": 40, "w": 12, "h": 8 },
+      "title": "Queue Operations",
+      "gridPos": { "x": 8, "y": 24, "w": 8, "h": 8 },
       "targets": [
-        { "expr": "histogram_quantile(0.95, sum(rate(messaging_gateway_request_duration_seconds_bucket[5m])) by (le, endpoint))", "legendFormat": "P95 {{endpoint}}" }
+        { "expr": "sum(rate(cast_queue_operations_total[5m])) by (operation)", "legendFormat": "{{operation}}" }
       ],
-      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 30 } } }
-    },
-    {
-      "type": "heatmap",
-      "title": "Request Duration Distribution",
-      "gridPos": { "x": 0, "y": 48, "w": 12, "h": 8 },
-      "targets": [
-        { "expr": "sum(rate(messaging_gateway_request_duration_seconds_bucket[5m])) by (le)", "legendFormat": "{{le}}" }
-      ],
-      "options": { "calculate": false, "cellGap": 2, "cellRadius": 0, "cellValues": {} },
-      "fieldConfig": { "defaults": { "unit": "s" } }
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 30 } } }
     },
     {
       "type": "timeseries",
-      "title": "Average Request Duration",
-      "gridPos": { "x": 12, "y": 48, "w": 12, "h": 8 },
+      "title": "Scheduler Executions",
+      "gridPos": { "x": 16, "y": 24, "w": 8, "h": 8 },
       "targets": [
-        { "expr": "sum(rate(messaging_gateway_request_duration_seconds_sum[5m])) / sum(rate(messaging_gateway_request_duration_seconds_count[5m]))", "legendFormat": "Average" }
+        { "expr": "sum(rate(cast_scheduler_executions_total{status=\"success\"}[5m]))", "legendFormat": "Success" },
+        { "expr": "sum(rate(cast_scheduler_executions_total{status=\"failure\"}[5m]))", "legendFormat": "Failure" },
+        { "expr": "sum(rate(cast_scheduler_executions_total{status=\"skipped\"}[5m]))", "legendFormat": "Skipped" }
       ],
-      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 30 } } }
+      "fieldConfig": {
+        "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 30 } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Success" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "Failure" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "Skipped" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] }
+        ]
+      }
     }
   ],
   "time": { "from": "now-1h", "to": "now" }

--- a/pmoves/monitoring/grafana/dashboards/messaging-gateway.json
+++ b/pmoves/monitoring/grafana/dashboards/messaging-gateway.json
@@ -64,7 +64,7 @@
       "type": "stat",
       "title": "Cache Hit Rate",
       "gridPos": { "x": 20, "y": 1, "w": 4, "h": 4 },
-      "targets": [{ "expr": "sum(cast_cache_operations_total{operation=\"hit\"}) / (sum(cast_cache_operations_total{operation=\"hit\"}) + sum(cast_cache_operations_total{operation=\"miss\"})) * 100", "legendFormat": "Hit %" }],
+      "targets": [{ "expr": "(sum(rate(cast_cache_operations_total{operation=\"hit\"}[$__rate_interval])) / (sum(rate(cast_cache_operations_total{operation=\"hit\"}[$__rate_interval])) + sum(rate(cast_cache_operations_total{operation=\"miss\"}[$__rate_interval])))) * 100 > 0", "legendFormat": "Hit %" }],
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
       "fieldConfig": { "defaults": { "unit": "percent", "decimals": 1, "thresholds": { "steps": [{ "color": "red", "value": 0 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] } } }
     },

--- a/pmoves/monitoring/prometheus/prometheus.yml
+++ b/pmoves/monitoring/prometheus/prometheus.yml
@@ -137,9 +137,7 @@ scrape_configs:
     static_configs:
       - targets: ["session-context-worker:8100"]
 
-  - job_name: messaging-gateway
-    static_configs:
-      - targets: ["messaging-gateway:8101"]
+  # messaging-gateway removed — service no longer exists in docker-compose.yml
 
   # === GitHub Runner Controller metrics ===
   # Exposes github_runner_* metrics matching the github-runners Grafana dashboard

--- a/pmoves/scripts/cast_tts.py
+++ b/pmoves/scripts/cast_tts.py
@@ -7,7 +7,7 @@ Usage:
     python scripts/cast_tts.py -d "Speaker group" --list-devices
     python scripts/cast_tts.py -d "Brysons Speaker set" "Alert: deployment complete"
 
-Requires: catt, Ultimate-TTS-Studio running on port 7861
+Requires: catt, Ultimate-TTS-Studio running on port 7860
 """
 import argparse
 import subprocess

--- a/pmoves/services/botz-gateway/main.py
+++ b/pmoves/services/botz-gateway/main.py
@@ -586,31 +586,46 @@ async def whoami(instance_id: Optional[str] = None):
     # Try to match by instance_id → registered BoTZ → agent signature
     if instance_id:
         async with httpx.AsyncClient() as client:
-            response = await client.get(
-                f"{SUPABASE_URL}/rest/v1/botz_instances",
-                headers=supabase_headers,
-                params={"instance_id": f"eq.{instance_id}"}
+            try:
+                response = await client.get(
+                    f"{SUPABASE_URL}/rest/v1/botz_instances",
+                    headers=supabase_headers,
+                    params={"instance_id": f"eq.{instance_id}"}
+                )
+            except Exception as exc:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Supabase lookup failed: {exc}",
+                )
+            if response.status_code != 200:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Supabase returned {response.status_code} for instance lookup",
+                )
+            instances = response.json()
+            if instances:
+                botz = instances[0]
+                agent_id = botz.get("metadata", {}).get("agent_id", botz.get("botz_name"))
+                sig = agent_signatures.get(agent_id, {})
+                return {
+                    "agent_id": agent_id,
+                    "botz_name": botz.get("botz_name"),
+                    "instance_id": instance_id,
+                    "theme": {
+                        "glyph": sig.get("glyph", "?"),
+                        "color": sig.get("color", "#888888"),
+                        "voice": sig.get("voice", "unknown"),
+                    },
+                    "skill_level": botz.get("skill_level"),
+                    "is_available": botz.get("is_available"),
+                }
+            # instance_id provided but not found in Supabase — 404, not a fake identity
+            raise HTTPException(
+                status_code=404,
+                detail=f"No BoTZ instance found for instance_id={instance_id}",
             )
-            if response.status_code == 200:
-                instances = response.json()
-                if instances:
-                    botz = instances[0]
-                    agent_id = botz.get("metadata", {}).get("agent_id", botz.get("botz_name"))
-                    sig = agent_signatures.get(agent_id, {})
-                    return {
-                        "agent_id": agent_id,
-                        "botz_name": botz.get("botz_name"),
-                        "instance_id": instance_id,
-                        "theme": {
-                            "glyph": sig.get("glyph", "?"),
-                            "color": sig.get("color", "#888888"),
-                            "voice": sig.get("voice", "unknown"),
-                        },
-                        "skill_level": botz.get("skill_level"),
-                        "is_available": botz.get("is_available"),
-                    }
 
-    # Fallback: return hostname-based identity
+    # Fallback: no instance_id provided — return hostname-based identity
     hostname = os.getenv("HOSTNAME", "unknown")
     return {
         "agent_id": "unknown",

--- a/pmoves/services/botz-gateway/main.py
+++ b/pmoves/services/botz-gateway/main.py
@@ -592,11 +592,11 @@ async def whoami(instance_id: Optional[str] = None):
                     headers=supabase_headers,
                     params={"instance_id": f"eq.{instance_id}"}
                 )
-            except Exception as exc:
+            except httpx.RequestError as exc:
                 raise HTTPException(
                     status_code=502,
                     detail=f"Supabase lookup failed: {exc}",
-                )
+                ) from exc
             if response.status_code != 200:
                 raise HTTPException(
                     status_code=502,

--- a/pmoves/services/botz-gateway/main.py
+++ b/pmoves/services/botz-gateway/main.py
@@ -593,14 +593,16 @@ async def whoami(instance_id: Optional[str] = None):
                     params={"instance_id": f"eq.{instance_id}"}
                 )
             except httpx.RequestError as exc:
+                logger.warning("Supabase lookup failed: %s", exc)
                 raise HTTPException(
                     status_code=502,
-                    detail=f"Supabase lookup failed: {exc}",
+                    detail="Upstream service unavailable",
                 ) from exc
             if response.status_code != 200:
+                logger.warning("Supabase returned %d for instance lookup", response.status_code)
                 raise HTTPException(
                     status_code=502,
-                    detail=f"Supabase returned {response.status_code} for instance lookup",
+                    detail="Upstream service error",
                 )
             instances = response.json()
             if instances:

--- a/pmoves/services/cast-tts-gateway/docker-compose.yml
+++ b/pmoves/services/cast-tts-gateway/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - FLUTE_GATEWAY_URL=http://flute-gateway:8055
       - ULTIMATE_TTS_URL=http://host.docker.internal:7860
       - NATS_URL=nats://nats:pmoves@nats:4222
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - app_tier
       - bus_tier

--- a/pmoves/services/flute-gateway/main.py
+++ b/pmoves/services/flute-gateway/main.py
@@ -123,11 +123,11 @@ NATS_URL = _build_nats_url()
 NATS_URL_REDACTED = _redact_url_password(NATS_URL)
 SUPABASE_URL = os.getenv("SUPABASE_URL", "http://localhost:3010")
 SUPABASE_KEY = get_secret("SUPABASE_SERVICE_ROLE_KEY", "")
-# VibeVoice is now served by Ultimate-TTS-Studio (port 7860 native, 7861 Docker)
-# Default to the host-gateway URL so the Flute stack is voice-ready by default.
+# Ultimate-TTS-Studio: native Pinokio at 7860, Docker at 7861.
+# Default to host-gateway (native) — override with ULTIMATE_TTS_URL for Docker.
 VIBEVOICE_URL = (os.getenv("VIBEVOICE_URL") or "http://host.docker.internal:7860").strip()
 WHISPER_URL = os.getenv("WHISPER_URL", "http://ffmpeg-whisper:8078")
-ULTIMATE_TTS_URL = os.getenv("ULTIMATE_TTS_URL", "http://ultimate-tts-studio:7861")
+ULTIMATE_TTS_URL = os.getenv("ULTIMATE_TTS_URL", "http://host.docker.internal:7860")
 DEFAULT_PROVIDER = os.getenv("DEFAULT_VOICE_PROVIDER", "vibevoice")
 FLUTE_API_KEY = get_secret("FLUTE_API_KEY", "")
 

--- a/pmoves/services/flute-gateway/main.py
+++ b/pmoves/services/flute-gateway/main.py
@@ -127,7 +127,7 @@ SUPABASE_KEY = get_secret("SUPABASE_SERVICE_ROLE_KEY", "")
 # Default to the host-gateway URL so the Flute stack is voice-ready by default.
 VIBEVOICE_URL = (os.getenv("VIBEVOICE_URL") or "http://host.docker.internal:7860").strip()
 WHISPER_URL = os.getenv("WHISPER_URL", "http://ffmpeg-whisper:8078")
-ULTIMATE_TTS_URL = os.getenv("ULTIMATE_TTS_URL", "http://ultimate-tts-studio:7860")
+ULTIMATE_TTS_URL = os.getenv("ULTIMATE_TTS_URL", "http://ultimate-tts-studio:7861")
 DEFAULT_PROVIDER = os.getenv("DEFAULT_VOICE_PROVIDER", "vibevoice")
 FLUTE_API_KEY = get_secret("FLUTE_API_KEY", "")
 

--- a/pmoves/services/flute-gateway/providers/ultimate_tts.py
+++ b/pmoves/services/flute-gateway/providers/ultimate_tts.py
@@ -22,19 +22,20 @@ class UltimateTTSError(RuntimeError):
 class UltimateTTSProvider(VoiceProvider):
     """Ultimate-TTS-Studio provider via Gradio API.
 
-    Supports 13 TTS engines:
+    Supports 14 TTS engines:
       - kitten_tts (KittenTTS) - Ultra-lightweight, fast
       - kokoro (Kokoro TTS) - Multilingual ONNX
       - f5_tts (F5-TTS) - High quality voice cloning
-      - indextts2 (IndexTTS2) - Emotion vector control
       - indextts (IndexTTS) - Index-based synthesis
-      - fish (Fish Speech) - Zero-shot cloning
+      - indextts2 (IndexTTS2) - Emotion vector control
+      - fish (Fish Speech S1) - Zero-shot cloning
       - fish_s2 (Fish Speech S2 Pro) - 13-language zero-shot
-      - chatterbox (ChatterboxTTS) - Multilingual with controls
+      - chatterbox (ChatterboxTTS) - Expressive narration
       - chatterbox_turbo (Chatterbox Turbo) - Fast multilingual
+      - chatterbox_multilingual (Chatterbox Multilingual) - 17-language synthesis
       - voxcpm (VoxCPM) - Voice cloning + transcription
       - higgs (Higgs Audio) - Streaming capable
-      - qwen (Qwen3 TTS) - Alibaba multilingual
+      - qwen (Qwen Voice Design) - Alibaba multilingual
       - vibevoice (VibeVoice) - Style transfer synthesis
 
     Audio format: WAV, 24kHz sample rate (varies by engine).

--- a/pmoves/services/flute-gateway/tests/test_ultimate_tts.py
+++ b/pmoves/services/flute-gateway/tests/test_ultimate_tts.py
@@ -238,8 +238,7 @@ class TestUltimateTTSProviderSynthesize:
             "",
         ]
 
-        def mock_stream(*args, **kwargs):
-            url = args[1] if len(args) > 1 else ""
+        def mock_stream(method, url, **kwargs):
             if "generate_unified_tts" in url:
                 return _MockSSEStream(synth_sse)
             return _MockSSEStream(load_sse)
@@ -319,7 +318,7 @@ class TestUltimateTTSProviderSynthesize:
         # SSE stream for model load
         load_sse = ["event: complete", "data: " + json.dumps(["Loaded"]), ""]
         mock_client.stream = MagicMock(
-            side_effect=lambda *a, **kw: _MockSSEStream(load_sse)
+            side_effect=lambda method, url, **kw: _MockSSEStream(load_sse)
         )
         mock_client.get = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)

--- a/pmoves/services/flute-gateway/tests/test_ultimate_tts.py
+++ b/pmoves/services/flute-gateway/tests/test_ultimate_tts.py
@@ -40,29 +40,51 @@ def create_mock_wav_bytes(duration_samples: int = 24000) -> bytes:
     return buf.getvalue()
 
 
+class _MockSSEStream:
+    """Mock SSE stream for Gradio 4.x event API responses.
+
+    Simulates the server-sent events returned by
+    GET /gradio_api/call/<endpoint>/<event_id>.
+    """
+
+    def __init__(self, lines: list):
+        self._lines = lines
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
 class TestUltimateTTSProviderInit:
     """Test provider initialization."""
 
     def test_init_default_values(self):
         """Test provider initializes with correct defaults."""
         provider = UltimateTTSProvider()
-        assert provider.base_url == "http://localhost:7861"
-        assert provider.predict_api_url == "http://localhost:7861/api"
-        assert provider.gradio_api_url == "http://localhost:7861/gradio_api"
+        assert provider.base_url == "http://localhost:7860"
+        assert provider.call_api_url == "http://localhost:7860/gradio_api/call"
+        assert provider.gradio_api_url == "http://localhost:7860/gradio_api"
 
     def test_init_custom_url(self):
         """Test provider accepts custom base_url."""
         provider = UltimateTTSProvider(base_url="http://custom:8080")
         assert provider.base_url == "http://custom:8080"
-        assert provider.predict_api_url == "http://custom:8080/api"
+        assert provider.call_api_url == "http://custom:8080/gradio_api/call"
         assert provider.gradio_api_url == "http://custom:8080/gradio_api"
 
     def test_engine_names_mapping(self):
-        """Test ENGINE_NAMES contains all 7 engines."""
+        """Test ENGINE_NAMES contains all 14 engines."""
         provider = UltimateTTSProvider()
         expected_engines = {
-            "kitten_tts", "kokoro", "f5_tts", "indextts2",
-            "fish", "chatterbox", "voxcpm"
+            "kitten_tts", "kokoro", "f5_tts", "indextts2", "indextts",
+            "fish", "fish_s2", "chatterbox", "chatterbox_turbo",
+            "chatterbox_multilingual", "voxcpm", "higgs", "qwen", "vibevoice",
         }
         assert set(provider.ENGINE_NAMES.keys()) == expected_engines
 
@@ -193,38 +215,43 @@ class TestUltimateTTSProviderSynthesize:
     def _create_mock_client(self, audio_url: str = "http://localhost:7861/file=test.wav"):
         """Create a mock httpx client for synthesis tests.
 
-        Mocks the Gradio synchronous predict API (/api/) which returns
-        results directly without SSE/WebSocket event polling.
+        Mocks the Gradio 4.x event-based API (/gradio_api/call/) which
+        uses a POST→event_id then GET→SSE stream polling pattern.
         """
         mock_client = AsyncMock()
 
-        # Mock model load response (predict API — direct result)
-        mock_load_response = MagicMock()
-        mock_load_response.status_code = 200
-        mock_load_response.json.return_value = {"data": ["\u2705 Loaded"]}
+        # All Gradio call POSTs return an event_id
+        mock_event_response = MagicMock()
+        mock_event_response.status_code = 200
+        mock_event_response.json.return_value = {"event_id": "mock-evt-123"}
+        mock_client.post = AsyncMock(return_value=mock_event_response)
 
-        # Mock synthesis response (predict API — direct result)
-        mock_synth_response = MagicMock()
-        mock_synth_response.status_code = 200
-        mock_synth_response.json.return_value = {
-            "data": [{"url": audio_url}, "Success"]
-        }
+        # SSE streams: model-load vs synthesis have different payloads
+        load_sse = [
+            "event: complete",
+            "data: " + json.dumps(["\u2705 Loaded"]),
+            "",
+        ]
+        synth_sse = [
+            "event: complete",
+            "data: " + json.dumps([{"url": audio_url}, "\u2705 Done"]),
+            "",
+        ]
 
-        # Mock audio download
+        def mock_stream(*args, **kwargs):
+            url = args[1] if len(args) > 1 else ""
+            if "generate_unified_tts" in url:
+                return _MockSSEStream(synth_sse)
+            return _MockSSEStream(load_sse)
+
+        mock_client.stream = MagicMock(side_effect=mock_stream)
+
+        # GET returns audio bytes (for the final audio download)
         mock_audio_response = MagicMock()
         mock_audio_response.status_code = 200
         mock_audio_response.content = create_mock_wav_bytes()
+        mock_client.get = AsyncMock(return_value=mock_audio_response)
 
-        async def mock_post(url, **kwargs):
-            if "handle_load" in url or "handle_f5" in url:
-                return mock_load_response
-            return mock_synth_response
-
-        async def mock_get(url, **kwargs):
-            return mock_audio_response
-
-        mock_client.post = AsyncMock(side_effect=mock_post)
-        mock_client.get = AsyncMock(side_effect=mock_get)
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -242,8 +269,9 @@ class TestUltimateTTSProviderSynthesize:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("engine", [
-        "kitten_tts", "kokoro", "f5_tts", "indextts2",
-        "fish", "chatterbox", "voxcpm"
+        "kitten_tts", "kokoro", "f5_tts", "indextts2", "indextts",
+        "fish", "fish_s2", "chatterbox", "chatterbox_turbo",
+        "chatterbox_multilingual", "voxcpm", "higgs", "qwen", "vibevoice",
     ])
     async def test_synthesize_each_engine(self, provider, engine):
         """Test synthesize works for each engine type."""
@@ -271,28 +299,34 @@ class TestUltimateTTSProviderSynthesize:
         """Test synthesize raises error on API failure."""
         mock_client = AsyncMock()
 
-        # Model load succeeds (predict API)
-        mock_load_response = MagicMock()
-        mock_load_response.status_code = 200
-        mock_load_response.json.return_value = {"data": ["Loaded"]}
+        # Model load POST succeeds with event_id
+        mock_load_post = MagicMock()
+        mock_load_post.status_code = 200
+        mock_load_post.json.return_value = {"event_id": "load-evt"}
 
-        # Synthesis fails with 500
-        mock_synth_response = MagicMock()
-        mock_synth_response.status_code = 500
-        mock_synth_response.text = "Internal Server Error"
+        # Synthesis POST fails with 500
+        mock_synth_post = MagicMock()
+        mock_synth_post.status_code = 500
+        mock_synth_post.text = "Internal Server Error"
 
         async def mock_post(url, **kwargs):
-            if "handle_load" in url:
-                return mock_load_response
-            return mock_synth_response
+            if "generate_unified_tts" in url:
+                return mock_synth_post
+            return mock_load_post
 
         mock_client.post = AsyncMock(side_effect=mock_post)
+
+        # SSE stream for model load
+        load_sse = ["event: complete", "data: " + json.dumps(["Loaded"]), ""]
+        mock_client.stream = MagicMock(
+            side_effect=lambda *a, **kw: _MockSSEStream(load_sse)
+        )
         mock_client.get = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
         with patch("httpx.AsyncClient", return_value=mock_client):
-            with pytest.raises(UltimateTTSError, match="API call failed"):
+            with pytest.raises(UltimateTTSError, match="Gradio call submit failed: 500"):
                 await provider.synthesize("Test", engine="kitten_tts")
 
     @pytest.mark.asyncio
@@ -374,10 +408,10 @@ class TestUltimateTTSProviderBuildParams:
         """Create provider instance."""
         return UltimateTTSProvider(base_url="http://localhost:7861")
 
-    def test_build_params_returns_92_elements(self, provider):
-        """Test _build_params returns exactly 92 parameters."""
+    def test_build_params_returns_121_elements(self, provider):
+        """Test _build_params returns exactly 121 parameters."""
         params = provider._build_params("Hello", "kitten_tts")
-        assert len(params) == 92
+        assert len(params) == 121
 
     def test_build_params_text_at_index_0(self, provider):
         """Test text is at index 0."""
@@ -397,12 +431,12 @@ class TestUltimateTTSProviderBuildParams:
         params = provider._build_params("Test", "kitten_tts")
         assert params[2] == "wav"
 
-    def test_build_params_kitten_voice_at_index_67(self, provider):
-        """Test KittenTTS voice is at index 67."""
+    def test_build_params_kitten_voice_at_index_83(self, provider):
+        """Test KittenTTS voice is at index 83."""
         params = provider._build_params("Test", "kitten_tts", voice="expr-voice-3-f")
-        assert params[67] == "expr-voice-3-f"
+        assert params[83] == "expr-voice-3-f"
 
-    def test_build_params_kokoro_voice_at_index_19(self, provider):
-        """Test Kokoro voice is at index 19."""
+    def test_build_params_kokoro_voice_at_index_28(self, provider):
+        """Test Kokoro voice is at index 28."""
         params = provider._build_params("Test", "kokoro", voice="af_bella")
-        assert params[19] == "af_bella"
+        assert params[28] == "af_bella"

--- a/pmoves/tools/test_all_tts_engines.py
+++ b/pmoves/tools/test_all_tts_engines.py
@@ -6,9 +6,9 @@ for all 121 unified synthesis parameters. No positional array indexing needed.
 
 Aligned with PMOVES-Ultimate-TTS-Studio fork (tools/test_engines.py pattern).
 
-Supports 14 engines: KittenTTS, Kokoro, F5-TTS, IndexTTS, IndexTTS2,
-Fish Speech, Fish Speech S2 Pro, ChatterboxTTS, Chatterbox Turbo,
-Chatterbox Multilingual, VoxCPM, Higgs Audio, Qwen3 TTS, VibeVoice.
+Supports 14 engines: KittenTTS, Kokoro TTS, F5-TTS, IndexTTS, IndexTTS2,
+Fish Speech S1, Fish Speech S2 Pro, ChatterboxTTS, Chatterbox Turbo,
+Chatterbox Multilingual, VoxCPM, Higgs Audio, Qwen Voice Design, VibeVoice.
 
 Per-engine client isolation: each engine load/synth reconnects the Gradio
 client on connection errors, preventing cascade failures when one engine

--- a/pmoves/tools/test_all_tts_engines.py
+++ b/pmoves/tools/test_all_tts_engines.py
@@ -102,7 +102,7 @@ ENGINES = [
     },
     {
         "id": "fish",
-        "name": "Fish Speech",
+        "name": "Fish Speech S1",
         "load_api": "/handle_load_fish",
         "load_kwargs": {},
         "synth_kwargs": {
@@ -151,7 +151,7 @@ ENGINES = [
     },
     {
         "id": "qwen",
-        "name": "Qwen3 TTS",
+        "name": "Qwen Voice Design",
         "load_api": "/handle_load_qwen",
         "load_kwargs": {"model_type": "Base", "model_size": "1.7B"},
         "synth_kwargs": {
@@ -695,8 +695,9 @@ def main():
     print(f"  Output: {OUTPUT_DIR}")
 
     # Pterm pre-flight: auto-start TTS Studio if possible
-    # Skip pterm if user explicitly provided --url (they know where the service is)
-    skip_pterm = args.no_pterm or (args.url != DEFAULT_URL)
+    # Skip pterm if user explicitly provided --url or set ULTIMATE_TTS_URL env var
+    env_url_set = "ULTIMATE_TTS_URL" in os.environ
+    skip_pterm = args.no_pterm or (args.url != DEFAULT_URL) or env_url_set
     print("\n  Pterm pre-flight...")
     ready_url = pterm_preflight(skip=skip_pterm)
     if ready_url:
@@ -765,7 +766,13 @@ def main():
 
     if args.load_only:
         print("\n  (--load-only mode, skipping synthesis)")
-        return 0 if loaded > 0 else 1
+        # Fail if fewer than half the tested engines loaded
+        if loaded == 0:
+            return 1
+        if loaded < len(engines_to_test) / 2:
+            print(f"\n  WARNING: Only {loaded}/{len(engines_to_test)} engines loaded — failing.")
+            return 1
+        return 0
 
     if loaded == 0:
         print("\n  ERROR: No models loaded. Cannot test synthesis.")
@@ -853,7 +860,14 @@ def main():
                 print(f"    ❌ {name} ({loaded_str})")
 
     print(f"\n  Audio files: {OUTPUT_DIR}")
-    return 0 if synth_pass > 0 else 1
+    # Fail if fewer than half the testable engines (excluding skips) synthesized
+    testable = synth_pass + synth_fail
+    if testable == 0:
+        return 1
+    if synth_pass < testable / 2:
+        print(f"\n  WARNING: Only {synth_pass}/{testable} testable engines passed — failing.")
+        return 1
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up sweep addressing 12 unresolved CodeRabbit review comments from merged PRs #1066 and #1069.

- 2 Critical: dead Prometheus scrape target, flute-gateway port default
- 10 Major: engine name alignment (5 files), Gradio 4.x TAC assertions, host.docker.internal mapping, BoTZ identity 502/404 errors, test exit codes, pterm URL override

## Test plan

- [ ] Engine names consistent: CLAUDE.md, capabilities yaml, test harness, provider docstring
- [ ] TAC tree references /gradio_api/call/ not /api/
- [ ] BoTZ gateway returns 502/404 on Supabase failures (not fake unknown)
- [ ] test_all_tts_engines exits 1 when <50% engines pass
- [ ] cast-tts compose has extra_hosts for host.docker.internal

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded and reordered TTS engine lineup; added KittenTTS, Kokoro TTS, Fish Speech S1, Chatterbox variants (including Chatterbox Multilingual/ Turbo), and Qwen Voice Design.

* **Bug Fixes**
  * Improved instance-lookup error handling to return clear HTTP errors on upstream failures or missing instances.

* **Documentation**
  * CLI docs: synthesis is now default; flag changed to --load-only. Provider docs and configs updated for Gradio 4.x call API and engine display names.

* **Tests**
  * Expanded engine tests, added Gradio SSE/event mocks, and tightened pass thresholds.

* **Chores**
  * Removed obsolete Prometheus job, updated Grafana dashboard, adjusted container host mapping and default Ultimate-TTS port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->