### PR TITLE
fix(schema): align geometry_parameter_packs.version NOT NULL default

### DIFF
--- a/pmoves/supabase/migrations/2025-10-18_geometry_swarm_compat.sql
+++ b/pmoves/supabase/migrations/2025-10-18_geometry_swarm_compat.sql
@@ -37,7 +37,7 @@ DO $$ BEGIN
     WHERE table_schema='public' AND table_name='geometry_parameter_packs' AND column_name='version'
   ) THEN
     ALTER TABLE public.geometry_parameter_packs
-      ADD COLUMN version text NULL;
+      ADD COLUMN version text NOT NULL DEFAULT 'v1';
   END IF;
 END $$;
 

--- a/pmoves/supabase/migrations/20260326000300_geometry_version_default.sql
+++ b/pmoves/supabase/migrations/20260326000300_geometry_version_default.sql
@@ -1,0 +1,13 @@
+-- Fix nullable version in geometry_parameter_packs compat path
+-- Base schema: NOT NULL. Compat migration: NULL. Resolve inconsistency.
+-- Follow-up from PR #1100 CodeRabbit finding
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_parameter_packs'
+  ) THEN
+    UPDATE public.geometry_parameter_packs SET version = 'v1' WHERE version IS NULL;
+    ALTER TABLE public.geometry_parameter_packs ALTER COLUMN version SET DEFAULT 'v1';
+    ALTER TABLE public.geometry_parameter_packs ALTER COLUMN version SET NOT NULL;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Fix compat migration: `version text NULL` → `version text NOT NULL DEFAULT 'v1'`
- Add backfill migration: sets NULL versions to 'v1', adds DEFAULT, restores NOT NULL
- Guarded with `IF EXISTS` for safety on databases without the table

## Context
Follow-up from PR #1100 CodeRabbit finding: base schema (`2025-10-18_geometry_swarm.sql` line 9) says `version text NOT NULL`, but the compat migration (`_compat.sql` line 40) says `text NULL`. This inconsistency means databases that got the column via the compat path have a nullable version.

## Test plan
- [ ] Verify backfill runs before NOT NULL constraint
- [ ] Confirm guard skips if table absent
- [ ] Run `make -C pmoves verify-all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data integrity for geometry parameter packs by enforcing a default version value and ensuring all records have valid version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->