### PR TITLE
fix(schema): add missing index on publisher_audit.published_at

### DIFF
--- a/pmoves/supabase/initdb/18_publisher_publish_state.sql
+++ b/pmoves/supabase/initdb/18_publisher_publish_state.sql
@@ -47,6 +47,7 @@ create index if not exists idx_publisher_audit_namespace on public.publisher_aud
 create index if not exists idx_publisher_audit_reviewer on public.publisher_audit(reviewer);
 create index if not exists idx_publisher_audit_processed_at on public.publisher_audit(processed_at desc);
 create index if not exists idx_publisher_audit_studio_board_id on public.publisher_audit(studio_board_id);
+create index if not exists idx_publisher_audit_published_at on public.publisher_audit(published_at desc);
 
 create or replace function public.set_publisher_audit_updated_at()
 returns trigger

--- a/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
+++ b/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
@@ -47,6 +47,7 @@ create index if not exists idx_publisher_audit_namespace on public.publisher_aud
 create index if not exists idx_publisher_audit_reviewer on public.publisher_audit(reviewer);
 create index if not exists idx_publisher_audit_processed_at on public.publisher_audit(processed_at desc);
 create index if not exists idx_publisher_audit_studio_board_id on public.publisher_audit(studio_board_id);
+create index if not exists idx_publisher_audit_published_at on public.publisher_audit(published_at desc);
 
 create or replace function public.set_publisher_audit_updated_at()
 returns trigger

--- a/pmoves/supabase/migrations/20260326000100_publisher_audit_published_at_idx.sql
+++ b/pmoves/supabase/migrations/20260326000100_publisher_audit_published_at_idx.sql
@@ -1,0 +1,4 @@
+-- Add missing index on publisher_audit.published_at for recency queries
+-- Follow-up from PR #1100 CodeRabbit finding
+CREATE INDEX IF NOT EXISTS idx_publisher_audit_published_at
+  ON public.publisher_audit(published_at DESC);


### PR DESCRIPTION
## Summary
- Add `idx_publisher_audit_published_at` descending index to `publisher_audit` table
- Added to initdb script, synced migration, and standalone migration for existing DBs
- `IF NOT EXISTS` makes it idempotent and safe to re-run

## Context
Follow-up from PR #1100 CodeRabbit finding: recency queries on `publisher_audit` will table-scan without this index.

## Test plan
- [ ] Verify index creation is idempotent (`IF NOT EXISTS`)
- [ ] Confirm initdb and migration scripts stay in sync
- [ ] Run `make -C pmoves verify-all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized database queries for publisher content retrieval, enhancing responsiveness when accessing recently published items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->