### PR TITLE
fix(supabase): harden bootstrap seed entrypoints

### DIFF
--- a/pmoves/contracts/schemas/content/publish.approved.v1.schema.json
+++ b/pmoves/contracts/schemas/content/publish.approved.v1.schema.json
@@ -28,6 +28,13 @@
     },
     "meta": {
       "type": "object"
+    },
+    "studio_board_id": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "publish_request_id": {
+      "type": "string"
     }
   }
 }

--- a/pmoves/contracts/schemas/content/publish.failed.v1.schema.json
+++ b/pmoves/contracts/schemas/content/publish.failed.v1.schema.json
@@ -20,7 +20,10 @@
     },
     "outcome": {
       "type": "string",
-      "enum": ["fatal", "partial"]
+      "enum": [
+        "fatal",
+        "partial"
+      ]
     },
     "artifact_uri": {
       "type": "string"
@@ -45,6 +48,13 @@
     },
     "meta": {
       "type": "object"
+    },
+    "studio_board_id": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "publish_request_id": {
+      "type": "string"
     }
   }
 }

--- a/pmoves/contracts/schemas/content/published.v1.schema.json
+++ b/pmoves/contracts/schemas/content/published.v1.schema.json
@@ -47,6 +47,13 @@
     },
     "meta": {
       "type": "object"
+    },
+    "studio_board_id": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "publish_request_id": {
+      "type": "string"
     }
   }
 }

--- a/pmoves/docs/MODEL_REGISTRY.md
+++ b/pmoves/docs/MODEL_REGISTRY.md
@@ -276,8 +276,9 @@ The parser extracts:
 
 ### Empty models list
 1. Check migration ran: `SELECT COUNT(*) FROM pmoves_core.models`
-2. Verify seed data: `psql -f pmoves/supabase/initdb/12_model_registry_seed.sql`
-3. Confirm RLS policies allow access
+2. Run the canonical bootstrap path: `make -C pmoves supabase-bootstrap`
+3. If you are debugging by hand, apply `pmoves/supabase/migrations/20260115_model_registry.sql` before replaying `pmoves/supabase/initdb/12_model_registry_seed.sql`
+4. Confirm RLS policies allow access
 
 ### TOML generation errors
 1. Verify all models have valid providers
@@ -293,5 +294,6 @@ The parser extracts:
 
 - Migration: `pmoves/supabase/migrations/20260115_model_registry.sql`
 - Seed: `pmoves/supabase/initdb/12_model_registry_seed.sql`
+- Canonical bootstrap: `make -C pmoves supabase-bootstrap`
 - Service: `pmoves/services/model-registry/`
 - Docker: `pmoves/docker-compose.yml` (model-registry service)

--- a/pmoves/docs/NEXT_STEPS.md
+++ b/pmoves/docs/NEXT_STEPS.md
@@ -607,7 +607,7 @@ Next 48 hours
 - **Manual verification checklist**
   1. Insert a `studio_board` row with `status='approved'`, `content_url='s3://...'`, and confirm `meta.publish_event_sent_at` is null.
   2. Trigger the approval poller (activate or execute once) and confirm Agent Zero logs a `content.publish.approved.v1` event.
-  3. Verify Supabase row updates to `status='published'` with `meta.publish_event_sent_at` timestamp.
+  3. Verify Supabase row first moves to `status='publishing'` with `meta.publish_request_id` / `meta.publish_requested_at`, then finalizes to `status='published'` with `meta.publish_event_sent_at`.
   4. POST a `content.published.v1` envelope to the webhook (`/webhook/pmoves/content-published`) and confirm Discord receives an embed (title, path, artifact, optional thumbnail).
   5. Deactivate flows after testing or leave active with schedules confirmed.
 

--- a/pmoves/docs/context/PMOVES_COMPLETE_ARCHITECTURE.md
+++ b/pmoves/docs/context/PMOVES_COMPLETE_ARCHITECTURE.md
@@ -405,8 +405,8 @@ n8n is labeled as the **"MCP Hub"** in `docs/PMOVES_Multi-Agent_System_Crush_CLI
 **Example M2 Workflows**:
 1. **Approval Poller** (`n8n/flows/approval_poller.json`)
    - Polls Supabase `studio_board` for `status='approved'`
-   - Posts `content.publish.approved.v1` to Agent Zero `/events/publish`
-   - Updates row to `status='published'`
+   - Posts `content.publish.approved.v1` to Agent Zero `/events/publish` with `studio_board_id` + `publish_request_id`
+   - Marks the row `status='publishing'` while the publisher owns downstream delivery
 
 2. **Echo Publisher** (`n8n/flows/echo_publisher.json`)
    - Receives webhook from `publisher` service with `content.published.v1` payload
@@ -437,7 +437,7 @@ n8n is labeled as the **"MCP Hub"** in `docs/PMOVES_Multi-Agent_System_Crush_CLI
 **Key Tables** (from `db/v5_12_*.sql` and `supabase/migrations/`):
 - `videos` - YouTube videos metadata (duration, channel, tags, s3_base_prefix)
 - `transcripts` - Whisper transcriptions (text, timestamps, language)
-- `studio_board` - Creator approval queue (status, content_url, meta.publish_event_sent_at)
+- `studio_board` - Creator approval queue (`approved` → `publishing` → `published`, content_url, `meta.publish_request_id`, `meta.publish_requested_at`, `meta.publish_event_sent_at`)
 - `chunks` - Extracted text chunks (from LangExtract)
 - `personas` - AI agent personas (embeddings, prompts, packs)
 - `packs` - Knowledge packs (manifests, selectors, age/size limits)
@@ -578,14 +578,14 @@ Crush CLI → MCP client
 
 1. **Supabase `studio_board` Table**
    - Rows represent content awaiting approval/publishing
-   - Columns: `status` (pending/approved/published), `content_url` (S3 path), `meta` (JSONB with `publish_event_sent_at`)
+   - Columns: `status` (`submitted`/`approved`/`publishing`/`published`), `content_url` (S3 path), `meta` (JSONB with `publish_request_id`, `publish_requested_at`, `publish_event_sent_at`)
 
 2. **n8n Approval Poller Workflow**
    - Cron: Every 5 minutes (configurable)
    - Query: `SELECT * FROM studio_board WHERE status='approved' AND meta->>'publish_event_sent_at' IS NULL`
    - For each row:
-     - POST to Agent Zero `/events/publish` with `content.publish.approved.v1` event
-     - PATCH row to `status='published'`, set `meta.publish_event_sent_at=<timestamp>`
+     - POST to Agent Zero `/events/publish` with `content.publish.approved.v1`, `studio_board_id`, and `publish_request_id`
+     - PATCH row to `status='publishing'`, set `meta.publish_request_id` + `meta.publish_requested_at`
 
 3. **Agent Zero Event Republisher**
    - Subscribes to `content.publish.approved.v1` (via JetStream controller)
@@ -593,9 +593,10 @@ Crush CLI → MCP client
 
 4. **Publisher Service** (port 8092)
    - Subscribes to `content.publish.approved.v1`
+   - Claims the matching `studio_board` row using `publish_request_id` to suppress duplicate deliveries
    - Uploads asset to Jellyfin library
    - Enriches with metadata: `jellyfin_item_id`, `jellyfin_public_url`, `thumbnail_url`, `duration`, tags
-   - Publishes `content.published.v1` event (enriched)
+   - Publishes `content.published.v1` and then finalizes the row to `status='published'` with `meta.publish_event_sent_at`
 
 5. **Jellyfin Bridge** (port 8093)
    - Provides `/map-by-title` endpoint for auto-linking assets by fuzzy title match

