### PR TITLE
feat(voice): add TTS MCP bridge and expression registry

### DIFF
--- a/.claude/commands/tts/express.md
+++ b/.claude/commands/tts/express.md
@@ -1,0 +1,113 @@
+Expressive TTS synthesis with automatic engine selection based on intent.
+
+## Usage
+
+```
+/tts:express <text> [--intent <intent>] [--modifier <mod>] [--ref-audio <path>] [--language <lang>]
+```
+
+## Intents
+
+| Intent | Engine | What it does |
+|--------|--------|-------------|
+| `narrate` | Kokoro | Clear narration with speed control |
+| `emote` | IndexTTS2 | 8-dimensional emotion vector (happy, angry, sad, etc.) |
+| `dramatic` | Chatterbox | Theatrical delivery with exaggeration control |
+| `clone` | F5-TTS | Voice cloning from reference audio |
+| `multilingual` | Chatterbox MTL | 17-language synthesis |
+| `podcast` | VibeVoice | Multi-speaker dialogue |
+| `persona` | Qwen3 | Design a voice from text/preset |
+| `agent` | KittenTTS | Ultra-fast for CLI/agent responses |
+| `bpm_sync` | F5-TTS | Beat-synchronized for music/DJ |
+
+## Implementation
+
+1. **Load expressions registry:**
+```bash
+EXPR_FILE="pmoves/configs/tts-engine-expressions.yaml"
+```
+
+2. **Resolve intent to engine + params:**
+   - Parse `--intent` (default: `narrate`)
+   - Look up `intents.<intent>.primary` for engine ID
+   - Load `intents.<intent>.params` as base params
+   - If `--modifier` given, overlay `intents.<intent>.modifiers.<mod>` params
+   - Check `requires` — if `ref_audio` required, verify `--ref-audio` provided
+
+3. **Ensure TTS is running:**
+```bash
+# Use pterm to check/start
+pterm status Ultimate-TTS-Studio.git
+# If offline, start it
+pterm run "D:\pinokio\api\Ultimate-TTS-Studio.git"
+```
+
+4. **Select the correct engine tab in Gradio:**
+```python
+from gradio_client import Client
+client = Client("https://7860.localhost")
+
+# Switch to the target engine
+client.predict(engine_name, api_name="/handle_tts_engine_change")
+```
+
+5. **Load the engine model (if not already loaded):**
+```python
+# Each engine has a load handler: /handle_load_<engine_id>
+client.predict(api_name=f"/handle_load_{engine_id}")
+```
+
+6. **Synthesize with resolved params:**
+```python
+# Most engines use the unified endpoint
+result = client.predict(
+    text,           # input text
+    ref_audio,      # reference audio (None if not cloning)
+    ref_text,       # reference text (empty string if none)
+    *engine_params, # engine-specific params from registry
+    api_name="/generate_unified_tts"
+)
+```
+
+7. **Return result:**
+   - Audio file path from Gradio
+   - Engine used + params applied
+   - Duration and GPU metrics if available
+
+## Modifier Examples
+
+```bash
+# Happy narration
+/tts:express "Welcome to the show!" --intent emote --modifier happy
+
+# Theatrical dramatic reading
+/tts:express "To be or not to be" --intent dramatic --modifier theatrical
+
+# Voice clone with tight timing
+/tts:express "Clone test" --intent clone --modifier tight --ref-audio /path/to/voice.wav
+
+# Spanish synthesis
+/tts:express "Hola mundo" --intent multilingual --language es
+
+# Fast agent response
+/tts:express "Task complete" --intent agent
+
+# BPM-synced DJ drop
+/tts:express "Drop the bass" --intent bpm_sync --modifier fast_tempo
+```
+
+## Cross-References
+
+- **Engine registry:** `pmoves/configs/tts-engine-expressions.yaml`
+- **Engine capabilities:** `pmoves/configs/tts-engine-capabilities.yaml`
+- **Prosodic templates:** `pmoves/configs/tts-prosodic-templates.yaml`
+- **BPM encoding:** `/chit:bpm` (encode prosodic markers before synthesis)
+- **Voice status:** `/voice:status` (check Flute-Gateway + TTS health)
+- **Skill pairing:** `voice-synthesis` in `pmoves/configs/skill-pairings.yaml`
+
+## Notes
+
+- First synthesis per engine may be slow due to model loading (~10-30s)
+- GPU VRAM is shared across loaded engines — check `/gpu:status` for budget
+- 3 legacy engines (Fish S1, IndexTTS, Higgs) are accessible via manual engine selection in the Gradio UI but not mapped to intents (superseded by better versions)
+- VibeVoice podcast intent uses `/handle_vibevoice_generation`, not the unified endpoint

