### PR TITLE
fix(tts): per-engine timeout overrides for heavy TTS models

### DIFF
--- a/pmoves/services/flute-gateway/providers/ultimate_tts.py
+++ b/pmoves/services/flute-gateway/providers/ultimate_tts.py
@@ -67,6 +67,19 @@ class UltimateTTSProvider(VoiceProvider):
         "indextts2": None,
     }
 
+    # Per-engine synthesis timeout overrides (seconds).
+    # Heavier models (large vocab, zero-shot cloning, streaming decode) need
+    # more headroom than the global default.
+    ENGINE_TIMEOUTS: Dict[str, float] = {
+        "fish_s2": 300.0,              # 13-lang zero-shot, 2048 max tokens
+        "higgs": 240.0,                # streaming-capable, large context
+        "qwen": 240.0,                 # Alibaba multilingual, voice design mode
+        "voxcpm": 240.0,               # voice cloning + transcription pipeline
+        "chatterbox_multilingual": 180.0,  # 17-language synthesis
+        "f5_tts": 180.0,               # high-quality voice cloning
+        "indextts2": 180.0,            # emotion vector control
+    }
+
     # Available KittenTTS voices
     KITTEN_VOICES = [
         "expr-voice-2-m", "expr-voice-2-f",
@@ -369,7 +382,9 @@ class UltimateTTSProvider(VoiceProvider):
         engine = kwargs.get("engine", self._default_engine)
         voice = voice or self.DEFAULT_VOICES.get(engine)
 
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
+        engine_timeout = self.ENGINE_TIMEOUTS.get(engine, self._timeout)
+
+        async with httpx.AsyncClient(timeout=engine_timeout) as client:
             # Ensure model is loaded
             await self._load_model(client, engine)
 
@@ -379,7 +394,7 @@ class UltimateTTSProvider(VoiceProvider):
             try:
                 # Use Gradio's event-based API (/gradio_api/call/).
                 result_data = await self._call_gradio(
-                    client, "/generate_unified_tts", data, timeout=self._timeout,
+                    client, "/generate_unified_tts", data, timeout=engine_timeout,
                 )
 
                 if not isinstance(result_data, list) or len(result_data) < 2:
@@ -422,7 +437,9 @@ class UltimateTTSProvider(VoiceProvider):
                 return wav_bytes
 
             except httpx.TimeoutException as exc:
-                raise UltimateTTSError(f"Timeout during synthesis: {exc}") from exc
+                raise UltimateTTSError(
+                    f"Timeout during {engine} synthesis ({engine_timeout}s): {exc}"
+                ) from exc
             except httpx.HTTPError as exc:
                 raise UltimateTTSError(f"HTTP error: {exc}") from exc
 

--- a/pmoves/services/flute-gateway/tests/test_ultimate_tts.py
+++ b/pmoves/services/flute-gateway/tests/test_ultimate_tts.py
@@ -94,6 +94,17 @@ class TestUltimateTTSProviderInit:
         assert "kitten_tts" in provider.DEFAULT_VOICES
         assert "kokoro" in provider.DEFAULT_VOICES
 
+    def test_engine_timeouts_keys_are_valid_engines(self):
+        """Test ENGINE_TIMEOUTS only references known engines."""
+        provider = UltimateTTSProvider()
+        for engine in provider.ENGINE_TIMEOUTS:
+            assert engine in provider.ENGINE_NAMES, f"Unknown engine in ENGINE_TIMEOUTS: {engine}"
+
+    def test_engine_timeouts_fish_s2_is_elevated(self):
+        """Test Fish S2 Pro has a higher timeout than the default."""
+        provider = UltimateTTSProvider()
+        assert provider.ENGINE_TIMEOUTS["fish_s2"] > provider._timeout
+
 
 class TestUltimateTTSProviderHealthCheck:
     """Test health check functionality."""


### PR DESCRIPTION
## Summary
- Adds `ENGINE_TIMEOUTS` class-level dict to `UltimateTTSProvider` with per-engine timeout overrides
- Fish Speech S2 Pro: 120s → 300s (13-language zero-shot, 2048 max tokens)
- Higgs/Qwen/VoxCPM: 120s → 240s (large context / voice cloning pipelines)
- Chatterbox Multilingual/F5-TTS/IndexTTS2: 120s → 180s (multi-language / emotion vector)
- Lightweight engines (KittenTTS, Kokoro, etc.) keep 120s default
- Improved timeout error messages include engine name + configured timeout for diagnostics

## Test plan
- [x] 38/38 unit tests pass (including 2 new timeout validation tests)
- [ ] `test_engine_timeouts_keys_are_valid_engines` — validates no typos in ENGINE_TIMEOUTS keys
- [ ] `test_engine_timeouts_fish_s2_is_elevated` — confirms fish_s2 timeout > global default
- [ ] Live test: `/tts:test-engine fish_speech_s2_pro` when Ultimate-TTS-Studio is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Text-to-speech engines now support individualized timeout settings based on engine type for improved stability and performance.

* **Bug Fixes**
  * Timeout error messages now include engine-specific details and values for better troubleshooting.

* **Tests**
  * Added validation tests for engine timeout configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->