--- a/pmoves/docs/services/supabase/MIGRATION_WORKFLOW.md
+++ b/pmoves/docs/services/supabase/MIGRATION_WORKFLOW.md
@@ -17,6 +17,8 @@ PMOVES uses a dual-path schema strategy:
 
 - **migrations/**: Applied via `supabase db push` or `make supa-migrate` against a running database. Used for production upgrades where data must be preserved. Tracked by Supabase's migration history table.
 
+For a full PMOVES bootstrap on an existing database, the canonical entrypoint is `make -C pmoves supabase-bootstrap`, which applies `supabase/migrations/*.sql` first and then replays `supabase/initdb/*.sql` as tracked seeds via `public.pmoves_bootstrap_history`.
+
 ## File Naming Conventions
 
 ### initdb/ — Numbered ordering
@@ -68,15 +70,14 @@ The following tables appear in **both** initdb and migrations, guarded by `CREAT
 
 | Directory | Files | Purpose |
 |-----------|-------|---------|
-| `pmoves/db/` | 6 files | Versioned schema updates (`v5_12_*`, `v5_13_*`, `v5_14_*`) — legacy, being consolidated |
-| `pmoves/migrations/` | 3 files | Root-level migrations (large, numbered `001-002`) — legacy |
+| `pmoves/db/` | 6 files | Legacy source SQL (`v5_12_*`, `v5_13_*`, `v5_14_*`) referenced by newer seeds; not executed by `supabase-bootstrap` |
+| `pmoves/migrations/` | 3 files | Root-level legacy migrations (large, numbered `001-002`); not part of the current Supabase bootstrap path |
 
 ## Common Operations
 
 ```bash
-# Fresh database (dev): destroy volume and reinitialize
-make -C pmoves volume-reset SERVICE=supabase-db
-make -C pmoves up-supabase
+# Fresh or existing database: apply canonical PMOVES bootstrap
+make -C pmoves supabase-bootstrap
 
 # Apply migrations to running database
 make -C pmoves supa-migrate
@@ -84,6 +85,8 @@ make -C pmoves supa-migrate
 # Check migration status
 supabase db status --db-url "postgresql://supabase_admin:${DB_PASSWORD}@localhost:5432/postgres"
 ```
+
+Do not replay `supabase/initdb/*.sql` seed files directly against an empty database unless you have already applied the dependent migrations they assume.
 
 ## Postgres 17 Compatibility
 

--- a/pmoves/docs/services/supabase/SUPABASE_MIGRATIONS.md
+++ b/pmoves/docs/services/supabase/SUPABASE_MIGRATIONS.md
@@ -79,8 +79,11 @@ cd pmoves
 make supabase-bootstrap
 ```
 
-This applies all migrations in:
-1. `supabase/migrations/*.sql` (PMOVES custom)
+This is the canonical PMOVES bootstrap path. It applies:
+1. `supabase/migrations/*.sql`
+2. `supabase/initdb/*.sql` as tracked seeds in `public.pmoves_bootstrap_history`
+
+Do not treat individual `supabase/initdb/*.sql` files as standalone entrypoints for an empty database unless the required migrations have already landed.
 
 ### Individual Migration
 
@@ -190,6 +193,8 @@ Located in `pmoves/supabase/initdb/`:
 | `10_archon_prompts_seed.sql` | Archon prompts | Pre-configured agent prompts |
 | `12_model_registry_seed.sql` | Model registry | LLM provider configurations |
 
+These files are bootstrap seeds, not independent schema sources. Some of them depend on tables created by `supabase/migrations/*.sql`.
+
 ### db/ Version Seeds
 
 Located in `pmoves/db/` (v5.x versioned seeds):
@@ -202,6 +207,8 @@ Located in `pmoves/db/` (v5.x versioned seeds):
 | `v5_13_persona_enhancements.sql` | Persona extensions | 100 lines |
 | `v5_13_pmoves_core_rest_grants.sql` | REST API grants | 20 lines |
 | `v5_14_seed_standard_personas.sql` | **Standard personas catalog** | 1515 lines |
+
+These `pmoves/db/` files are legacy source material and references. They are not replayed automatically by the current Supabase bootstrap targets.
 
 **v5_14 Standard Personas** (Most Important):
 - Seeds 8 production-ready personas for agent orchestration

--- a/pmoves/n8n/flows/approval_poller.json
+++ b/pmoves/n8n/flows/approval_poller.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "PMOVES • Supabase Approval Poller v1",
+    "name": "PMOVES - Supabase Approval Poller v1",
     "nodes": [
       {
         "parameters": {
@@ -80,7 +80,7 @@
       },
       {
         "parameters": {
-          "functionCode": "const row = item.json || {};\nconst meta = (row.meta && typeof row.meta === 'object') ? row.meta : {};\nconst payload = {\n  artifact_uri: row.content_url,\n  title: row.title || meta.title || 'Untitled Artifact',\n  namespace: row.namespace || undefined,\n  description: meta.description || undefined,\n  tags: Array.isArray(meta.tags) ? meta.tags : undefined,\n  meta\n};\n\nif (!payload.namespace) {\n  delete payload.namespace;\n}\nif (!payload.description) {\n  delete payload.description;\n}\nif (!payload.tags || payload.tags.length === 0) {\n  delete payload.tags;\n}\n\nconst patch = {\n  status: 'published',\n  meta: {\n    ...meta,\n    publish_event_sent_at: new Date().toISOString()\n  }\n};\n\nreturn {\n  json: {\n    envelope: {\n      topic: 'content.publish.approved.v1',\n      payload\n    },\n    rowId: row.id,\n    patch\n  }\n};"
+          "functionCode": "const row = item.json || {};\nconst meta = (row.meta && typeof row.meta === 'object') ? row.meta : {};\nconst requestedAt = new Date().toISOString();\nconst publishRequestId = `${row.id}:${requestedAt}`;\nconst payload = {\n  studio_board_id: row.id,\n  publish_request_id: publishRequestId,\n  artifact_uri: row.content_url,\n  title: row.title || meta.title || 'Untitled Artifact',\n  namespace: row.namespace || undefined,\n  description: meta.description || undefined,\n  tags: Array.isArray(meta.tags) ? meta.tags : undefined,\n  meta: {\n    ...meta,\n    studio_board_id: row.id,\n    publish_request_id: publishRequestId,\n    publish_requested_at: requestedAt,\n    publish_request_source: 'n8n-approval-poller'\n  }\n};\n\nif (!payload.namespace) {\n  delete payload.namespace;\n}\nif (!payload.description) {\n  delete payload.description;\n}\nif (!payload.tags || payload.tags.length === 0) {\n  delete payload.tags;\n}\n\nconst patch = {\n  status: 'publishing',\n  meta: {\n    ...meta,\n    studio_board_id: row.id,\n    publish_request_id: publishRequestId,\n    publish_requested_at: requestedAt,\n    publish_request_source: 'n8n-approval-poller'\n  }\n};\n\nreturn {\n  json: {\n    envelope: {\n      topic: 'content.publish.approved.v1',\n      payload\n    },\n    rowId: row.id,\n    patch\n  }\n};"
         },
         "id": "prepare_event",
         "name": "Prepare Publish Envelope",
@@ -127,7 +127,7 @@
       {
         "parameters": {
           "method": "PATCH",
-          "url": "={{ $env.SUPABASE_REST_URL }}/studio_board?id=eq.{{$json.rowId}}",
+          "url": "={{ $env.SUPABASE_REST_URL }}/studio_board?id=eq.{{$node[\"Prepare Publish Envelope\"].json[\"rowId\"]}}",
           "sendHeaders": true,
           "headerParameters": {
             "parameters": [
@@ -153,11 +153,11 @@
           "bodyParameters": {
             "parameters": []
           },
-          "body": "={{ JSON.stringify($json.patch) }}",
+          "body": "={{ JSON.stringify($node[\"Prepare Publish Envelope\"].json[\"patch\"]) }}",
           "options": {}
         },
         "id": "mark_processed",
-        "name": "Mark Approval Row",
+        "name": "Mark Publish Requested",
         "type": "n8n-nodes-base.httpRequest",
         "typeVersion": 4.1,
         "position": [
@@ -243,14 +243,14 @@
         "main": [
           [
             {
-              "node": "Mark Approval Row",
+              "node": "Mark Publish Requested",
               "type": "main",
               "index": 0
             }
           ]
         ]
       },
-      "Mark Approval Row": {
+      "Mark Publish Requested": {
         "main": [
           [
             {

--- a/pmoves/services/common/supabase.py
+++ b/pmoves/services/common/supabase.py
@@ -62,6 +62,85 @@ def _extract_rpc_bool(result: Any) -> bool:
     return bool(result)
 
 
+def _studio_board_meta(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def reconcile_studio_board_publish_completion(
+    row_id: int,
+    publish_event_id: str,
+    published_event_id: Optional[str],
+    published_at: Optional[str] = None,
+    publish_meta: Optional[Dict[str, Any]] = None,
+) -> bool:
+    if not publish_event_id:
+        return False
+
+    response = (
+        client()
+        .table("studio_board")
+        .select("id,status,meta")
+        .eq("id", row_id)
+        .limit(1)
+        .execute()
+    )
+    rows = getattr(response, "data", None) or []
+    if not rows:
+        return False
+
+    row = rows[0] if isinstance(rows[0], dict) else {}
+    status = row.get("status")
+    meta = _studio_board_meta(row.get("meta"))
+    current_request_id = meta.get("publish_request_id")
+    current_request_text = str(current_request_id) if current_request_id is not None else ""
+
+    if status == "published":
+        if current_request_text and current_request_text != publish_event_id:
+            return False
+        if published_event_id and meta.get("published_event_id") not in (None, published_event_id):
+            return False
+        return True
+
+    if status not in ("approved", "publishing"):
+        return False
+    if current_request_text and current_request_text != publish_event_id:
+        return False
+
+    updated_meta = {
+        key: value
+        for key, value in meta.items()
+        if key
+        not in {
+            "publish_failed_at",
+            "publish_failure_reason",
+            "publish_failure_stage",
+            "publish_failure_meta",
+        }
+    }
+    updated_meta.update(
+        {
+            "studio_board_id": row_id,
+            "publish_state": "published",
+            "publish_request_id": publish_event_id,
+            "publish_event_sent_at": published_at,
+            "published_at": published_at,
+            "published_event_id": published_event_id,
+        }
+    )
+    if publish_meta:
+        for key, value in publish_meta.items():
+            if value is not None:
+                updated_meta[key] = value
+
+    client().table("studio_board").update(
+        {
+            "status": "published",
+            "meta": updated_meta,
+        }
+    ).eq("id", row_id).execute()
+    return True
+
+
 def claim_studio_board_publish(
     row_id: int,
     publish_event_id: str,
@@ -115,4 +194,3 @@ def fail_studio_board_publish(
         params["p_failed_at"] = failed_at
     response = client().rpc("fail_studio_board_publish", params).execute()
     return _extract_rpc_bool(getattr(response, "data", None))
-

--- a/pmoves/services/common/supabase.py
+++ b/pmoves/services/common/supabase.py
@@ -43,3 +43,76 @@ def upsert_publisher_audit(row: Dict[str, Any]) -> None:
     if row:
         client().table("publisher_audit").upsert(row, on_conflict="publish_event_id").execute()
 
+
+def _extract_rpc_bool(result: Any) -> bool:
+    if isinstance(result, bool):
+        return result
+    if isinstance(result, dict):
+        for value in result.values():
+            if isinstance(value, bool):
+                return value
+    if isinstance(result, list):
+        for item in result:
+            if isinstance(item, bool):
+                return item
+            if isinstance(item, dict):
+                for value in item.values():
+                    if isinstance(value, bool):
+                        return value
+    return bool(result)
+
+
+def claim_studio_board_publish(
+    row_id: int,
+    publish_event_id: str,
+    requested_at: Optional[str] = None,
+) -> bool:
+    params: Dict[str, Any] = {
+        "p_row_id": row_id,
+        "p_publish_event_id": publish_event_id,
+    }
+    if requested_at:
+        params["p_requested_at"] = requested_at
+    response = client().rpc("claim_studio_board_publish", params).execute()
+    return _extract_rpc_bool(getattr(response, "data", None))
+
+
+def complete_studio_board_publish(
+    row_id: int,
+    publish_event_id: str,
+    published_event_id: Optional[str],
+    published_at: Optional[str] = None,
+    publish_meta: Optional[Dict[str, Any]] = None,
+) -> bool:
+    params: Dict[str, Any] = {
+        "p_row_id": row_id,
+        "p_publish_event_id": publish_event_id,
+        "p_published_event_id": published_event_id,
+        "p_publish_meta": publish_meta or {},
+    }
+    if published_at:
+        params["p_published_at"] = published_at
+    response = client().rpc("complete_studio_board_publish", params).execute()
+    return _extract_rpc_bool(getattr(response, "data", None))
+
+
+def fail_studio_board_publish(
+    row_id: int,
+    publish_event_id: str,
+    stage: str,
+    reason: str,
+    failed_at: Optional[str] = None,
+    failure_meta: Optional[Dict[str, Any]] = None,
+) -> bool:
+    params: Dict[str, Any] = {
+        "p_row_id": row_id,
+        "p_publish_event_id": publish_event_id,
+        "p_stage": stage,
+        "p_reason": reason,
+        "p_failure_meta": failure_meta or {},
+    }
+    if failed_at:
+        params["p_failed_at"] = failed_at
+    response = client().rpc("fail_studio_board_publish", params).execute()
+    return _extract_rpc_bool(getattr(response, "data", None))
+

--- a/pmoves/services/model-registry/README.md
+++ b/pmoves/services/model-registry/README.md
@@ -149,7 +149,8 @@ docker compose restart model-registry
 - Review logs: `docker compose logs model-registry`
 
 ### Empty models list
-- Run seed script: `psql -f pmoves/supabase/initdb/12_model_registry_seed.sql`
+- Run the canonical bootstrap: `make -C pmoves supabase-bootstrap`
+- If debugging manually, apply `pmoves/supabase/migrations/20260115_model_registry.sql` before replaying `pmoves/supabase/initdb/12_model_registry_seed.sql`
 - Or run migration: `python migrate_tensorzero.py`
 
 ### TensorZero config errors
@@ -176,4 +177,5 @@ docker compose restart model-registry
 
 - Migration: `/pmoves/supabase/migrations/20260115_model_registry.sql`
 - Seed data: `/pmoves/supabase/initdb/12_model_registry_seed.sql`
+- Canonical bootstrap: `make -C pmoves supabase-bootstrap`
 - Architecture docs: `/pmoves/docs/MODEL_REGISTRY.md`

--- a/pmoves/services/publisher/publisher.py
+++ b/pmoves/services/publisher/publisher.py
@@ -123,6 +123,8 @@ MEDIA_LIBRARY_PATH = os.environ.get("MEDIA_LIBRARY_PATH", "/library/images")
 MEDIA_LIBRARY_PUBLIC_BASE_URL = os.environ.get("MEDIA_LIBRARY_PUBLIC_BASE_URL")
 DOWNLOAD_RETRIES = int(os.environ.get("PUBLISHER_DOWNLOAD_RETRIES", "3"))
 DOWNLOAD_RETRY_BACKOFF_SEC = float(os.environ.get("PUBLISHER_DOWNLOAD_RETRY_BACKOFF", "1.5"))
+STUDIO_BOARD_SYNC_RETRIES = max(1, int(os.environ.get("PUBLISHER_STUDIO_BOARD_SYNC_RETRIES", "3")))
+STUDIO_BOARD_SYNC_BACKOFF_SEC = max(0.0, float(os.environ.get("PUBLISHER_STUDIO_BOARD_SYNC_BACKOFF_SEC", "1.0")))
 METRICS_HOST = os.environ.get("PUBLISHER_METRICS_HOST", "0.0.0.0")
 METRICS_PORT = int(os.environ.get("PUBLISHER_METRICS_PORT", "9095"))
 METRICS_ROLLUP_TABLE = os.environ.get("PUBLISHER_METRICS_TABLE", "publisher_metrics_rollup")
@@ -406,6 +408,7 @@ def build_published_payload(
     *,
     artifact_uri: str,
     studio_board_id: Optional[int],
+    publish_request_id: Optional[str],
     published_path: str,
     namespace: str,
     title: str,
@@ -430,6 +433,8 @@ def build_published_payload(
     }
     if studio_board_id is not None:
         payload["studio_board_id"] = studio_board_id
+    if publish_request_id:
+        payload["publish_request_id"] = publish_request_id
     if title:
         payload["title"] = title
     if description:
@@ -455,6 +460,7 @@ def build_published_payload(
                 jellyfin_meta,
                 {
                     "studio_board_id": studio_board_id,
+                    "publish_request_id": publish_request_id,
                     "thumbnail_url": thumbnail_url,
                     "duration": duration,
                     "jellyfin_public_url": jellyfin_public_url,
@@ -480,6 +486,7 @@ def build_failure_payload(
     outcome: str,
     artifact_uri: Optional[str],
     studio_board_id: Optional[int],
+    publish_request_id: Optional[str],
     namespace: Optional[str],
     publish_event_id: Optional[str],
     public_url: Optional[str],
@@ -498,6 +505,8 @@ def build_failure_payload(
         payload["artifact_uri"] = artifact_uri
     if studio_board_id is not None:
         payload["studio_board_id"] = studio_board_id
+    if publish_request_id:
+        payload["publish_request_id"] = publish_request_id
     if namespace:
         payload["namespace"] = namespace
     if publish_event_id:
@@ -525,6 +534,7 @@ async def emit_publish_failure(
     outcome: str = "fatal",
     artifact_uri: Optional[str],
     studio_board_id: Optional[int],
+    publish_request_id: Optional[str],
     namespace: Optional[str],
     public_url: Optional[str],
     jellyfin_public_url: Optional[str],
@@ -541,6 +551,7 @@ async def emit_publish_failure(
         outcome=outcome,
         artifact_uri=artifact_uri,
         studio_board_id=studio_board_id,
+        publish_request_id=publish_request_id,
         namespace=namespace,
         publish_event_id=publish_event_id,
         public_url=public_url,
@@ -569,6 +580,109 @@ async def emit_publish_failure(
                 "publish_event_id": publish_event_id,
             },
         )
+
+
+async def _sync_studio_board_publish_completion(
+    *,
+    studio_board_id: int,
+    publish_request_id: str,
+    published_event_id: Optional[str],
+    published_at: Optional[str],
+    completion_meta: Dict[str, Any],
+) -> Optional[str]:
+    attempts = max(1, STUDIO_BOARD_SYNC_RETRIES)
+    last_error: Optional[str] = None
+
+    if supabase_client is None:
+        return "studio_board completion sync unavailable"
+
+    for attempt in range(1, attempts + 1):
+        if not hasattr(supabase_client, "complete_studio_board_publish"):
+            last_error = "studio_board completion sync unavailable"
+            break
+        try:
+            synced = await asyncio.to_thread(
+                supabase_client.complete_studio_board_publish,
+                studio_board_id,
+                publish_request_id,
+                published_event_id,
+                published_at,
+                completion_meta,
+            )
+            if synced:
+                return None
+            last_error = "studio_board row was not updated after publish"
+            logger.warning(
+                "Studio board publish completion returned no update",
+                extra={
+                    "studio_board_id": studio_board_id,
+                    "publish_request_id": publish_request_id,
+                    "attempt": attempt,
+                },
+            )
+        except RuntimeError as exc:  # pragma: no cover - supabase config missing
+            last_error = _describe_exception(exc)
+            logger.warning(
+                "Supabase not configured for studio_board publish completion",
+                extra={
+                    "studio_board_id": studio_board_id,
+                    "publish_request_id": publish_request_id,
+                    "attempt": attempt,
+                },
+                exc_info=exc,
+            )
+        except Exception as exc:
+            last_error = _describe_exception(exc)
+            logger.warning(
+                "Failed to sync studio_board published state",
+                extra={
+                    "studio_board_id": studio_board_id,
+                    "publish_request_id": publish_request_id,
+                    "attempt": attempt,
+                },
+                exc_info=exc,
+            )
+        if attempt < attempts and STUDIO_BOARD_SYNC_BACKOFF_SEC > 0:
+            await asyncio.sleep(STUDIO_BOARD_SYNC_BACKOFF_SEC * attempt)
+
+    if hasattr(supabase_client, "reconcile_studio_board_publish_completion"):
+        try:
+            reconciled = await asyncio.to_thread(
+                supabase_client.reconcile_studio_board_publish_completion,
+                studio_board_id,
+                publish_request_id,
+                published_event_id,
+                published_at,
+                completion_meta,
+            )
+            if reconciled:
+                logger.warning(
+                    "Recovered studio_board publish completion via direct update fallback",
+                    extra={
+                        "studio_board_id": studio_board_id,
+                        "publish_request_id": publish_request_id,
+                    },
+                )
+                return None
+            last_error = last_error or "studio_board completion sync unavailable"
+        except RuntimeError as exc:  # pragma: no cover - supabase config missing
+            last_error = _describe_exception(exc)
+            logger.error(
+                "Supabase not configured for studio_board completion recovery",
+                extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                exc_info=exc,
+            )
+        except Exception as exc:
+            last_error = _describe_exception(exc)
+            logger.error(
+                "Failed to recover studio_board published state",
+                extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                exc_info=exc,
+            )
+
+    return last_error or "studio_board completion sync unavailable"
+
+
 async def download_with_retries(minio: MinioClientType, bucket: str, key: str, dest: str) -> None:
     last_error: Optional[Exception] = None
     for attempt in range(1, DOWNLOAD_RETRIES + 1):
@@ -877,6 +991,8 @@ async def main() -> None:
         base_meta: Dict[str, Any] = {}
         if studio_board_id is not None:
             base_meta["studio_board_id"] = studio_board_id
+        if publish_request_id:
+            base_meta["publish_request_id"] = publish_request_id
         if isinstance(payload.get("meta"), dict):
             base_meta["source_meta"] = payload["meta"]
 
@@ -904,6 +1020,7 @@ async def main() -> None:
                 outcome=outcome,
                 artifact_uri=artifact_uri,
                 studio_board_id=studio_board_id,
+                publish_request_id=publish_request_id,
                 namespace=namespace,
                 public_url=public_url_value,
                 jellyfin_public_url=jellyfin_public_url_value,
@@ -925,7 +1042,13 @@ async def main() -> None:
                 failure_reason=reason,
                 meta=combined_meta,
             )
-            if studio_board_id is not None and publish_request_id and supabase_client is not None and hasattr(supabase_client, "fail_studio_board_publish"):
+            if (
+                outcome != "partial"
+                and studio_board_id is not None
+                and publish_request_id
+                and supabase_client is not None
+                and hasattr(supabase_client, "fail_studio_board_publish")
+            ):
                 try:
                     await asyncio.to_thread(
                         supabase_client.fail_studio_board_publish,
@@ -1152,6 +1275,7 @@ async def main() -> None:
             published_payload = build_published_payload(
                 artifact_uri=artifact_uri,
                 studio_board_id=studio_board_id,
+                publish_request_id=publish_request_id,
                 published_path=out_path,
                 namespace=namespace,
                 title=title,
@@ -1204,50 +1328,22 @@ async def main() -> None:
             await nc.publish("content.published.v1", json.dumps(evt).encode())
 
             if studio_board_id is not None and publish_request_id:
-                if supabase_client is None or not hasattr(supabase_client, "complete_studio_board_publish"):
-                    studio_board_sync_error = "studio_board completion sync unavailable"
-                    logger.error(
-                        "Studio board publish completion sync unavailable",
-                        extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
-                    )
-                else:
-                    completion_meta = {
-                        "public_url": published_payload.get("public_url"),
-                        "jellyfin_public_url": published_payload.get("jellyfin_public_url"),
-                        "jellyfin_item_id": published_payload.get("jellyfin_item_id"),
-                        "published_path": published_payload.get("published_path"),
-                        "thumbnail_url": published_payload.get("thumbnail_url"),
-                        "duration": published_payload.get("duration"),
-                    }
-                    try:
-                        synced = await asyncio.to_thread(
-                            supabase_client.complete_studio_board_publish,
-                            studio_board_id,
-                            publish_request_id,
-                            _coerce_text(evt.get("id")),
-                            _coerce_text(evt.get("ts")),
-                            completion_meta,
-                        )
-                        if not synced:
-                            studio_board_sync_error = "studio_board row was not updated after publish"
-                            logger.error(
-                                "Studio board publish completion returned no update",
-                                extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
-                            )
-                    except RuntimeError as exc:  # pragma: no cover - supabase config missing
-                        studio_board_sync_error = _describe_exception(exc)
-                        logger.error(
-                            "Supabase not configured for studio_board publish completion",
-                            extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
-                            exc_info=exc,
-                        )
-                    except Exception as exc:
-                        studio_board_sync_error = _describe_exception(exc)
-                        logger.error(
-                            "Failed to sync studio_board published state",
-                            extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
-                            exc_info=exc,
-                        )
+                completion_meta = {
+                    "public_url": published_payload.get("public_url"),
+                    "jellyfin_public_url": published_payload.get("jellyfin_public_url"),
+                    "jellyfin_item_id": published_payload.get("jellyfin_item_id"),
+                    "published_path": published_payload.get("published_path"),
+                    "thumbnail_url": published_payload.get("thumbnail_url"),
+                    "duration": published_payload.get("duration"),
+                    "publish_request_id": publish_request_id,
+                }
+                studio_board_sync_error = await _sync_studio_board_publish_completion(
+                    studio_board_id=studio_board_id,
+                    publish_request_id=publish_request_id,
+                    published_event_id=_coerce_text(evt.get("id")),
+                    published_at=_coerce_text(evt.get("ts")),
+                    completion_meta=completion_meta,
+                )
         except Exception as exc:
             logger.exception(
                 "Failed to finalize publish pipeline",
@@ -1286,6 +1382,8 @@ async def main() -> None:
             success_context["jellyfin_item_id"] = jellyfin_item_id
         if studio_board_id is not None:
             success_context["studio_board_id"] = studio_board_id
+        if publish_request_id:
+            success_context["publish_request_id"] = publish_request_id
         if studio_board_sync_error:
             success_context["studio_board_sync_error"] = studio_board_sync_error
         success_context.update(jellyfin_meta)

--- a/pmoves/services/publisher/publisher.py
+++ b/pmoves/services/publisher/publisher.py
@@ -176,6 +176,44 @@ def _coerce_float(value: Any) -> Optional[float]:
         return None
 
 
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_studio_board_id(payload: Dict[str, Any]) -> Optional[int]:
+    meta = payload.get("meta") if isinstance(payload.get("meta"), dict) else {}
+    candidates = [
+        payload.get("studio_board_id"),
+        payload.get("row_id"),
+        meta.get("studio_board_id") if isinstance(meta, dict) else None,
+        meta.get("row_id") if isinstance(meta, dict) else None,
+    ]
+    for candidate in candidates:
+        value = _coerce_int(candidate)
+        if value is not None:
+            return value
+    return None
+
+
+def _extract_publish_request_id(payload: Dict[str, Any], fallback: Optional[str]) -> Optional[str]:
+    meta = payload.get("meta") if isinstance(payload.get("meta"), dict) else {}
+    candidates = [
+        payload.get("publish_request_id"),
+        meta.get("publish_request_id") if isinstance(meta, dict) else None,
+        fallback,
+    ]
+    for candidate in candidates:
+        text = _coerce_text(candidate)
+        if text:
+            return text
+    return None
+
+
 def _extract_reviewer(payload: Dict[str, Any]) -> Optional[str]:
     meta = payload.get("meta") if isinstance(payload.get("meta"), dict) else {}
     candidates = [
@@ -226,6 +264,7 @@ def _record_audit(
     correlation_id: Optional[str],
     artifact_uri: Optional[str],
     artifact_path: Optional[str],
+    studio_board_id: Optional[int],
     namespace: Optional[str],
     reviewer: Optional[str],
     reviewed_at: Optional[str],
@@ -252,6 +291,7 @@ def _record_audit(
         "correlation_id": correlation_id,
         "artifact_uri": artifact_uri,
         "artifact_path": artifact_path,
+        "studio_board_id": studio_board_id,
         "namespace": namespace,
         "reviewer": reviewer,
         "reviewed_at": reviewed_at,
@@ -365,6 +405,7 @@ def merge_metadata(
 def build_published_payload(
     *,
     artifact_uri: str,
+    studio_board_id: Optional[int],
     published_path: str,
     namespace: str,
     title: str,
@@ -387,6 +428,8 @@ def build_published_payload(
         "published_path": published_path,
         "namespace": namespace,
     }
+    if studio_board_id is not None:
+        payload["studio_board_id"] = studio_board_id
     if title:
         payload["title"] = title
     if description:
@@ -411,6 +454,7 @@ def build_published_payload(
             additional_meta=_combine_meta(
                 jellyfin_meta,
                 {
+                    "studio_board_id": studio_board_id,
                     "thumbnail_url": thumbnail_url,
                     "duration": duration,
                     "jellyfin_public_url": jellyfin_public_url,
@@ -435,6 +479,7 @@ def build_failure_payload(
     retryable: bool,
     outcome: str,
     artifact_uri: Optional[str],
+    studio_board_id: Optional[int],
     namespace: Optional[str],
     publish_event_id: Optional[str],
     public_url: Optional[str],
@@ -451,6 +496,8 @@ def build_failure_payload(
     }
     if artifact_uri:
         payload["artifact_uri"] = artifact_uri
+    if studio_board_id is not None:
+        payload["studio_board_id"] = studio_board_id
     if namespace:
         payload["namespace"] = namespace
     if publish_event_id:
@@ -477,6 +524,7 @@ async def emit_publish_failure(
     retryable: bool,
     outcome: str = "fatal",
     artifact_uri: Optional[str],
+    studio_board_id: Optional[int],
     namespace: Optional[str],
     public_url: Optional[str],
     jellyfin_public_url: Optional[str],
@@ -492,6 +540,7 @@ async def emit_publish_failure(
         retryable=retryable,
         outcome=outcome,
         artifact_uri=artifact_uri,
+        studio_board_id=studio_board_id,
         namespace=namespace,
         publish_event_id=publish_event_id,
         public_url=public_url,
@@ -822,8 +871,12 @@ async def main() -> None:
         namespace = _coerce_text(payload.get("namespace")) or "pmoves-demo"
         reviewer = _extract_reviewer(payload)
         reviewed_at = _extract_reviewed_at(payload, approval_event_ts)
+        studio_board_id = _extract_studio_board_id(payload)
+        publish_request_id = _extract_publish_request_id(payload, publish_event_id)
 
         base_meta: Dict[str, Any] = {}
+        if studio_board_id is not None:
+            base_meta["studio_board_id"] = studio_board_id
         if isinstance(payload.get("meta"), dict):
             base_meta["source_meta"] = payload["meta"]
 
@@ -850,6 +903,7 @@ async def main() -> None:
                 retryable=retryable,
                 outcome=outcome,
                 artifact_uri=artifact_uri,
+                studio_board_id=studio_board_id,
                 namespace=namespace,
                 public_url=public_url_value,
                 jellyfin_public_url=jellyfin_public_url_value,
@@ -863,6 +917,7 @@ async def main() -> None:
                 correlation_id=correlation_id,
                 artifact_uri=artifact_uri,
                 artifact_path=artifact_path_value,
+                studio_board_id=studio_board_id,
                 namespace=namespace,
                 reviewer=reviewer,
                 reviewed_at=reviewed_at,
@@ -870,6 +925,89 @@ async def main() -> None:
                 failure_reason=reason,
                 meta=combined_meta,
             )
+            if studio_board_id is not None and publish_request_id and supabase_client is not None and hasattr(supabase_client, "fail_studio_board_publish"):
+                try:
+                    await asyncio.to_thread(
+                        supabase_client.fail_studio_board_publish,
+                        studio_board_id,
+                        publish_request_id,
+                        stage,
+                        reason,
+                        _utc_now_iso(),
+                        combined_meta,
+                    )
+                except RuntimeError as exc:  # pragma: no cover - supabase config missing
+                    logger.debug(
+                        "Supabase not configured; skipping studio_board failure sync",
+                        extra={"studio_board_id": studio_board_id, "stage": stage},
+                        exc_info=exc,
+                    )
+                except Exception as exc:  # pragma: no cover - network/driver errors
+                    logger.warning(
+                        "Failed to sync studio_board failure state",
+                        extra={"studio_board_id": studio_board_id, "stage": stage},
+                        exc_info=exc,
+                    )
+
+        if studio_board_id is not None and publish_request_id:
+            if supabase_client is None or not hasattr(supabase_client, "claim_studio_board_publish"):
+                logger.error(
+                    "Studio board publish sync unavailable",
+                    extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                )
+                await record_failure(
+                    stage="sync_claim",
+                    reason="studio_board publish sync unavailable",
+                    retryable=True,
+                    meta_base=base_meta,
+                    details={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                )
+                return
+            try:
+                claimed = await asyncio.to_thread(
+                    supabase_client.claim_studio_board_publish,
+                    studio_board_id,
+                    publish_request_id,
+                    approval_event_ts,
+                )
+            except RuntimeError as exc:  # pragma: no cover - supabase config missing
+                logger.error(
+                    "Supabase not configured for studio_board claim",
+                    extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                    exc_info=exc,
+                )
+                await record_failure(
+                    stage="sync_claim",
+                    reason=_describe_exception(exc),
+                    retryable=True,
+                    meta_base=base_meta,
+                    details={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id, "exception": exc.__class__.__name__},
+                )
+                return
+            except Exception as exc:
+                logger.error(
+                    "Failed to claim studio_board row for publish",
+                    extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                    exc_info=exc,
+                )
+                await record_failure(
+                    stage="sync_claim",
+                    reason=_describe_exception(exc),
+                    retryable=True,
+                    meta_base=base_meta,
+                    details={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id, "exception": exc.__class__.__name__},
+                )
+                return
+            if not claimed:
+                logger.info(
+                    "Skipping duplicate or already-complete publish event",
+                    extra={
+                        "studio_board_id": studio_board_id,
+                        "publish_request_id": publish_request_id,
+                        "artifact_uri": artifact_uri,
+                    },
+                )
+                return
 
         if not artifact_uri:
             logger.error(
@@ -1007,11 +1145,13 @@ async def main() -> None:
 
         published_payload: Dict[str, Any] = {}
         evt: Optional[Dict[str, Any]] = None
+        studio_board_sync_error: Optional[str] = None
         failure_stage = "build_payload"
 
         try:
             published_payload = build_published_payload(
                 artifact_uri=artifact_uri,
+                studio_board_id=studio_board_id,
                 published_path=out_path,
                 namespace=namespace,
                 title=title,
@@ -1062,6 +1202,52 @@ async def main() -> None:
                 source="publisher",
             )
             await nc.publish("content.published.v1", json.dumps(evt).encode())
+
+            if studio_board_id is not None and publish_request_id:
+                if supabase_client is None or not hasattr(supabase_client, "complete_studio_board_publish"):
+                    studio_board_sync_error = "studio_board completion sync unavailable"
+                    logger.error(
+                        "Studio board publish completion sync unavailable",
+                        extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                    )
+                else:
+                    completion_meta = {
+                        "public_url": published_payload.get("public_url"),
+                        "jellyfin_public_url": published_payload.get("jellyfin_public_url"),
+                        "jellyfin_item_id": published_payload.get("jellyfin_item_id"),
+                        "published_path": published_payload.get("published_path"),
+                        "thumbnail_url": published_payload.get("thumbnail_url"),
+                        "duration": published_payload.get("duration"),
+                    }
+                    try:
+                        synced = await asyncio.to_thread(
+                            supabase_client.complete_studio_board_publish,
+                            studio_board_id,
+                            publish_request_id,
+                            _coerce_text(evt.get("id")),
+                            _coerce_text(evt.get("ts")),
+                            completion_meta,
+                        )
+                        if not synced:
+                            studio_board_sync_error = "studio_board row was not updated after publish"
+                            logger.error(
+                                "Studio board publish completion returned no update",
+                                extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                            )
+                    except RuntimeError as exc:  # pragma: no cover - supabase config missing
+                        studio_board_sync_error = _describe_exception(exc)
+                        logger.error(
+                            "Supabase not configured for studio_board publish completion",
+                            extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                            exc_info=exc,
+                        )
+                    except Exception as exc:
+                        studio_board_sync_error = _describe_exception(exc)
+                        logger.error(
+                            "Failed to sync studio_board published state",
+                            extra={"studio_board_id": studio_board_id, "publish_request_id": publish_request_id},
+                            exc_info=exc,
+                        )
         except Exception as exc:
             logger.exception(
                 "Failed to finalize publish pipeline",
@@ -1098,6 +1284,10 @@ async def main() -> None:
         success_context: Dict[str, Any] = {"stage": "published"}
         if jellyfin_item_id:
             success_context["jellyfin_item_id"] = jellyfin_item_id
+        if studio_board_id is not None:
+            success_context["studio_board_id"] = studio_board_id
+        if studio_board_sync_error:
+            success_context["studio_board_sync_error"] = studio_board_sync_error
         success_context.update(jellyfin_meta)
         success_meta = _combine_meta(
             path_meta_with_url,
@@ -1113,6 +1303,7 @@ async def main() -> None:
             correlation_id=correlation_id,
             artifact_uri=artifact_uri,
             artifact_path=out_path,
+            studio_board_id=studio_board_id,
             namespace=namespace,
             reviewer=reviewer,
             reviewed_at=reviewed_at,

--- a/pmoves/services/publisher/tests/test_publisher.py
+++ b/pmoves/services/publisher/tests/test_publisher.py
@@ -33,6 +33,7 @@ def test_slugify_and_output_path(tmp_path):
 def test_build_published_payload_merges_metadata():
     payload = publisher.build_published_payload(
         artifact_uri="s3://bucket/key",
+        studio_board_id=42,
         published_path="/library/creative-works/summer-gala-2024.png",
         namespace="Creative Works",
         title="Summer Gala 2024",
@@ -52,6 +53,7 @@ def test_build_published_payload_merges_metadata():
     )
 
     assert payload["artifact_uri"] == "s3://bucket/key"
+    assert payload["studio_board_id"] == 42
     assert payload["published_path"].endswith("summer-gala-2024.png")
     assert payload["namespace"] == "Creative Works"
     assert payload["public_url"].endswith("summer-gala-2024.png")
@@ -65,6 +67,7 @@ def test_build_published_payload_merges_metadata():
 
     meta = payload["meta"]
     assert meta["title"] == "Custom Title"
+    assert meta["studio_board_id"] == 42
     assert meta["description"] == "A highlight reel"
     assert meta["tags"] == ["events", "summer"]
     assert meta["camera"] == "FX3"
@@ -104,6 +107,7 @@ def test_build_failure_payload_includes_details():
         retryable=True,
         outcome="fatal",
         artifact_uri="s3://bucket/key",
+        studio_board_id=42,
         namespace="demo",
         publish_event_id="evt-1",
         public_url="http://public",
@@ -114,6 +118,7 @@ def test_build_failure_payload_includes_details():
     )
 
     assert payload["stage"] == "download"
+    assert payload["studio_board_id"] == 42
     assert payload["retryable"] is True
     assert payload["outcome"] == "fatal"
     assert payload["artifact_uri"] == "s3://bucket/key"
@@ -293,6 +298,13 @@ def test_lookup_jellyfin_item_handles_http_error(monkeypatch):
     assert url is None and item_id is None and meta == {}
 
 
+def test_extract_studio_board_id_from_payload_and_meta():
+    assert publisher._extract_studio_board_id({"studio_board_id": "42"}) == 42
+    assert publisher._extract_studio_board_id({"meta": {"studio_board_id": 7}}) == 7
+    assert publisher._extract_studio_board_id({"meta": {"row_id": "11"}}) == 11
+    assert publisher._extract_studio_board_id({"studio_board_id": "bad"}) is None
+
+
 def test_compute_publish_telemetry_and_metrics_summary():
     published_at = datetime.datetime(2024, 1, 1, 12, 0, tzinfo=datetime.timezone.utc)
     incoming_meta = {
@@ -408,7 +420,7 @@ def test_handle_download_failed_emits_failure_envelope(monkeypatch, tmp_path):
     assert meta["stage"] == "download"
     assert meta["bucket"] == "assets"
     assert meta["key"] == "demo/video.mp4"
-    assert meta["output_path"].endswith("creative-works/creative-works--demo-video.mp4")
+    assert Path(meta["output_path"]).as_posix().endswith("creative-works/creative-works--demo-video.mp4")
     assert meta["source_meta"]["camera"] == "FX3"
 
     audit_kwargs = audit_calls["kwargs"]
@@ -416,3 +428,124 @@ def test_handle_download_failed_emits_failure_envelope(monkeypatch, tmp_path):
     assert audit_kwargs["publish_event_id"] == "evt-123"
     assert audit_kwargs["failure_reason"].startswith("Failed to download")
     assert audit_kwargs["meta"] == meta
+
+
+def test_successful_publish_claims_and_completes_studio_board(monkeypatch, tmp_path):
+    published_messages: list[tuple[str, bytes]] = []
+    audit_calls: Dict[str, Any] = {}
+    state_calls: Dict[str, Any] = {}
+
+    async def exercise() -> None:
+        subscription_ready: asyncio.Future = asyncio.get_running_loop().create_future()
+
+        class StubNATS:
+            def __init__(self) -> None:
+                self.published = published_messages
+
+            async def connect(self, servers=None):
+                return None
+
+            async def publish(self, subject, data):
+                self.published.append((subject, data))
+
+            async def subscribe(self, subject, cb):
+                if not subscription_ready.done():
+                    subscription_ready.set_result(cb)
+
+        class StubMinio:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        async def fake_start_metrics_server():
+            return SimpleNamespace()
+
+        async def fake_download_with_retries(_minio, _bucket, _key, dest):
+            Path(dest).parent.mkdir(parents=True, exist_ok=True)
+            Path(dest).write_bytes(b"demo")
+
+        async def fake_request_jellyfin_refresh(_title, _namespace):
+            return None, None, {}
+
+        async def fake_persist_publish_rollup(_row):
+            return None
+
+        def fake_record_audit(**kwargs):
+            audit_calls["kwargs"] = kwargs
+
+        def fake_claim(row_id, publish_event_id, requested_at=None):
+            state_calls["claim"] = (row_id, publish_event_id, requested_at)
+            return True
+
+        def fake_complete(row_id, publish_event_id, published_event_id, published_at=None, publish_meta=None):
+            state_calls["complete"] = (row_id, publish_event_id, published_event_id, published_at, publish_meta)
+            return True
+
+        def fake_fail(*args, **kwargs):
+            state_calls["fail"] = (args, kwargs)
+            return True
+
+        monkeypatch.setattr(publisher, "MEDIA_LIBRARY_PATH", str(tmp_path))
+        monkeypatch.setattr(publisher, "_NATSClient", lambda: StubNATS())
+        monkeypatch.setattr(publisher, "_MinioClient", lambda *args, **kwargs: StubMinio())
+        monkeypatch.setattr(publisher, "start_metrics_server", fake_start_metrics_server)
+        monkeypatch.setattr(publisher, "download_with_retries", fake_download_with_retries)
+        monkeypatch.setattr(publisher, "request_jellyfin_refresh", fake_request_jellyfin_refresh)
+        monkeypatch.setattr(publisher, "persist_publish_rollup", fake_persist_publish_rollup)
+        monkeypatch.setattr(publisher, "_record_audit", fake_record_audit)
+        monkeypatch.setattr(
+            publisher,
+            "supabase_client",
+            SimpleNamespace(
+                claim_studio_board_publish=fake_claim,
+                complete_studio_board_publish=fake_complete,
+                fail_studio_board_publish=fake_fail,
+                upsert_publisher_audit=lambda row: None,
+            ),
+        )
+
+        main_task = asyncio.create_task(publisher.main())
+        handle = await asyncio.wait_for(subscription_ready, timeout=1)
+        main_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await main_task
+
+        env = {
+            "id": "evt-200",
+            "ts": "2024-01-01T12:00:00Z",
+            "correlation_id": "corr-200",
+            "payload": {
+                "studio_board_id": 91,
+                "artifact_uri": "s3://assets/demo/video.mp4",
+                "namespace": "Creative Works",
+                "title": "Demo Video",
+                "meta": {"camera": "FX3", "approved_at": "2024-01-01T11:30:00Z"},
+            },
+        }
+
+        msg = SimpleNamespace(data=json.dumps(env).encode("utf-8"))
+        await handle(msg)
+
+    asyncio.run(exercise())
+
+    assert published_messages, "expected published envelope to be emitted"
+    assert published_messages[0][0] == "content.published.v1"
+    emitted = json.loads(published_messages[0][1].decode("utf-8"))
+    assert emitted["payload"]["studio_board_id"] == 91
+
+    claim_row_id, claim_event_id, claim_requested_at = state_calls["claim"]
+    assert claim_row_id == 91
+    assert claim_event_id == "evt-200"
+    assert claim_requested_at == "2024-01-01T12:00:00Z"
+
+    complete_row_id, complete_event_id, published_event_id, published_at, publish_meta = state_calls["complete"]
+    assert complete_row_id == 91
+    assert complete_event_id == "evt-200"
+    assert published_event_id == emitted["id"]
+    assert published_at == emitted["ts"]
+    assert publish_meta["published_path"].endswith("creative-works--demo-video.mp4")
+
+    assert "fail" not in state_calls
+    audit_kwargs = audit_calls["kwargs"]
+    assert audit_kwargs["status"] == "published"
+    assert audit_kwargs["studio_board_id"] == 91
+    assert audit_kwargs["published_event_id"] == emitted["id"]

--- a/pmoves/services/publisher/tests/test_publisher.py
+++ b/pmoves/services/publisher/tests/test_publisher.py
@@ -34,6 +34,7 @@ def test_build_published_payload_merges_metadata():
     payload = publisher.build_published_payload(
         artifact_uri="s3://bucket/key",
         studio_board_id=42,
+        publish_request_id="req-42",
         published_path="/library/creative-works/summer-gala-2024.png",
         namespace="Creative Works",
         title="Summer Gala 2024",
@@ -54,6 +55,7 @@ def test_build_published_payload_merges_metadata():
 
     assert payload["artifact_uri"] == "s3://bucket/key"
     assert payload["studio_board_id"] == 42
+    assert payload["publish_request_id"] == "req-42"
     assert payload["published_path"].endswith("summer-gala-2024.png")
     assert payload["namespace"] == "Creative Works"
     assert payload["public_url"].endswith("summer-gala-2024.png")
@@ -68,6 +70,7 @@ def test_build_published_payload_merges_metadata():
     meta = payload["meta"]
     assert meta["title"] == "Custom Title"
     assert meta["studio_board_id"] == 42
+    assert meta["publish_request_id"] == "req-42"
     assert meta["description"] == "A highlight reel"
     assert meta["tags"] == ["events", "summer"]
     assert meta["camera"] == "FX3"
@@ -108,6 +111,7 @@ def test_build_failure_payload_includes_details():
         outcome="fatal",
         artifact_uri="s3://bucket/key",
         studio_board_id=42,
+        publish_request_id="req-42",
         namespace="demo",
         publish_event_id="evt-1",
         public_url="http://public",
@@ -119,6 +123,7 @@ def test_build_failure_payload_includes_details():
 
     assert payload["stage"] == "download"
     assert payload["studio_board_id"] == 42
+    assert payload["publish_request_id"] == "req-42"
     assert payload["retryable"] is True
     assert payload["outcome"] == "fatal"
     assert payload["artifact_uri"] == "s3://bucket/key"
@@ -305,6 +310,12 @@ def test_extract_studio_board_id_from_payload_and_meta():
     assert publisher._extract_studio_board_id({"studio_board_id": "bad"}) is None
 
 
+def test_extract_publish_request_id_from_payload_and_meta():
+    assert publisher._extract_publish_request_id({"publish_request_id": "req-42"}, "evt-1") == "req-42"
+    assert publisher._extract_publish_request_id({"meta": {"publish_request_id": "req-7"}}, "evt-1") == "req-7"
+    assert publisher._extract_publish_request_id({}, "evt-1") == "evt-1"
+
+
 def test_compute_publish_telemetry_and_metrics_summary():
     published_at = datetime.datetime(2024, 1, 1, 12, 0, tzinfo=datetime.timezone.utc)
     incoming_meta = {
@@ -410,6 +421,7 @@ def test_handle_download_failed_emits_failure_envelope(monkeypatch, tmp_path):
 
     assert payload["stage"] == "download"
     assert payload["outcome"] == "fatal"
+    assert payload["publish_request_id"] == "evt-123"
     assert payload["namespace"] == "Creative Works"
     assert payload["artifact_uri"] == "s3://assets/demo/video.mp4"
     details = payload.get("details")
@@ -499,6 +511,7 @@ def test_successful_publish_claims_and_completes_studio_board(monkeypatch, tmp_p
                 claim_studio_board_publish=fake_claim,
                 complete_studio_board_publish=fake_complete,
                 fail_studio_board_publish=fake_fail,
+                reconcile_studio_board_publish_completion=lambda *args, **kwargs: True,
                 upsert_publisher_audit=lambda row: None,
             ),
         )
@@ -515,6 +528,7 @@ def test_successful_publish_claims_and_completes_studio_board(monkeypatch, tmp_p
             "correlation_id": "corr-200",
             "payload": {
                 "studio_board_id": 91,
+                "publish_request_id": "req-200",
                 "artifact_uri": "s3://assets/demo/video.mp4",
                 "namespace": "Creative Works",
                 "title": "Demo Video",
@@ -531,21 +545,228 @@ def test_successful_publish_claims_and_completes_studio_board(monkeypatch, tmp_p
     assert published_messages[0][0] == "content.published.v1"
     emitted = json.loads(published_messages[0][1].decode("utf-8"))
     assert emitted["payload"]["studio_board_id"] == 91
+    assert emitted["payload"]["publish_request_id"] == "req-200"
 
     claim_row_id, claim_event_id, claim_requested_at = state_calls["claim"]
     assert claim_row_id == 91
-    assert claim_event_id == "evt-200"
+    assert claim_event_id == "req-200"
     assert claim_requested_at == "2024-01-01T12:00:00Z"
 
     complete_row_id, complete_event_id, published_event_id, published_at, publish_meta = state_calls["complete"]
     assert complete_row_id == 91
-    assert complete_event_id == "evt-200"
+    assert complete_event_id == "req-200"
     assert published_event_id == emitted["id"]
     assert published_at == emitted["ts"]
     assert publish_meta["published_path"].endswith("creative-works--demo-video.mp4")
+    assert publish_meta["publish_request_id"] == "req-200"
 
     assert "fail" not in state_calls
     audit_kwargs = audit_calls["kwargs"]
     assert audit_kwargs["status"] == "published"
     assert audit_kwargs["studio_board_id"] == 91
     assert audit_kwargs["published_event_id"] == emitted["id"]
+
+
+def test_partial_publish_warning_does_not_fail_studio_board(monkeypatch, tmp_path):
+    published_messages: list[tuple[str, bytes]] = []
+    state_calls: Dict[str, Any] = {}
+
+    async def exercise() -> None:
+        subscription_ready: asyncio.Future = asyncio.get_running_loop().create_future()
+
+        class StubNATS:
+            def __init__(self) -> None:
+                self.published = published_messages
+
+            async def connect(self, servers=None):
+                return None
+
+            async def publish(self, subject, data):
+                self.published.append((subject, data))
+
+            async def subscribe(self, subject, cb):
+                if not subscription_ready.done():
+                    subscription_ready.set_result(cb)
+
+        class StubMinio:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        async def fake_start_metrics_server():
+            return SimpleNamespace()
+
+        async def fake_download_with_retries(_minio, _bucket, _key, dest):
+            Path(dest).parent.mkdir(parents=True, exist_ok=True)
+            Path(dest).write_bytes(b"demo")
+
+        async def fake_request_jellyfin_refresh(_title, _namespace):
+            raise publisher.JellyfinRefreshError("refresh timeout", details={"status_code": 504})
+
+        async def fake_persist_publish_rollup(_row):
+            return None
+
+        def fake_claim(row_id, publish_event_id, requested_at=None):
+            state_calls["claim"] = (row_id, publish_event_id, requested_at)
+            return True
+
+        def fake_complete(row_id, publish_event_id, published_event_id, published_at=None, publish_meta=None):
+            state_calls["complete"] = (row_id, publish_event_id, published_event_id, published_at, publish_meta)
+            return True
+
+        def fake_fail(*args, **kwargs):
+            state_calls["fail"] = (args, kwargs)
+            return True
+
+        monkeypatch.setattr(publisher, "MEDIA_LIBRARY_PATH", str(tmp_path))
+        monkeypatch.setattr(publisher, "_NATSClient", lambda: StubNATS())
+        monkeypatch.setattr(publisher, "_MinioClient", lambda *args, **kwargs: StubMinio())
+        monkeypatch.setattr(publisher, "start_metrics_server", fake_start_metrics_server)
+        monkeypatch.setattr(publisher, "download_with_retries", fake_download_with_retries)
+        monkeypatch.setattr(publisher, "request_jellyfin_refresh", fake_request_jellyfin_refresh)
+        monkeypatch.setattr(publisher, "persist_publish_rollup", fake_persist_publish_rollup)
+        monkeypatch.setattr(publisher, "_record_audit", lambda **kwargs: None)
+        monkeypatch.setattr(
+            publisher,
+            "supabase_client",
+            SimpleNamespace(
+                claim_studio_board_publish=fake_claim,
+                complete_studio_board_publish=fake_complete,
+                fail_studio_board_publish=fake_fail,
+                reconcile_studio_board_publish_completion=lambda *args, **kwargs: True,
+                upsert_publisher_audit=lambda row: None,
+            ),
+        )
+
+        main_task = asyncio.create_task(publisher.main())
+        handle = await asyncio.wait_for(subscription_ready, timeout=1)
+        main_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await main_task
+
+        env = {
+            "id": "evt-300",
+            "ts": "2024-01-01T12:00:00Z",
+            "correlation_id": "corr-300",
+            "payload": {
+                "studio_board_id": 93,
+                "publish_request_id": "req-300",
+                "artifact_uri": "s3://assets/demo/video.mp4",
+                "namespace": "Creative Works",
+                "title": "Demo Video",
+                "meta": {"camera": "FX3", "approved_at": "2024-01-01T11:30:00Z"},
+            },
+        }
+
+        msg = SimpleNamespace(data=json.dumps(env).encode("utf-8"))
+        await handle(msg)
+
+    asyncio.run(exercise())
+
+    subjects = [subject for subject, _ in published_messages]
+    assert subjects == ["content.publish.failed.v1", "content.published.v1"]
+    partial_evt = json.loads(published_messages[0][1].decode("utf-8"))
+    success_evt = json.loads(published_messages[1][1].decode("utf-8"))
+    assert partial_evt["payload"]["outcome"] == "partial"
+    assert partial_evt["payload"]["publish_request_id"] == "req-300"
+    assert success_evt["payload"]["publish_request_id"] == "req-300"
+    assert "fail" not in state_calls
+    assert state_calls["complete"][1] == "req-300"
+
+
+def test_completion_sync_falls_back_to_direct_reconcile(monkeypatch, tmp_path):
+    published_messages: list[tuple[str, bytes]] = []
+    state_calls: Dict[str, Any] = {"complete": [], "reconcile": []}
+
+    async def exercise() -> None:
+        subscription_ready: asyncio.Future = asyncio.get_running_loop().create_future()
+
+        class StubNATS:
+            def __init__(self) -> None:
+                self.published = published_messages
+
+            async def connect(self, servers=None):
+                return None
+
+            async def publish(self, subject, data):
+                self.published.append((subject, data))
+
+            async def subscribe(self, subject, cb):
+                if not subscription_ready.done():
+                    subscription_ready.set_result(cb)
+
+        class StubMinio:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        async def fake_start_metrics_server():
+            return SimpleNamespace()
+
+        async def fake_download_with_retries(_minio, _bucket, _key, dest):
+            Path(dest).parent.mkdir(parents=True, exist_ok=True)
+            Path(dest).write_bytes(b"demo")
+
+        async def fake_request_jellyfin_refresh(_title, _namespace):
+            return None, None, {}
+
+        async def fake_persist_publish_rollup(_row):
+            return None
+
+        def fake_complete(*args, **kwargs):
+            state_calls["complete"].append((args, kwargs))
+            raise RuntimeError("rpc unavailable")
+
+        def fake_reconcile(*args, **kwargs):
+            state_calls["reconcile"].append((args, kwargs))
+            return True
+
+        monkeypatch.setattr(publisher, "MEDIA_LIBRARY_PATH", str(tmp_path))
+        monkeypatch.setattr(publisher, "STUDIO_BOARD_SYNC_RETRIES", 1)
+        monkeypatch.setattr(publisher, "STUDIO_BOARD_SYNC_BACKOFF_SEC", 0)
+        monkeypatch.setattr(publisher, "_NATSClient", lambda: StubNATS())
+        monkeypatch.setattr(publisher, "_MinioClient", lambda *args, **kwargs: StubMinio())
+        monkeypatch.setattr(publisher, "start_metrics_server", fake_start_metrics_server)
+        monkeypatch.setattr(publisher, "download_with_retries", fake_download_with_retries)
+        monkeypatch.setattr(publisher, "request_jellyfin_refresh", fake_request_jellyfin_refresh)
+        monkeypatch.setattr(publisher, "persist_publish_rollup", fake_persist_publish_rollup)
+        monkeypatch.setattr(publisher, "_record_audit", lambda **kwargs: None)
+        monkeypatch.setattr(
+            publisher,
+            "supabase_client",
+            SimpleNamespace(
+                claim_studio_board_publish=lambda *args, **kwargs: True,
+                complete_studio_board_publish=fake_complete,
+                reconcile_studio_board_publish_completion=fake_reconcile,
+                fail_studio_board_publish=lambda *args, **kwargs: True,
+                upsert_publisher_audit=lambda row: None,
+            ),
+        )
+
+        main_task = asyncio.create_task(publisher.main())
+        handle = await asyncio.wait_for(subscription_ready, timeout=1)
+        main_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await main_task
+
+        env = {
+            "id": "evt-400",
+            "ts": "2024-01-01T12:00:00Z",
+            "correlation_id": "corr-400",
+            "payload": {
+                "studio_board_id": 94,
+                "publish_request_id": "req-400",
+                "artifact_uri": "s3://assets/demo/video.mp4",
+                "namespace": "Creative Works",
+                "title": "Demo Video",
+                "meta": {"camera": "FX3", "approved_at": "2024-01-01T11:30:00Z"},
+            },
+        }
+
+        msg = SimpleNamespace(data=json.dumps(env).encode("utf-8"))
+        await handle(msg)
+
+    asyncio.run(exercise())
+
+    assert published_messages
+    assert published_messages[0][0] == "content.published.v1"
+    assert len(state_calls["complete"]) == 1
+    assert len(state_calls["reconcile"]) == 1

--- a/pmoves/supabase/initdb/12_model_registry_seed.sql
+++ b/pmoves/supabase/initdb/12_model_registry_seed.sql
@@ -11,6 +11,27 @@
 -- Version: 2.0 (reconciled with gpu-models.yaml + tensorzero.toml)
 -- Idempotent: Uses ON CONFLICT to allow safe re-seeding
 
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'pmoves_core' AND table_name = 'model_providers'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'pmoves_core' AND table_name = 'models'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'pmoves_core' AND table_name = 'model_aliases'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'pmoves_core' AND table_name = 'service_model_mappings'
+  ) THEN
+    RAISE EXCEPTION USING
+      MESSAGE = '12_model_registry_seed.sql requires the model registry schema to exist first.',
+      HINT = 'Run make -C pmoves supabase-bootstrap, or apply 20260115_model_registry.sql before replaying this seed manually.';
+  END IF;
+END $$;
+
 -- =============================================================================
 -- Providers
 -- =============================================================================

--- a/pmoves/supabase/initdb/17_persona_seed.sql
+++ b/pmoves/supabase/initdb/17_persona_seed.sql
@@ -32,6 +32,24 @@
 
 DO $$
 BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'pmoves_core' AND table_name = 'personas'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'pmoves_core' AND table_name = 'model_providers'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'pmoves_core' AND table_name = 'models'
+  ) THEN
+    RAISE EXCEPTION USING
+      MESSAGE = '17_persona_seed.sql requires personas plus model registry tables to exist first.',
+      HINT = 'Run make -C pmoves supabase-bootstrap so migrations land before persona seeds, or apply 20250115_persona_agent_creation.sql and 20260115_model_registry.sql before replaying this file manually.';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
   IF EXISTS (
     SELECT 1 FROM information_schema.tables
     WHERE table_schema = 'pmoves_core' AND table_name = 'personas'

--- a/pmoves/supabase/initdb/18_publisher_publish_state.sql
+++ b/pmoves/supabase/initdb/18_publisher_publish_state.sql
@@ -1,0 +1,249 @@
+alter table if exists public.studio_board
+  add column if not exists updated_at timestamptz default now();
+
+update public.studio_board
+set updated_at = coalesce(updated_at, created_at, now())
+where updated_at is null;
+
+create or replace function public.set_studio_board_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists studio_board_touch_updated_at on public.studio_board;
+create trigger studio_board_touch_updated_at
+before update on public.studio_board
+for each row
+execute function public.set_studio_board_updated_at();
+
+create table if not exists public.publisher_audit (
+  publish_event_id text primary key,
+  studio_board_id bigint references public.studio_board(id) on delete set null,
+  approval_event_ts timestamptz,
+  correlation_id text,
+  artifact_uri text,
+  artifact_path text,
+  namespace text,
+  reviewer text,
+  reviewed_at timestamptz,
+  status text not null check (status in ('published', 'failed')),
+  failure_reason text,
+  published_event_id text,
+  public_url text,
+  published_at timestamptz,
+  processed_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  meta jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_publisher_audit_status on public.publisher_audit(status);
+create index if not exists idx_publisher_audit_artifact_path on public.publisher_audit(artifact_path);
+create index if not exists idx_publisher_audit_namespace on public.publisher_audit(namespace);
+create index if not exists idx_publisher_audit_reviewer on public.publisher_audit(reviewer);
+create index if not exists idx_publisher_audit_processed_at on public.publisher_audit(processed_at desc);
+create index if not exists idx_publisher_audit_studio_board_id on public.publisher_audit(studio_board_id);
+
+create or replace function public.set_publisher_audit_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists publisher_audit_touch_updated_at on public.publisher_audit;
+create trigger publisher_audit_touch_updated_at
+before update on public.publisher_audit
+for each row
+execute function public.set_publisher_audit_updated_at();
+
+create table if not exists public.publisher_metrics_rollup (
+  artifact_uri text primary key,
+  namespace text,
+  slug text,
+  published_at timestamptz,
+  turnaround_seconds double precision,
+  approval_latency_seconds double precision,
+  engagement jsonb,
+  cost jsonb
+);
+
+create table if not exists public.publisher_discord_metrics (
+  published_event_id text primary key,
+  artifact_uri text,
+  namespace text,
+  slug text,
+  published_at timestamptz,
+  turnaround_seconds double precision,
+  approval_latency_seconds double precision,
+  engagement jsonb,
+  cost jsonb,
+  event_topic text,
+  channel text,
+  webhook_success boolean
+);
+
+create index if not exists idx_publisher_discord_metrics_published_at
+  on public.publisher_discord_metrics(published_at desc);
+
+create or replace function public.claim_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_requested_at timestamptz default now()
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
+    return false;
+  end if;
+
+  update public.studio_board
+  set status = 'publishing',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_failed_at'
+          - 'publish_failure_reason'
+          - 'publish_failure_stage'
+          - 'publish_failure_meta'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'publishing',
+          'publish_request_id', p_publish_event_id,
+          'publish_requested_at', p_requested_at,
+          'publish_request_source', 'publisher'
+        )
+      )
+  where id = p_row_id
+    and coalesce(meta->>'publish_event_sent_at', '') = ''
+    and (
+      status = 'approved'
+      or (
+        status = 'publishing'
+        and coalesce(meta->>'publish_request_id', '') = p_publish_event_id
+      )
+    );
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;
+
+create or replace function public.complete_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_published_event_id text,
+  p_published_at timestamptz default now(),
+  p_publish_meta jsonb default '{}'::jsonb
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null then
+    return false;
+  end if;
+
+  update public.studio_board
+  set status = 'published',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_failed_at'
+          - 'publish_failure_reason'
+          - 'publish_failure_stage'
+          - 'publish_failure_meta'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'published',
+          'publish_request_id', p_publish_event_id,
+          'publish_event_sent_at', p_published_at,
+          'published_at', p_published_at,
+          'published_event_id', p_published_event_id
+        )
+        || coalesce(p_publish_meta, '{}'::jsonb)
+      )
+  where id = p_row_id
+    and (
+      status in ('approved', 'publishing')
+      or (
+        status = 'published'
+        and coalesce(meta->>'publish_request_id', '') = coalesce(p_publish_event_id, '')
+      )
+    );
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;
+
+create or replace function public.fail_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_stage text,
+  p_reason text,
+  p_failed_at timestamptz default now(),
+  p_failure_meta jsonb default '{}'::jsonb
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null then
+    return false;
+  end if;
+
+  update public.studio_board
+  set status = 'approved',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_request_id'
+          - 'publish_requested_at'
+          - 'publish_request_source'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'failed',
+          'last_publish_request_id', p_publish_event_id,
+          'publish_failed_at', p_failed_at,
+          'publish_failure_stage', coalesce(p_stage, 'unknown'),
+          'publish_failure_reason', coalesce(nullif(btrim(p_reason), ''), 'unspecified failure'),
+          'publish_failure_meta', coalesce(p_failure_meta, '{}'::jsonb)
+        )
+      )
+  where id = p_row_id
+    and coalesce(meta->>'publish_event_sent_at', '') = ''
+    and status in ('approved', 'publishing');
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;
+
+grant select, insert, update on table public.publisher_audit to service_role;
+grant select, insert, update on table public.publisher_metrics_rollup to service_role;
+grant select, insert, update on table public.publisher_discord_metrics to service_role;
+grant execute on function public.claim_studio_board_publish(bigint, text, timestamptz) to service_role;
+grant execute on function public.complete_studio_board_publish(bigint, text, text, timestamptz, jsonb) to service_role;
+grant execute on function public.fail_studio_board_publish(bigint, text, text, text, timestamptz, jsonb) to service_role;

--- a/pmoves/supabase/initdb/18_publisher_publish_state.sql
+++ b/pmoves/supabase/initdb/18_publisher_publish_state.sql
@@ -214,7 +214,7 @@ begin
   end if;
 
   update public.studio_board
-  set status = 'approved',
+  set status = 'publish_failed',
       meta = (
         (
           coalesce(meta, '{}'::jsonb)
@@ -234,7 +234,13 @@ begin
       )
   where id = p_row_id
     and coalesce(meta->>'publish_event_sent_at', '') = ''
-    and status in ('approved', 'publishing');
+    and (
+      status in ('approved', 'publishing')
+      or (
+        status = 'publish_failed'
+        and coalesce(meta->>'last_publish_request_id', '') = coalesce(p_publish_event_id, '')
+      )
+    );
 
   get diagnostics updated_rows = row_count;
   return updated_rows > 0;

--- a/pmoves/supabase/migrations/2025-10-18_geometry_swarm_compat.sql
+++ b/pmoves/supabase/migrations/2025-10-18_geometry_swarm_compat.sql
@@ -3,7 +3,10 @@
 -- Date: 2025-10-18
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_parameter_packs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_parameter_packs' AND column_name='pack_type'
   ) THEN
@@ -13,7 +16,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_parameter_packs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_parameter_packs' AND column_name='params'
   ) THEN
@@ -23,7 +29,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_parameter_packs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_parameter_packs' AND column_name='version'
   ) THEN
@@ -33,7 +42,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_parameter_packs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_parameter_packs' AND column_name='population_id'
   ) THEN
@@ -43,7 +55,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_parameter_packs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_parameter_packs' AND column_name='generation'
   ) THEN
@@ -53,7 +68,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_parameter_packs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_parameter_packs' AND column_name='fitness'
   ) THEN
@@ -63,12 +81,24 @@ DO $$ BEGIN
 END $$;
 
 -- Index to aid latest-active lookups by pack_type
-CREATE INDEX IF NOT EXISTS idx_geom_param_packs_packtype_status_created
-  ON public.geometry_parameter_packs (pack_type, status, created_at DESC);
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_parameter_packs'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_geom_param_packs_packtype_status_created
+      ON public.geometry_parameter_packs (pack_type, status, created_at DESC);
+  ELSE
+    RAISE NOTICE 'Skipping geometry_parameter_packs compatibility indexes because the base table is absent.';
+  END IF;
+END $$;
 
 -- geometry_swarm_runs compatibility
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_swarm_runs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_swarm_runs' AND column_name='pack_id'
   ) THEN
@@ -78,7 +108,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_swarm_runs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_swarm_runs' AND column_name='best_fitness'
   ) THEN
@@ -88,7 +121,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_swarm_runs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_swarm_runs' AND column_name='metrics'
   ) THEN
@@ -98,7 +134,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_swarm_runs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_swarm_runs' AND column_name='created_by'
   ) THEN
@@ -108,7 +147,10 @@ DO $$ BEGIN
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_swarm_runs'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_schema='public' AND table_name='geometry_swarm_runs' AND column_name='created_at'
   ) THEN
@@ -117,5 +159,14 @@ DO $$ BEGIN
   END IF;
 END $$;
 
-CREATE INDEX IF NOT EXISTS idx_geom_swarm_runs_pack ON public.geometry_swarm_runs (pack_id);
-CREATE INDEX IF NOT EXISTS idx_geom_swarm_runs_population_created ON public.geometry_swarm_runs (population_id, created_at DESC);
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='geometry_swarm_runs'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_geom_swarm_runs_pack ON public.geometry_swarm_runs (pack_id);
+    CREATE INDEX IF NOT EXISTS idx_geom_swarm_runs_population_created ON public.geometry_swarm_runs (population_id, created_at DESC);
+  ELSE
+    RAISE NOTICE 'Skipping geometry_swarm_runs compatibility indexes because the base table is absent.';
+  END IF;
+END $$;

--- a/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
+++ b/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
@@ -1,0 +1,249 @@
+alter table if exists public.studio_board
+  add column if not exists updated_at timestamptz default now();
+
+update public.studio_board
+set updated_at = coalesce(updated_at, created_at, now())
+where updated_at is null;
+
+create or replace function public.set_studio_board_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists studio_board_touch_updated_at on public.studio_board;
+create trigger studio_board_touch_updated_at
+before update on public.studio_board
+for each row
+execute function public.set_studio_board_updated_at();
+
+create table if not exists public.publisher_audit (
+  publish_event_id text primary key,
+  studio_board_id bigint references public.studio_board(id) on delete set null,
+  approval_event_ts timestamptz,
+  correlation_id text,
+  artifact_uri text,
+  artifact_path text,
+  namespace text,
+  reviewer text,
+  reviewed_at timestamptz,
+  status text not null check (status in ('published', 'failed')),
+  failure_reason text,
+  published_event_id text,
+  public_url text,
+  published_at timestamptz,
+  processed_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  meta jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_publisher_audit_status on public.publisher_audit(status);
+create index if not exists idx_publisher_audit_artifact_path on public.publisher_audit(artifact_path);
+create index if not exists idx_publisher_audit_namespace on public.publisher_audit(namespace);
+create index if not exists idx_publisher_audit_reviewer on public.publisher_audit(reviewer);
+create index if not exists idx_publisher_audit_processed_at on public.publisher_audit(processed_at desc);
+create index if not exists idx_publisher_audit_studio_board_id on public.publisher_audit(studio_board_id);
+
+create or replace function public.set_publisher_audit_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists publisher_audit_touch_updated_at on public.publisher_audit;
+create trigger publisher_audit_touch_updated_at
+before update on public.publisher_audit
+for each row
+execute function public.set_publisher_audit_updated_at();
+
+create table if not exists public.publisher_metrics_rollup (
+  artifact_uri text primary key,
+  namespace text,
+  slug text,
+  published_at timestamptz,
+  turnaround_seconds double precision,
+  approval_latency_seconds double precision,
+  engagement jsonb,
+  cost jsonb
+);
+
+create table if not exists public.publisher_discord_metrics (
+  published_event_id text primary key,
+  artifact_uri text,
+  namespace text,
+  slug text,
+  published_at timestamptz,
+  turnaround_seconds double precision,
+  approval_latency_seconds double precision,
+  engagement jsonb,
+  cost jsonb,
+  event_topic text,
+  channel text,
+  webhook_success boolean
+);
+
+create index if not exists idx_publisher_discord_metrics_published_at
+  on public.publisher_discord_metrics(published_at desc);
+
+create or replace function public.claim_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_requested_at timestamptz default now()
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
+    return false;
+  end if;
+
+  update public.studio_board
+  set status = 'publishing',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_failed_at'
+          - 'publish_failure_reason'
+          - 'publish_failure_stage'
+          - 'publish_failure_meta'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'publishing',
+          'publish_request_id', p_publish_event_id,
+          'publish_requested_at', p_requested_at,
+          'publish_request_source', 'publisher'
+        )
+      )
+  where id = p_row_id
+    and coalesce(meta->>'publish_event_sent_at', '') = ''
+    and (
+      status = 'approved'
+      or (
+        status = 'publishing'
+        and coalesce(meta->>'publish_request_id', '') = p_publish_event_id
+      )
+    );
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;
+
+create or replace function public.complete_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_published_event_id text,
+  p_published_at timestamptz default now(),
+  p_publish_meta jsonb default '{}'::jsonb
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null then
+    return false;
+  end if;
+
+  update public.studio_board
+  set status = 'published',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_failed_at'
+          - 'publish_failure_reason'
+          - 'publish_failure_stage'
+          - 'publish_failure_meta'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'published',
+          'publish_request_id', p_publish_event_id,
+          'publish_event_sent_at', p_published_at,
+          'published_at', p_published_at,
+          'published_event_id', p_published_event_id
+        )
+        || coalesce(p_publish_meta, '{}'::jsonb)
+      )
+  where id = p_row_id
+    and (
+      status in ('approved', 'publishing')
+      or (
+        status = 'published'
+        and coalesce(meta->>'publish_request_id', '') = coalesce(p_publish_event_id, '')
+      )
+    );
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;
+
+create or replace function public.fail_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_stage text,
+  p_reason text,
+  p_failed_at timestamptz default now(),
+  p_failure_meta jsonb default '{}'::jsonb
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null then
+    return false;
+  end if;
+
+  update public.studio_board
+  set status = 'approved',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_request_id'
+          - 'publish_requested_at'
+          - 'publish_request_source'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'failed',
+          'last_publish_request_id', p_publish_event_id,
+          'publish_failed_at', p_failed_at,
+          'publish_failure_stage', coalesce(p_stage, 'unknown'),
+          'publish_failure_reason', coalesce(nullif(btrim(p_reason), ''), 'unspecified failure'),
+          'publish_failure_meta', coalesce(p_failure_meta, '{}'::jsonb)
+        )
+      )
+  where id = p_row_id
+    and coalesce(meta->>'publish_event_sent_at', '') = ''
+    and status in ('approved', 'publishing');
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;
+
+grant select, insert, update on table public.publisher_audit to service_role;
+grant select, insert, update on table public.publisher_metrics_rollup to service_role;
+grant select, insert, update on table public.publisher_discord_metrics to service_role;
+grant execute on function public.claim_studio_board_publish(bigint, text, timestamptz) to service_role;
+grant execute on function public.complete_studio_board_publish(bigint, text, text, timestamptz, jsonb) to service_role;
+grant execute on function public.fail_studio_board_publish(bigint, text, text, text, timestamptz, jsonb) to service_role;

--- a/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
+++ b/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
@@ -214,7 +214,7 @@ begin
   end if;
 
   update public.studio_board
-  set status = 'approved',
+  set status = 'publish_failed',
       meta = (
         (
           coalesce(meta, '{}'::jsonb)
@@ -234,7 +234,13 @@ begin
       )
   where id = p_row_id
     and coalesce(meta->>'publish_event_sent_at', '') = ''
-    and status in ('approved', 'publishing');
+    and (
+      status in ('approved', 'publishing')
+      or (
+        status = 'publish_failed'
+        and coalesce(meta->>'last_publish_request_id', '') = coalesce(p_publish_event_id, '')
+      )
+    );
 
   get diagnostics updated_rows = row_count;
   return updated_rows > 0;

--- a/pmoves/ui/app/dashboard/studio-board/page.tsx
+++ b/pmoves/ui/app/dashboard/studio-board/page.tsx
@@ -20,6 +20,7 @@ interface StudioBoardRowMeta {
   reviewed_by?: string | null;
   publish_event_sent_at?: string | null;
   publish_requested_at?: string | null;
+  publish_failed_at?: string | null;
   publish_failure_reason?: string | null;
   tags?: string[];
   persona?: string;
@@ -38,7 +39,7 @@ interface StudioBoardRow {
 
 type ReviewAction = "approve" | "reject";
 
-const STATUS_OPTIONS = ["all", "submitted", "approved", "publishing", "rejected", "published"];
+const STATUS_OPTIONS = ["all", "submitted", "approved", "publishing", "publish_failed", "rejected", "published"];
 
 const formatDate = (value?: string | null) => {
   if (!value) return "—";
@@ -170,6 +171,11 @@ export default function StudioBoardDashboardPage() {
           reviewed_at: now,
           reviewed_by: reviewer || null,
           rejection_reason: rejectionReason,
+          publish_state: action === "approve" ? null : meta.publish_state,
+          publish_failed_at: action === "approve" ? null : meta.publish_failed_at,
+          publish_failure_reason: action === "approve" ? null : meta.publish_failure_reason,
+          publish_failure_stage: action === "approve" ? null : meta.publish_failure_stage,
+          publish_failure_meta: action === "approve" ? null : meta.publish_failure_meta,
         });
 
         const payload: Partial<StudioBoardRow> = {

--- a/pmoves/ui/app/dashboard/studio-board/page.tsx
+++ b/pmoves/ui/app/dashboard/studio-board/page.tsx
@@ -19,6 +19,8 @@ interface StudioBoardRowMeta {
   reviewed_at?: string | null;
   reviewed_by?: string | null;
   publish_event_sent_at?: string | null;
+  publish_requested_at?: string | null;
+  publish_failure_reason?: string | null;
   tags?: string[];
   persona?: string;
   workflow?: string;
@@ -36,7 +38,7 @@ interface StudioBoardRow {
 
 type ReviewAction = "approve" | "reject";
 
-const STATUS_OPTIONS = ["all", "submitted", "approved", "rejected", "published"];
+const STATUS_OPTIONS = ["all", "submitted", "approved", "publishing", "rejected", "published"];
 
 const formatDate = (value?: string | null) => {
   if (!value) return "—";
@@ -385,6 +387,16 @@ export default function StudioBoardDashboardPage() {
                     {meta.publish_event_sent_at ? (
                       <div className="text-xs text-brand-subtle">
                         published @ {formatDate(meta.publish_event_sent_at)}
+                      </div>
+                    ) : null}
+                    {meta.publish_requested_at && !meta.publish_event_sent_at ? (
+                      <div className="text-xs text-brand-subtle">
+                        publish requested @ {formatDate(meta.publish_requested_at)}
+                      </div>
+                    ) : null}
+                    {meta.publish_failure_reason ? (
+                      <div className="text-xs text-brand-crimson">
+                        publish failed: {meta.publish_failure_reason}
                       </div>
                     ) : null}
                     {meta.rejection_reason ? (


### PR DESCRIPTION
Follow-up to merged #1100.

## What this does
- hardens Supabase bootstrap seed entrypoints so manual replay fails fast with actionable hints
- makes geometry swarm compatibility migration no-op safely when base tables are absent
- updates Supabase/model-registry docs to point operators at `make -C pmoves supabase-bootstrap` as the canonical path

## Why this exists
PR #1100 merged the publisher state-sync fixes, but while validating on the z890 Windows node I found older bootstrap/operator drift that can recreate confusing failures when seed SQL is replayed directly.

## Validation
- `pytest -q pmoves/services/publisher/tests/test_publisher.py`
- scratch Postgres replay confirmed:
 - `12_model_registry_seed.sql` now fails fast with bootstrap hint when prerequisites are absent
 - `17_persona_seed.sql` now fails fast with bootstrap hint when prerequisites are absent
 - `2025-10-18_geometry_swarm_compat.sql` now skips cleanly when base tables are absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented two-phase publishing state management with an intermediate "publishing" status before finalization to "published"
  * Added publish request tracking using unique identifiers across event messages
  * Enhanced publisher audit trails and metrics collection for improved visibility
  * Updated dashboard to display "publish requested" and "publish failed" statuses alongside existing states

* **Documentation**
  * Updated Supabase bootstrap and migration workflow guidance for clarity and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->