--- a/pmoves/configs/tts-engine-expressions.yaml
+++ b/pmoves/configs/tts-engine-expressions.yaml
@@ -1,0 +1,310 @@
+# TTS Engine Expressions Registry
+# Maps expressive synthesis intents to engine parameters.
+# Consumed by /tts:express and /tts:synthesize skills.
+#
+# Each intent selects a primary engine + default params,
+# with modifiers that overlay additional param values.
+#
+# Cross-refs:
+#   pmoves/configs/tts-engine-capabilities.yaml  (engine specs, VRAM, latency)
+#   pmoves/configs/tts-prosodic-templates.yaml   (prosodic text patterns)
+#   .claude/commands/tts/express.md              (skill definition)
+#   .claude/commands/chit/bpm.md                 (BPM encoding for beat-sync)
+
+version: "1.0.0"
+last_updated: "2026-03-22"
+description: >
+  Maps 9 expressive synthesis intents to 14 TTS engines.
+  Each intent has a primary engine, default params, optional modifiers,
+  and fallback engines. The /tts:express skill reads this file to
+  auto-select the right engine based on user intent.
+
+# ─────────────────────────────────────────────────────────────────────
+# Gradio API: all engines except VibeVoice use /generate_unified_tts
+# VibeVoice uses /handle_vibevoice_generation (separate endpoint)
+# ─────────────────────────────────────────────────────────────────────
+
+intents:
+
+  # ───────────────────────────────────────────────────────────────────
+  # NARRATE: Clear narration with pace control
+  # ───────────────────────────────────────────────────────────────────
+  narrate:
+    description: "Clear narration with pace control"
+    primary: kokoro
+    gradio_endpoint: /generate_unified_tts
+    params:
+      kokoro_voice: af_heart
+      kokoro_speed: 1.0
+    modifiers:
+      fast:
+        kokoro_speed: 1.4
+      slow:
+        kokoro_speed: 0.7
+      warm:
+        kokoro_voice: af_sarah
+      male:
+        kokoro_voice: am_adam
+    fallback: kitten_tts
+    fallback_params:
+      kitten_voice: expr-voice-2-f
+
+  # ───────────────────────────────────────────────────────────────────
+  # EMOTE: Emotion-driven synthesis (8-dimensional vector)
+  # ───────────────────────────────────────────────────────────────────
+  emote:
+    description: "Emotion-driven synthesis via 8-dimensional vector"
+    primary: indextts2
+    gradio_endpoint: /generate_unified_tts
+    params:
+      indextts2_emotion_mode: vector_control
+      indextts2_calm: 1.0
+      indextts2_happy: 0.0
+      indextts2_angry: 0.0
+      indextts2_sad: 0.0
+      indextts2_afraid: 0.0
+      indextts2_disgusted: 0.0
+      indextts2_melancholic: 0.0
+      indextts2_surprised: 0.0
+      indextts2_emo_alpha: 1.0
+      indextts2_temperature: 0.8
+    modifiers:
+      happy:
+        indextts2_happy: 0.8
+        indextts2_calm: 0.2
+      angry:
+        indextts2_angry: 0.8
+        indextts2_calm: 0.0
+      sad:
+        indextts2_sad: 0.7
+        indextts2_melancholic: 0.5
+        indextts2_calm: 0.1
+      afraid:
+        indextts2_afraid: 0.7
+        indextts2_calm: 0.1
+      surprised:
+        indextts2_surprised: 0.9
+        indextts2_calm: 0.1
+      melancholic:
+        indextts2_melancholic: 0.8
+        indextts2_sad: 0.3
+        indextts2_calm: 0.1
+      disgusted:
+        indextts2_disgusted: 0.7
+        indextts2_calm: 0.1
+      intense:
+        indextts2_emo_alpha: 1.0
+        indextts2_temperature: 1.2
+      subtle:
+        indextts2_emo_alpha: 0.4
+        indextts2_temperature: 0.6
+    requires: [ref_audio]
+    fallback: chatterbox
+    fallback_params:
+      chatterbox_exaggeration: 0.7
+      chatterbox_temperature: 0.9
+
+  # ───────────────────────────────────────────────────────────────────
+  # DRAMATIC: Theatrical/expressive delivery via exaggeration
+  # ───────────────────────────────────────────────────────────────────
+  dramatic:
+    description: "Theatrical delivery with exaggeration control"
+    primary: chatterbox
+    gradio_endpoint: /generate_unified_tts
+    params:
+      chatterbox_exaggeration: 0.7
+      chatterbox_temperature: 0.9
+      chatterbox_cfg_weight: 0.5
+    modifiers:
+      subtle:
+        chatterbox_exaggeration: 0.3
+        chatterbox_temperature: 0.7
+      theatrical:
+        chatterbox_exaggeration: 0.9
+        chatterbox_temperature: 1.0
+      over_the_top:
+        chatterbox_exaggeration: 1.0
+        chatterbox_temperature: 1.2
+      flat:
+        chatterbox_exaggeration: 0.0
+        chatterbox_temperature: 0.5
+    fallback: chatterbox_turbo
+    fallback_params:
+      chatterbox_turbo_exaggeration: 0.7
+      chatterbox_turbo_temperature: 0.9
+
+  # ───────────────────────────────────────────────────────────────────
+  # CLONE: Voice cloning from reference audio
+  # ───────────────────────────────────────────────────────────────────
+  clone:
+    description: "Voice cloning from reference audio"
+    primary: f5_tts
+    gradio_endpoint: /generate_unified_tts
+    params:
+      f5_speed: 1.0
+      f5_cross_fade: 0.15
+      f5_remove_silence: false
+    modifiers:
+      fast:
+        f5_speed: 1.3
+      slow:
+        f5_speed: 0.8
+      tight:
+        f5_cross_fade: 0.05
+        f5_remove_silence: true
+    requires: [ref_audio]
+    fallback: fish_s2
+    fallback_params:
+      fish_s2_temperature: 0.8
+      fish_s2_top_p: 0.8
+      fish_s2_repetition_penalty: 1.1
+
+  # ───────────────────────────────────────────────────────────────────
+  # MULTILINGUAL: Multi-language synthesis (17 languages max)
+  # ───────────────────────────────────────────────────────────────────
+  multilingual:
+    description: "Multi-language synthesis (up to 17 languages)"
+    primary: chatterbox_multilingual
+    gradio_endpoint: /generate_unified_tts
+    params:
+      chatterbox_mtl_language: en
+      chatterbox_mtl_exaggeration: 0.5
+      chatterbox_mtl_temperature: 0.8
+      chatterbox_mtl_cfg_weight: 0.5
+    modifiers:
+      expressive:
+        chatterbox_mtl_exaggeration: 0.8
+        chatterbox_mtl_temperature: 1.0
+      neutral:
+        chatterbox_mtl_exaggeration: 0.2
+        chatterbox_mtl_temperature: 0.6
+    requires: [language]
+    supported_languages:
+      - en
+      - es
+      - fr
+      - de
+      - it
+      - pt
+      - pl
+      - tr
+      - ru
+      - nl
+      - cs
+      - ar
+      - zh
+      - ja
+      - hu
+      - ko
+      - hi
+    fallback: fish_s2
+    fallback_languages: [en, zh, ja, ko, fr, de, ar, es, pt, it, th, vi, ru]
+
+  # ───────────────────────────────────────────────────────────────────
+  # PODCAST: Multi-speaker dialogue generation
+  # ───────────────────────────────────────────────────────────────────
+  podcast:
+    description: "Multi-speaker dialogue/podcast generation"
+    primary: vibevoice
+    gradio_endpoint: /handle_vibevoice_generation
+    params: {}
+    requires: [speakers_config, podcast_script]
+    notes: >
+      VibeVoice uses a separate endpoint, not /generate_unified_tts.
+      Each speaker is configured independently with ref audio.
+      Also available as standalone vibevoice-realtime.git (WebSocket streaming).
+
+  # ───────────────────────────────────────────────────────────────────
+  # PERSONA: Design a voice from text description
+  # ───────────────────────────────────────────────────────────────────
+  persona:
+    description: "Design a voice persona from text or preset"
+    primary: qwen
+    gradio_endpoint: /generate_unified_tts
+    params:
+      qwen_mode: voice_design
+      qwen_speaker: Ryan
+      qwen_language: Auto
+      qwen_chunk_size: 200
+    modifiers:
+      female:
+        qwen_speaker: Anna
+      mature_female:
+        qwen_speaker: Sarah
+      young_female:
+        qwen_speaker: Emily
+      male:
+        qwen_speaker: Ryan
+      deep_male:
+        qwen_speaker: Ethan
+    notes: >
+      Qwen3 also supports voice_clone mode (requires ref_audio).
+      Standalone Qwen3-TTS-Pinokio.git has VoiceDesign mode with
+      text-to-voice-persona creation (not available in Ultimate-TTS).
+
+  # ───────────────────────────────────────────────────────────────────
+  # AGENT: Low-latency agent/CLI voice
+  # ───────────────────────────────────────────────────────────────────
+  agent:
+    description: "Ultra-fast synthesis for agent/CLI voice responses"
+    primary: kitten_tts
+    gradio_endpoint: /generate_unified_tts
+    params:
+      kitten_voice: expr-voice-2-f
+    modifiers:
+      male:
+        kitten_voice: expr-voice-2-m
+      deep:
+        kitten_voice: expr-voice-4-m
+      bright:
+        kitten_voice: expr-voice-3-f
+    fallback: kokoro
+    fallback_params:
+      kokoro_voice: af_heart
+      kokoro_speed: 1.1
+    notes: >
+      KittenTTS has ~500MB VRAM and ultra-fast latency.
+      Ideal for real-time agent responses where speed > quality.
+
+  # ───────────────────────────────────────────────────────────────────
+  # BPM_SYNC: Beat-synchronized synthesis for music/DJ
+  # ───────────────────────────────────────────────────────────────────
+  bpm_sync:
+    description: "Beat-synchronized synthesis for music/DJ workflows"
+    primary: f5_tts
+    gradio_endpoint: /generate_unified_tts
+    params:
+      f5_speed: 1.0
+      f5_cross_fade: 0.1
+      f5_remove_silence: true
+    modifiers:
+      fast_tempo:
+        f5_speed: 1.4
+        f5_cross_fade: 0.05
+      slow_groove:
+        f5_speed: 0.75
+        f5_cross_fade: 0.2
+    cross_ref: "chit:bpm"
+    fallback: kokoro
+    fallback_params:
+      kokoro_speed: 1.0
+    notes: >
+      Use /chit:bpm to encode prosodic BPM markers into text first,
+      then synthesize with this intent. F5-TTS speed + cross_fade
+      control enables precise beat alignment.
+
+# ─────────────────────────────────────────────────────────────────────
+# Engine Coverage Summary
+# ─────────────────────────────────────────────────────────────────────
+# Primary engines used:  9 of 14
+# Fallback engines used: 4 of 14
+# Total coverage:       11 of 14
+#
+# Engines NOT directly mapped (accessible via manual engine selection):
+#   - higgs:     Use temperature-control intent or select manually
+#   - fish:      Superseded by fish_s2 (more languages, same params)
+#   - indextts:  Superseded by indextts2 (adds emotion vectors)
+#
+# These 3 remain available in Ultimate-TTS-Studio UI for manual use.
+# They're not mapped to intents because their successors cover all
+# use cases with strictly more capabilities.

