### PR TITLE
fix(ci): add packages:write to GitHub App token for GHCR push

### DIFF
--- a/.github/workflows/integrations-ghcr.yml
+++ b/.github/workflows/integrations-ghcr.yml
@@ -216,10 +216,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_SEC }}
-          # Explicit permissions: packages:write required for GHCR push (403 without it)
-          permissions: >-
-            contents:read,
-            packages:write
+          # Explicit token scopes required for clone + GHCR push
+          permission-contents: read
+          permission-packages: write
 
       - name: Prepare integration source
         run: |

--- a/.github/workflows/integrations-ghcr.yml
+++ b/.github/workflows/integrations-ghcr.yml
@@ -216,6 +216,10 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_SEC }}
+          # Explicit permissions: packages:write required for GHCR push (403 without it)
+          permissions: >-
+            contents:read,
+            packages:write
 
       - name: Prepare integration source
         run: |


### PR DESCRIPTION
## Summary
- All 14 GHCR image builds succeed (multi-arch amd64+arm64) but push fails with **403 Forbidden**
- Root cause: `create-github-app-token@v2` doesn't request `packages:write` by default
- Fix: add explicit `permissions: contents:read, packages:write` to the token action
- Job-level `permissions.packages: write` was already set (line 142) but the App token itself lacked the scope

## Test plan
- [ ] Merge this PR
- [ ] Trigger `gh workflow run integrations-ghcr.yml --ref main`
- [ ] Verify at least one image pushes successfully to GHCR
- [ ] `docker pull ghcr.io/powerfulmoves/pmoves-a2ui-nats-bridge:pmoves-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved deployment pipeline permission issues by explicitly scoping the token used in CI, ensuring repository clone and container registry publish steps have the correct access. This reduces intermittent CI deploy failures and makes package publishing to the registry more reliable and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->