### PR TITLE
fix(schema): add NULL validation for p_publish_event_id in complete/fail RPCs

### DIFF
--- a/pmoves/supabase/initdb/18_publisher_publish_state.sql
+++ b/pmoves/supabase/initdb/18_publisher_publish_state.sql
@@ -156,7 +156,7 @@ as $$
 declare
   updated_rows integer := 0;
 begin
-  if p_row_id is null then
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
     return false;
   end if;
 
@@ -209,7 +209,7 @@ as $$
 declare
   updated_rows integer := 0;
 begin
-  if p_row_id is null then
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
     return false;
   end if;
 

--- a/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
+++ b/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
@@ -156,7 +156,7 @@ as $$
 declare
   updated_rows integer := 0;
 begin
-  if p_row_id is null then
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
     return false;
   end if;
 
@@ -209,7 +209,7 @@ as $$
 declare
   updated_rows integer := 0;
 begin
-  if p_row_id is null then
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
     return false;
   end if;
 

--- a/pmoves/supabase/migrations/20260326000400_publish_rpc_null_validation.sql
+++ b/pmoves/supabase/migrations/20260326000400_publish_rpc_null_validation.sql
@@ -1,0 +1,108 @@
+-- Add missing NULL validation for p_publish_event_id in complete/fail RPCs
+-- claim_studio_board_publish already validates this (line 108); align the others.
+-- Follow-up from PR #1100 CodeRabbit finding
+
+CREATE OR REPLACE FUNCTION public.complete_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_published_event_id text,
+  p_published_at timestamptz default now(),
+  p_publish_meta jsonb default '{}'::jsonb
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
+    return false;
+  end if;
+
+  update public.studio_board
+  set status = 'published',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_failed_at'
+          - 'publish_failure_reason'
+          - 'publish_failure_stage'
+          - 'publish_failure_meta'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'published',
+          'publish_request_id', p_publish_event_id,
+          'publish_event_sent_at', p_published_at,
+          'published_at', p_published_at,
+          'published_event_id', p_published_event_id
+        )
+        || coalesce(p_publish_meta, '{}'::jsonb)
+      )
+  where id = p_row_id
+    and (
+      status in ('approved', 'publishing')
+      or (
+        status = 'published'
+        and coalesce(meta->>'publish_request_id', '') = coalesce(p_publish_event_id, '')
+      )
+    );
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fail_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_stage text,
+  p_reason text,
+  p_failed_at timestamptz default now(),
+  p_failure_meta jsonb default '{}'::jsonb
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
+    return false;
+  end if;
+
+  update public.studio_board
+  set status = 'publish_failed',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_request_id'
+          - 'publish_requested_at'
+          - 'publish_request_source'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'failed',
+          'last_publish_request_id', p_publish_event_id,
+          'publish_failed_at', p_failed_at,
+          'publish_failure_stage', coalesce(p_stage, 'unknown'),
+          'publish_failure_reason', coalesce(nullif(btrim(p_reason), ''), 'unspecified failure'),
+          'publish_failure_meta', coalesce(p_failure_meta, '{}'::jsonb)
+        )
+      )
+  where id = p_row_id
+    and coalesce(meta->>'publish_event_sent_at', '') = ''
+    and (
+      status in ('approved', 'publishing')
+      or (
+        status = 'publish_failed'
+        and coalesce(meta->>'last_publish_request_id', '') = coalesce(p_publish_event_id, '')
+      )
+    );
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;


### PR DESCRIPTION
## Summary
- Add `p_publish_event_id is null or btrim(p_publish_event_id) = ''` check to `complete_studio_board_publish` and `fail_studio_board_publish`
- Aligns with existing validation in `claim_studio_board_publish` (line 108)
- Updated initdb, synced migration, and standalone migration with full `CREATE OR REPLACE FUNCTION`

## Context
Follow-up from PR #1100 CodeRabbit finding: `claim_` validates `p_publish_event_id` but `complete_` and `fail_` don't. Python callers already check `if not publish_event_id` before calling, so this is belt-and-suspenders at the SQL level.

## Test plan
- [ ] Verify all three RPCs now have consistent null validation
- [ ] Confirm `CREATE OR REPLACE FUNCTION` includes complete function bodies
- [ ] Run `make -C pmoves verify-all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing operations for studio boards now perform stricter validation of required event parameters before processing state changes. The system ensures event identifiers are present and properly formatted, preventing incomplete or malformed publish requests from being processed. This strengthens data integrity and prevents unintended state transitions in the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->