--- a/pmoves/services/flute-gateway/mcp_bridge.py
+++ b/pmoves/services/flute-gateway/mcp_bridge.py
@@ -1,0 +1,538 @@
+"""MCP SSE transport bridge for Flute-Gateway TTS engine access.
+
+Exposes 14 TTS engines as MCP tools via Server-Sent Events transport.
+No external MCP SDK dependency — implements the protocol directly using
+FastAPI's StreamingResponse.
+
+MCP Protocol (SSE transport):
+    GET  /sse      → SSE stream, first event: endpoint URL for messages
+    POST /messages → JSON-RPC messages (initialize, tools/list, tools/call)
+
+Tools exposed:
+    tts_list_engines   — List all 14 engines with VRAM, latency, categories
+    tts_list_intents   — List 9 expressive synthesis intents
+    tts_synthesize     — Synthesize speech with engine + intent selection
+    tts_engine_status  — Per-engine loaded/unloaded status
+    tts_load_engine    — Load specific engine into VRAM
+    tts_unload_engine  — Unload specific engine to free VRAM
+
+Cross-refs:
+    pmoves/configs/tts-engine-capabilities.yaml  (engine specs)
+    pmoves/configs/tts-engine-expressions.yaml   (intent→engine mapping)
+    pmoves/docs/AGENTS/AGNOTE4482.BEATS.md       (BPM↔boundary architecture)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config paths — resolve relative to repo root
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[3]  # pmoves/services/flute-gateway → repo root
+_CAPABILITIES_PATH = _REPO_ROOT / "pmoves" / "configs" / "tts-engine-capabilities.yaml"
+_EXPRESSIONS_PATH = _REPO_ROOT / "pmoves" / "configs" / "tts-engine-expressions.yaml"
+
+# Engine endpoints — same as gpu-orchestrator/services/tts_client.py
+ENGINE_ENDPOINTS: dict[str, tuple[str, str]] = {
+    "kitten_tts": ("/handle_load_kitten", "/handle_unload_kitten"),
+    "kokoro": ("/handle_load_kokoro", "/handle_unload_kokoro"),
+    "f5_tts": ("/handle_f5_load", "/handle_f5_unload"),
+    "indextts": ("/handle_load_indextts", "/handle_unload_indextts"),
+    "indextts2": ("/handle_load_indextts2", "/handle_unload_indextts2"),
+    "fish": ("/handle_load_fish", "/handle_unload_fish"),
+    "fish_s2": ("/handle_load_fish_s2", "/handle_unload_fish_s2"),
+    "chatterbox": ("/handle_load_chatterbox", "/handle_unload_chatterbox"),
+    "chatterbox_turbo": ("/handle_load_chatterbox_turbo", "/handle_unload_chatterbox_turbo"),
+    "chatterbox_multilingual": ("/handle_load_chatterbox_multilingual", "/handle_unload_chatterbox_multilingual"),
+    "voxcpm": ("/handle_load_voxcpm", "/handle_unload_voxcpm"),
+    "higgs": ("/handle_load_higgs", "/handle_unload_higgs"),
+    "qwen": ("/handle_load_qwen", "/handle_unload_qwen"),
+    "vibevoice": ("/handle_vibevoice_load", "/handle_vibevoice_unload"),
+}
+
+# BPM ↔ Boundary mapping (from AGNOTE4482.BEATS.md)
+BOUNDARY_BPM: dict[str, dict[str, Any]] = {
+    "SENTENCE": {"bpm": 60, "pause_ms": 350, "root_note": "C4", "root_hz": 262},
+    "CLAUSE": {"bpm": 90, "pause_ms": 180, "root_note": "E4", "root_hz": 330},
+    "PHRASE": {"bpm": 120, "pause_ms": 100, "root_note": "G4", "root_hz": 392},
+    "BREATH": {"bpm": 80, "pause_ms": 130, "root_note": "D4", "root_hz": 294},
+    "NONE": {"bpm": 150, "pause_ms": 0, "root_note": "C5", "root_hz": 523},
+}
+
+
+# ---------------------------------------------------------------------------
+# YAML config loaders (lazy, cached)
+# ---------------------------------------------------------------------------
+_capabilities_cache: dict | None = None
+_expressions_cache: dict | None = None
+
+
+def _load_capabilities() -> dict:
+    """Load engine capabilities YAML, cached after first read."""
+    global _capabilities_cache
+    if _capabilities_cache is None:
+        if _CAPABILITIES_PATH.exists():
+            with open(_CAPABILITIES_PATH) as f:
+                _capabilities_cache = yaml.safe_load(f) or {}
+        else:
+            logger.warning("Engine capabilities not found: %s", _CAPABILITIES_PATH)
+            _capabilities_cache = {}
+    return _capabilities_cache
+
+
+def _load_expressions() -> dict:
+    """Load intent expressions YAML, cached after first read."""
+    global _expressions_cache
+    if _expressions_cache is None:
+        if _EXPRESSIONS_PATH.exists():
+            with open(_EXPRESSIONS_PATH) as f:
+                _expressions_cache = yaml.safe_load(f) or {}
+        else:
+            logger.warning("Engine expressions not found: %s", _EXPRESSIONS_PATH)
+            _expressions_cache = {}
+    return _expressions_cache
+
+
+# ---------------------------------------------------------------------------
+# MCP Tool definitions (JSON Schema for each tool)
+# ---------------------------------------------------------------------------
+MCP_TOOLS = [
+    {
+        "name": "tts_list_engines",
+        "description": "List all 14 TTS engines with VRAM requirements, latency tier, category, and supported features.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "tts_list_intents",
+        "description": "List 9 expressive synthesis intents (narrate, emote, dramatic, clone, multilingual, podcast, persona, agent, bpm_sync) with primary/fallback engines and available modifiers.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "tts_synthesize",
+        "description": "Synthesize speech using a specific engine or intent. Returns audio as base64 WAV.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string", "description": "Text to synthesize"},
+                "engine": {"type": "string", "description": "Engine ID (e.g., kitten_tts, kokoro, f5_tts). If omitted, uses intent to select."},
+                "intent": {"type": "string", "description": "Expressive intent (narrate, emote, dramatic, clone, multilingual, podcast, persona, agent, bpm_sync). Used if engine not specified."},
+                "modifier": {"type": "string", "description": "Intent modifier (e.g., happy, fast, theatrical). Overlays params on the intent defaults."},
+                "voice": {"type": "string", "description": "Voice preset name (engine-specific)."},
+            },
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "tts_engine_status",
+        "description": "Check which TTS engines are available and their load status via the Gradio API.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "tts_load_engine",
+        "description": "Load a specific TTS engine into GPU VRAM. Only one heavy engine should be loaded at a time.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "engine": {"type": "string", "description": "Engine ID to load (e.g., kitten_tts, kokoro, indextts2)"},
+            },
+            "required": ["engine"],
+        },
+    },
+    {
+        "name": "tts_unload_engine",
+        "description": "Unload a TTS engine from GPU VRAM (del model + gc.collect + torch.cuda.empty_cache).",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "engine": {"type": "string", "description": "Engine ID to unload"},
+            },
+            "required": ["engine"],
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+async def _tool_list_engines(
+    _args: dict,
+    provider: Any,
+) -> dict:
+    """Return engine registry from capabilities YAML."""
+    caps = _load_capabilities()
+    engines = caps.get("engines", {})
+    summary = {}
+    for eid, spec in engines.items():
+        summary[eid] = {
+            "name": spec.get("name", eid),
+            "category": spec.get("category", "unknown"),
+            "vram_mb": spec.get("vram_mb", 0),
+            "latency": spec.get("latency", "unknown"),
+            "voice_cloning": spec.get("voice_cloning", False),
+            "languages": spec.get("languages", []),
+        }
+    return {"engines": summary, "total": len(summary)}
+
+
+async def _tool_list_intents(
+    _args: dict,
+    provider: Any,
+) -> dict:
+    """Return intent→engine mapping from expressions YAML."""
+    expr = _load_expressions()
+    intents = expr.get("intents", {})
+    summary = {}
+    for iid, spec in intents.items():
+        summary[iid] = {
+            "description": spec.get("description", ""),
+            "primary_engine": spec.get("primary", ""),
+            "fallback_engine": spec.get("fallback", ""),
+            "modifiers": list(spec.get("modifiers", {}).keys()),
+            "requires": spec.get("requires", []),
+            "gradio_endpoint": spec.get("gradio_endpoint", "/generate_unified_tts"),
+        }
+    return {
+        "intents": summary,
+        "total": len(summary),
+        "boundary_bpm_mapping": BOUNDARY_BPM,
+    }
+
+
+async def _tool_synthesize(
+    args: dict,
+    provider: Any,
+) -> dict:
+    """Synthesize speech via UltimateTTSProvider."""
+    text = args.get("text", "")
+    if not text:
+        return {"error": "text is required"}
+
+    engine = args.get("engine")
+    intent = args.get("intent")
+    modifier = args.get("modifier")
+    voice = args.get("voice")
+
+    # Resolve engine from intent if not specified
+    if not engine and intent:
+        expr = _load_expressions()
+        intent_spec = expr.get("intents", {}).get(intent)
+        if intent_spec:
+            engine = intent_spec.get("primary")
+        else:
+            return {"error": f"Unknown intent: {intent}"}
+
+    engine = engine or "kitten_tts"
+
+    if engine not in ENGINE_ENDPOINTS:
+        return {"error": f"Unknown engine: {engine}", "available": list(ENGINE_ENDPOINTS.keys())}
+
+    if provider is None:
+        return {"error": "UltimateTTSProvider not available (TTS Studio offline?)"}
+
+    import base64
+    try:
+        audio_bytes = await provider.synthesize(
+            text=text,
+            voice=voice,
+            engine=engine,
+        )
+        audio_b64 = base64.b64encode(audio_bytes).decode("ascii")
+        return {
+            "engine": engine,
+            "intent": intent,
+            "modifier": modifier,
+            "text_length": len(text),
+            "audio_bytes": len(audio_bytes),
+            "audio_base64": audio_b64[:100] + "..." if len(audio_b64) > 100 else audio_b64,
+            "format": "wav",
+            "status": "ok",
+        }
+    except Exception as e:
+        return {"error": str(e), "engine": engine}
+
+
+async def _tool_engine_status(
+    _args: dict,
+    provider: Any,
+) -> dict:
+    """Check engine availability via Gradio API."""
+    if provider is None:
+        return {"error": "UltimateTTSProvider not available"}
+
+    try:
+        engines = await provider.get_engines()
+        return {"engines": engines, "provider_healthy": True}
+    except Exception as e:
+        return {"error": str(e), "provider_healthy": False}
+
+
+async def _tool_load_engine(
+    args: dict,
+    provider: Any,
+) -> dict:
+    """Load a TTS engine into VRAM."""
+    engine = args.get("engine", "")
+    if engine not in ENGINE_ENDPOINTS:
+        return {"error": f"Unknown engine: {engine}", "available": list(ENGINE_ENDPOINTS.keys())}
+
+    if provider is None:
+        return {"error": "UltimateTTSProvider not available"}
+
+    load_ep, _ = ENGINE_ENDPOINTS[engine]
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(
+                f"{provider.base_url}/api{load_ep}",
+                json={"data": []},
+            )
+            result = resp.json()
+            return {"engine": engine, "endpoint": load_ep, "result": result, "status": "loaded"}
+    except Exception as e:
+        return {"error": str(e), "engine": engine}
+
+
+async def _tool_unload_engine(
+    args: dict,
+    provider: Any,
+) -> dict:
+    """Unload a TTS engine from VRAM."""
+    engine = args.get("engine", "")
+    if engine not in ENGINE_ENDPOINTS:
+        return {"error": f"Unknown engine: {engine}", "available": list(ENGINE_ENDPOINTS.keys())}
+
+    if provider is None:
+        return {"error": "UltimateTTSProvider not available"}
+
+    _, unload_ep = ENGINE_ENDPOINTS[engine]
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                f"{provider.base_url}/api{unload_ep}",
+                json={"data": []},
+            )
+            result = resp.json()
+            return {"engine": engine, "endpoint": unload_ep, "result": result, "status": "unloaded"}
+    except Exception as e:
+        return {"error": str(e), "engine": engine}
+
+
+# Tool dispatch table
+_TOOL_HANDLERS = {
+    "tts_list_engines": _tool_list_engines,
+    "tts_list_intents": _tool_list_intents,
+    "tts_synthesize": _tool_synthesize,
+    "tts_engine_status": _tool_engine_status,
+    "tts_load_engine": _tool_load_engine,
+    "tts_unload_engine": _tool_unload_engine,
+}
+
+
+# ---------------------------------------------------------------------------
+# MCP SSE Transport
+# ---------------------------------------------------------------------------
+
+class MCPSession:
+    """Tracks a single MCP client session with its SSE queue."""
+
+    def __init__(self, session_id: str, provider: Any, nats_client: Any = None):
+        self.session_id = session_id
+        self.provider = provider
+        self.nats_client = nats_client
+        self.queue: asyncio.Queue[str] = asyncio.Queue()
+        self.initialized = False
+
+    async def handle_message(self, message: dict) -> None:
+        """Process a JSON-RPC message and enqueue the response."""
+        method = message.get("method", "")
+        msg_id = message.get("id")
+        params = message.get("params", {})
+
+        if method == "initialize":
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {
+                        "name": "pmoves-flute-gateway",
+                        "version": "1.0.0",
+                    },
+                },
+            }
+            self.initialized = True
+
+        elif method == "notifications/initialized":
+            # Client acknowledgement — no response needed
+            return
+
+        elif method == "tools/list":
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"tools": MCP_TOOLS},
+            }
+
+        elif method == "tools/call":
+            tool_name = params.get("name", "")
+            tool_args = params.get("arguments", {})
+            handler = _TOOL_HANDLERS.get(tool_name)
+
+            if handler is None:
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
+                }
+            else:
+                try:
+                    result = await handler(tool_args, self.provider)
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": msg_id,
+                        "result": {
+                            "content": [{"type": "text", "text": json.dumps(result, default=str)}],
+                        },
+                    }
+                    # Publish NATS event for synthesis calls
+                    if tool_name == "tts_synthesize" and self.nats_client and "error" not in result:
+                        await self._publish_tts_event(tool_name, tool_args, result)
+                except Exception as e:
+                    logger.exception("Tool %s failed", tool_name)
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": msg_id,
+                        "error": {"code": -32603, "message": str(e)},
+                    }
+
+        elif method == "ping":
+            response = {"jsonrpc": "2.0", "id": msg_id, "result": {}}
+
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"},
+            }
+
+        await self.queue.put(json.dumps(response))
+
+    async def _publish_tts_event(self, tool: str, args: dict, result: dict) -> None:
+        """Publish TTS synthesis event to NATS."""
+        try:
+            payload = {
+                "tool": tool,
+                "engine": result.get("engine", ""),
+                "text_length": result.get("text_length", 0),
+                "audio_bytes": result.get("audio_bytes", 0),
+                "intent": args.get("intent", ""),
+                "status": result.get("status", ""),
+            }
+            await self.nats_client.publish(
+                "tts.synthesis.result.v1",
+                json.dumps(payload).encode("utf-8"),
+            )
+        except Exception as e:
+            logger.warning("Failed to publish TTS NATS event: %s", e)
+
+
+# Active sessions
+_sessions: dict[str, MCPSession] = {}
+
+
+def create_mcp_router(
+    get_provider: Any,
+    get_nats_client: Any,
+) -> APIRouter:
+    """Create FastAPI router with MCP SSE endpoints.
+
+    Args:
+        get_provider: Callable returning the UltimateTTSProvider instance (or None).
+        get_nats_client: Callable returning the NATS client instance (or None).
+
+    Returns:
+        APIRouter with /sse and /messages endpoints mounted.
+    """
+    router = APIRouter()
+
+    @router.get("/sse")
+    async def sse_endpoint(request: Request):
+        """SSE stream endpoint — MCP clients connect here."""
+        session_id = str(uuid.uuid4())
+        provider = get_provider()
+        nats = get_nats_client()
+        session = MCPSession(session_id, provider, nats)
+        _sessions[session_id] = session
+
+        logger.info("MCP session started: %s", session_id)
+
+        async def event_stream():
+            # First event: tell client where to send messages
+            yield f"event: endpoint\ndata: /messages?session_id={session_id}\n\n"
+
+            try:
+                while True:
+                    if await request.is_disconnected():
+                        break
+                    try:
+                        msg = await asyncio.wait_for(session.queue.get(), timeout=30.0)
+                        yield f"event: message\ndata: {msg}\n\n"
+                    except asyncio.TimeoutError:
+                        # Send keepalive comment
+                        yield ": keepalive\n\n"
+            finally:
+                _sessions.pop(session_id, None)
+                logger.info("MCP session ended: %s", session_id)
+
+        return StreamingResponse(
+            event_stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @router.post("/messages")
+    async def messages_endpoint(request: Request, session_id: str):
+        """Receive JSON-RPC messages from MCP clients."""
+        session = _sessions.get(session_id)
+        if session is None:
+            from fastapi.responses import JSONResponse
+            return JSONResponse(
+                status_code=404,
+                content={"error": f"Session not found: {session_id}"},
+            )
+
+        body = await request.json()
+        await session.handle_message(body)
+        return {"ok": True}
+
+    return router

--- a/pmoves/tools/_check_higgs_params.py
+++ b/pmoves/tools/_check_higgs_params.py
@@ -1,0 +1,29 @@
+"""Diagnostic: check Gradio API param spec for Higgs Audio fields."""
+import json
+import urllib.request
+import sys
+
+resp = urllib.request.urlopen("http://127.0.0.1:7860/gradio_api/info")
+info = json.loads(resp.read())
+endpoint = info.get("named_endpoints", {}).get("/generate_unified_tts", {})
+params = endpoint.get("parameters", [])
+
+print(f"Total params: {len(params)}")
+print()
+
+# Show full spec for positions 75-80 (Higgs range)
+for i in range(75, 81):
+    p = params[i]
+    print(f"[{i}] parameter_name={p.get('parameter_name', 'N/A')}")
+    print(f"    label={p.get('label', 'N/A')}")
+    print(f"    python_type={p.get('python_type', {}).get('type', '?')}")
+    print(f"    parameter_default={p.get('parameter_default', 'NO_DEFAULT')}")
+    print(f"    component={p.get('component', 'N/A')}")
+    print()
+
+# Also check what gradio_client.predict actually maps
+print("--- All params with 'higgs' in parameter_name ---")
+for i, p in enumerate(params):
+    name = p.get("parameter_name", "")
+    if "higgs" in name.lower():
+        print(f"[{i}] parameter_name={name}, label={p.get('label', '')}")

--- a/pmoves/tools/_test_fish_s2_direct.py
+++ b/pmoves/tools/_test_fish_s2_direct.py
@@ -1,0 +1,102 @@
+"""Direct Gradio HTTP test for Fish S2 Pro — setup, load, synth, unload."""
+import json
+import urllib.request
+import sys
+import time
+
+BASE = "http://127.0.0.1:7860"
+
+
+def call_gradio(endpoint, data=None, timeout=300):
+    """Call Gradio event API and wait for result."""
+    if data is None:
+        data = []
+    req = urllib.request.Request(
+        f"{BASE}/gradio_api/call{endpoint}",
+        data=json.dumps({"data": data}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    resp = urllib.request.urlopen(req, timeout=30)
+    event_id = json.loads(resp.read()).get("event_id")
+
+    sse_resp = urllib.request.urlopen(
+        f"{BASE}/gradio_api/call{endpoint}/{event_id}", timeout=timeout
+    )
+    current_event = ""
+    result = None
+    for raw_line in sse_resp:
+        line = raw_line.decode("utf-8", errors="replace").strip()
+        if line.startswith("event:"):
+            current_event = line[6:].strip()
+        elif line.startswith("data:"):
+            raw_data = line[5:].strip()
+            if current_event == "complete":
+                result = json.loads(raw_data)
+                return True, result
+            elif current_event == "error":
+                return False, raw_data
+    return False, "stream ended"
+
+
+# Fetch defaults
+print("Fetching API defaults...")
+resp = urllib.request.urlopen(f"{BASE}/gradio_api/info")
+info = json.loads(resp.read())
+params = info["named_endpoints"]["/generate_unified_tts"]["parameters"]
+data = []
+for p in params:
+    default = p.get("parameter_default")
+    if default is not None:
+        data.append(default)
+    else:
+        ptype = p.get("python_type", {}).get("type", "str")
+        component = p.get("component", "")
+        if component == "Audio" or "filepath" in ptype:
+            data.append(None)
+        elif "float" in ptype or "int" in ptype:
+            data.append(0)
+        elif "bool" in ptype:
+            data.append(False)
+        else:
+            data.append("")
+
+data[0] = "Hello, this is a Fish Speech S2 Pro test from the production path."
+data[1] = "Fish Speech S2 Pro"
+data[2] = "wav"
+
+# Step 1: Setup (repo clone + weights)
+print("\n1. Setup (repo + weights)...")
+t0 = time.time()
+ok, result = call_gradio("/handle_setup_fish_s2", timeout=600)
+print(f"   {'OK' if ok else 'FAIL'} ({time.time()-t0:.1f}s): {str(result)[:200]}")
+if not ok:
+    print("Setup failed, exiting")
+    sys.exit(1)
+
+# Step 2: Load model
+print("\n2. Loading model...")
+t0 = time.time()
+ok, result = call_gradio("/handle_load_fish_s2", timeout=120)
+print(f"   {'OK' if ok else 'FAIL'} ({time.time()-t0:.1f}s): {str(result)[:200]}")
+if not ok:
+    print("Load failed, exiting")
+    sys.exit(1)
+
+# Step 3: Synthesize
+print("\n3. Synthesizing...")
+t0 = time.time()
+ok, result = call_gradio("/generate_unified_tts", data, timeout=300)
+print(f"   {'OK' if ok else 'FAIL'} ({time.time()-t0:.1f}s)")
+if ok and isinstance(result, list) and len(result) >= 2:
+    print(f"   Audio: {str(result[0])[:200]}")
+    print(f"   Status: {result[1]}")
+else:
+    print(f"   Result: {str(result)[:300]}")
+
+# Step 4: Unload
+print("\n4. Unloading...")
+t0 = time.time()
+ok, result = call_gradio("/handle_unload_fish_s2", timeout=60)
+print(f"   {'OK' if ok else 'FAIL'} ({time.time()-t0:.1f}s)")
+
+print("\nDone!")

--- a/pmoves/tools/_test_higgs_defaults.py
+++ b/pmoves/tools/_test_higgs_defaults.py
@@ -1,0 +1,75 @@
+"""Fetch all 121 parameter defaults from Gradio API and test Higgs with proper defaults."""
+import json
+import urllib.request
+import sys
+import time
+
+BASE = "http://127.0.0.1:7860"
+
+# Fetch API info
+resp = urllib.request.urlopen(f"{BASE}/gradio_api/info")
+info = json.loads(resp.read())
+endpoint = info.get("named_endpoints", {}).get("/generate_unified_tts", {})
+params = endpoint.get("parameters", [])
+
+print(f"Total params: {len(params)}")
+
+# Build array with ALL defaults filled in
+data = []
+none_positions = []
+for i, p in enumerate(params):
+    default = p.get("parameter_default")
+    data.append(default)
+    if default is None:
+        none_positions.append(i)
+
+print(f"Params with None default: {none_positions}")
+print()
+
+# Override core + Higgs params
+data[0] = "Hello, this is a Higgs Audio test."  # text_input
+data[1] = "Higgs Audio"  # tts_engine
+data[2] = "wav"  # audio_format
+
+# Show what positions 73-82 look like with defaults
+print("Higgs positions (73-82) with API defaults:")
+for i in range(73, 83):
+    p = params[i]
+    print(f"  [{i}] {p.get('parameter_name','?')} = {repr(data[i])}")
+
+print()
+print(f"Position 76 (system_prompt) = {repr(data[76])}")
+print()
+
+# Submit with all defaults
+print("Submitting with ALL defaults filled...")
+req = urllib.request.Request(
+    f"{BASE}/gradio_api/call/generate_unified_tts",
+    data=json.dumps({"data": data}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+t0 = time.time()
+resp = urllib.request.urlopen(req, timeout=30)
+submit_data = json.loads(resp.read())
+event_id = submit_data.get("event_id")
+print(f"Event ID: {event_id} ({time.time()-t0:.1f}s)")
+
+# Stream SSE
+print("Streaming SSE response...")
+sse_url = f"{BASE}/gradio_api/call/generate_unified_tts/{event_id}"
+sse_resp = urllib.request.urlopen(sse_url, timeout=240)
+
+current_event = ""
+for raw_line in sse_resp:
+    line = raw_line.decode("utf-8", errors="replace").rstrip("\\n\\r")
+    if line.startswith("event:"):
+        current_event = line[6:].strip()
+    elif line.startswith("data:"):
+        raw_data = line[5:].strip()
+        print(f"  [{current_event}] {raw_data[:300]}")
+        if current_event == "complete":
+            print(f"\\nSUCCESS in {time.time()-t0:.1f}s")
+            sys.exit(0)
+        elif current_event == "error":
+            print(f"\\nERROR in {time.time()-t0:.1f}s")
+            sys.exit(1)

--- a/pmoves/tools/_test_higgs_direct.py
+++ b/pmoves/tools/_test_higgs_direct.py
@@ -1,0 +1,65 @@
+"""Direct Gradio HTTP test for Higgs Audio — mirrors production provider path."""
+import json
+import urllib.request
+import sys
+import time
+
+BASE = "http://127.0.0.1:7860"
+
+# Build 121-element array matching _build_params() in ultimate_tts.py
+data = [None] * 121
+data[0] = "Hello, this is a Higgs Audio test."  # text_input
+data[1] = "Higgs Audio"  # tts_engine
+data[2] = "wav"  # audio_format
+data[75] = "EMPTY"  # higgs_voice_preset
+data[76] = ""  # higgs_system_prompt (empty string, NOT None)
+data[77] = 1.0  # higgs_temperature
+data[78] = 0.95  # higgs_top_p
+data[79] = 50  # higgs_top_k
+data[80] = 1024  # higgs_max_tokens
+data[81] = 7  # higgs_ras_win_len
+data[82] = 2  # higgs_ras_win_max_num_repeat
+
+print(f"Position 76 value: {repr(data[76])}")
+print(f"Position 76 type: {type(data[76])}")
+print()
+
+# Step 1: Submit
+print("Submitting to Gradio API...")
+req = urllib.request.Request(
+    f"{BASE}/gradio_api/call/generate_unified_tts",
+    data=json.dumps({"data": data}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+t0 = time.time()
+resp = urllib.request.urlopen(req, timeout=30)
+submit_data = json.loads(resp.read())
+event_id = submit_data.get("event_id")
+print(f"Event ID: {event_id} ({time.time()-t0:.1f}s)")
+
+# Step 2: Stream SSE
+print("Streaming SSE response...")
+sse_url = f"{BASE}/gradio_api/call/generate_unified_tts/{event_id}"
+sse_resp = urllib.request.urlopen(sse_url, timeout=240)
+
+current_event = ""
+for raw_line in sse_resp:
+    line = raw_line.decode("utf-8", errors="replace").rstrip("\n\r")
+    if line.startswith("event:"):
+        current_event = line[6:].strip()
+    elif line.startswith("data:"):
+        raw_data = line[5:].strip()
+        print(f"  [{current_event}] {raw_data[:300]}")
+        if current_event == "complete":
+            print(f"\nSUCCESS in {time.time()-t0:.1f}s")
+            result = json.loads(raw_data)
+            print(f"Result type: {type(result)}")
+            if isinstance(result, list) and len(result) >= 2:
+                print(f"Audio info: {str(result[0])[:200]}")
+                print(f"Status: {result[1]}")
+            sys.exit(0)
+        elif current_event == "error":
+            print(f"\nERROR in {time.time()-t0:.1f}s: {raw_data}")
+            sys.exit(1)
+
+print(f"Stream ended without complete/error event ({time.time()-t0:.1f}s)")

--- a/pmoves/tools/_test_higgs_filled.py
+++ b/pmoves/tools/_test_higgs_filled.py
@@ -1,0 +1,82 @@
+"""Test Higgs with ALL None positions replaced with type-appropriate defaults."""
+import json
+import urllib.request
+import sys
+import time
+
+BASE = "http://127.0.0.1:7860"
+
+# Fetch API info
+resp = urllib.request.urlopen(f"{BASE}/gradio_api/info")
+info = json.loads(resp.read())
+endpoint = info.get("named_endpoints", {}).get("/generate_unified_tts", {})
+params = endpoint.get("parameters", [])
+
+# Build array with ALL defaults, replacing None with type-appropriate values
+data = []
+for i, p in enumerate(params):
+    default = p.get("parameter_default")
+    if default is not None:
+        data.append(default)
+    else:
+        # Fill None with type-appropriate default
+        ptype = p.get("python_type", {}).get("type", "str")
+        component = p.get("component", "")
+        if component == "Audio" or "filepath" in ptype:
+            data.append(None)  # Audio/File inputs stay None (optional)
+        elif "float" in ptype or "int" in ptype:
+            data.append(0)
+        elif "bool" in ptype:
+            data.append(False)
+        else:
+            data.append("")  # str default
+
+print(f"Total params: {len(data)}")
+
+# Override core + Higgs
+data[0] = "Hello, this is a Higgs Audio test."
+data[1] = "Higgs Audio"
+data[2] = "wav"
+
+# Show None positions and what we filled them with
+print("Filled None positions:")
+for i, p in enumerate(params):
+    if p.get("parameter_default") is None:
+        print(f"  [{i}] {p.get('parameter_name','?')} ({p.get('component','?')}) -> {repr(data[i])}")
+
+print()
+print("Submitting...")
+req = urllib.request.Request(
+    f"{BASE}/gradio_api/call/generate_unified_tts",
+    data=json.dumps({"data": data}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+t0 = time.time()
+resp = urllib.request.urlopen(req, timeout=30)
+submit_data = json.loads(resp.read())
+event_id = submit_data.get("event_id")
+print(f"Event ID: {event_id} ({time.time()-t0:.1f}s)")
+
+# Stream SSE
+print("Streaming SSE response...")
+sse_url = f"{BASE}/gradio_api/call/generate_unified_tts/{event_id}"
+sse_resp = urllib.request.urlopen(sse_url, timeout=240)
+
+current_event = ""
+for raw_line in sse_resp:
+    line = raw_line.decode("utf-8", errors="replace").rstrip("\n\r")
+    if line.startswith("event:"):
+        current_event = line[6:].strip()
+    elif line.startswith("data:"):
+        raw_data = line[5:].strip()
+        print(f"  [{current_event}] {raw_data[:500]}")
+        if current_event == "complete":
+            print(f"\nSUCCESS in {time.time()-t0:.1f}s")
+            result = json.loads(raw_data)
+            if isinstance(result, list) and len(result) >= 2:
+                print(f"Audio: {str(result[0])[:200]}")
+                print(f"Status: {result[1]}")
+            sys.exit(0)
+        elif current_event == "error":
+            print(f"\nERROR in {time.time()-t0:.1f}s")
+            sys.exit(1)

--- a/pmoves/tools/_unload_engine.py
+++ b/pmoves/tools/_unload_engine.py
@@ -1,0 +1,46 @@
+"""Unload a TTS engine via Gradio event API."""
+import json
+import urllib.request
+import sys
+import time
+
+BASE = "http://127.0.0.1:7860"
+engine = sys.argv[1] if len(sys.argv) > 1 else "higgs"
+
+endpoint_map = {
+    "higgs": "/handle_unload_higgs",
+    "fish_s2": "/handle_unload_fish_s2",
+    "kitten": "/handle_unload_kitten",
+    "kokoro": "/handle_unload_kokoro",
+    "f5": "/handle_f5_unload",
+    "chatterbox": "/handle_unload_chatterbox",
+}
+
+endpoint = endpoint_map.get(engine)
+if not endpoint:
+    print(f"Unknown engine: {engine}")
+    sys.exit(1)
+
+print(f"Unloading {engine} via {endpoint}...")
+req = urllib.request.Request(
+    f"{BASE}/gradio_api/call{endpoint}",
+    data=json.dumps({"data": []}).encode(),
+    headers={"Content-Type": "application/json"},
+)
+t0 = time.time()
+resp = urllib.request.urlopen(req, timeout=30)
+result = json.loads(resp.read())
+event_id = result.get("event_id")
+
+# Poll SSE
+sse_resp = urllib.request.urlopen(
+    f"{BASE}/gradio_api/call{endpoint}/{event_id}", timeout=60
+)
+for raw_line in sse_resp:
+    line = raw_line.decode("utf-8", errors="replace").strip()
+    if line.startswith("event:") and "complete" in line:
+        print(f"Unloaded in {time.time()-t0:.1f}s")
+        break
+    if line.startswith("event:") and "error" in line:
+        print(f"Error unloading")
+        break


### PR DESCRIPTION
feat(voice): add TTS MCP bridge and expression registry

## Summary
- add expressive TTS intent registry for engine and modifier selection
- add `/tts:express` command definition
- add FastAPI SSE MCP bridge for Flute-Gateway TTS access
- add direct Gradio diagnostic helpers for Higgs and Fish S2 load/synthesis/unload paths

## Validation
- python -m py_compile pmoves/services/flute-gateway/mcp_bridge.py pmoves/tools/_check_higgs_params.py pmoves/tools/_test_fish_s2_direct.py pmoves/tools/_test_higgs_defaults.py pmoves/tools/_test_higgs_direct.py pmoves/tools/_test_higgs_filled.py pmoves/tools/_unload_engine.py
- YAML parse check for pmoves/configs/tts-engine-expressions.yaml

## Notes
- This branch intentionally stays separate from the Pinokio/networking docs branch and from unrelated dirty root-checkout changes.
- No live Gradio/TTS server execution was performed in this branch during extraction.
