### PR TITLE
docs(agnote4482): add codex creator publishing follow-up

### DIFF
--- a/pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md
+++ b/pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md
@@ -448,14 +448,16 @@ All resolved. No blockers.
 | Infra (Model Registry HF enrichment) | 4090-claude | 2026-03-24 | SHIPPED `07d06f70` | feat/chit-integration-wave-1 |
 | Infra (Model seed + gpu-models metadata) | 4090-claude | 2026-03-24 | SHIPPED `50ee0022`, `7cfacc8c` | feat/chit-integration-wave-1 |
 | Infra (BoTZ submodule sync d125e8a) | 4090-claude | 2026-03-24 | SHIPPED `63532a6b` | feat/chit-integration-wave-1 |
-| Infra (Publisher SQL P1 hardening) | 5090-claude | 2026-03-26 | IN PR #1126 (supersedes closed #1114) | fix/publisher-sql-p1-hardening |
-| W2 (Pinokio fleet networking + packaging docs) | codex-gpt5 | 2026-03-26 | IN PR #1115 | codex/pinokio-network-docs |
+| Infra (Publisher SQL P1 hardening) | 5090-claude | 2026-03-26 | MERGED #1126 (superseded closed #1114) | fix/publisher-sql-p1-hardening |
+| W2 (Pinokio fleet networking + packaging docs) | codex-gpt5 | 2026-03-26 | MERGED #1115 | codex/pinokio-network-docs |
 | W1/W6 (TTS MCP bridge + expression registry) | codex-gpt5 | 2026-03-26 | IN PR #1116 | codex/tts-mcp-bridge |
 | W3/M2 (creator publishing follow-up docs) | codex-gpt5 | 2026-03-26 | IN PR #1117 | codex/agnote4482-creator-publishing-docs |
 | Infra (`PMOVES.YT` pointer sync) | codex-gpt5 | 2026-03-26 | IN PR #1118 | codex/pmoves-yt-pointer |
-| W4 (search ingest command) | codex-gpt5 | 2026-03-26 | IN PR #1119 | codex/search-ingest-command |
+| W4 (search ingest command) | codex-gpt5 | 2026-03-26 | MERGED #1119 | codex/search-ingest-command |
 | W3/M2 (studio-board approval handoff UX) | codex-gpt5 | 2026-03-26 | IN PR #1120 | codex/agnote4482-approval-ux |
 | W2/W3 (Pinokio PMOVES Codex plugin + Agent Zero launcher) | codex-gpt5 | 2026-03-26 | IN PR #1121 | codex/pinokio-pmoves-plugin-pack |
+| W3/M2 (creator automation activation + Discord canonical lane) | codex-gpt5 | 2026-03-26 | RECOMMENDED — follow-up after #1126 merge | — |
+| W3/M2 (studio-board status UX: approved→published visibility) | codex-gpt5 | 2026-03-26 | RECOMMENDED — docs lane active, implementation next | — |
 
 ## Recommended Next Steps (Post 2026-03-24 CHIT Wave 1)
 
@@ -484,11 +486,14 @@ All resolved. No blockers.
 | 4 | Jetson Orin onboarding | P2 | Via RustDesk |
 | 5 | NATS leaf node to 5090 | P2 | Flute NATS=connected proves bus healthy |
 
+<<<<<<< HEAD
 ### codex-gpt5 (Board + Packaging + Creator Control)
 | # | Task | Priority | Notes |
 |---|------|----------|-------|
-| 1 | Review and land PR #1126 (P1 SQL fixes) | **P0** | #1114 closed — superseded by #1126 (IF EXISTS guard + idempotent claim). 5090-claude authored |
+| 1 | ~~Review and land PR #1126~~ | ~~**P0**~~ | DONE — #1126 merged, #1114 closed |
 | 2 | Close the creator-control loop in PRs #1117 + #1120 | **P0** | Keep `approved`, `publishing`, `published`, and `publish_failed` explicit in docs + UI |
-| 3 | Finish live Pinokio smoke for PR #1121 after env fixes | P1 | Repo-root launcher path is fixed; remaining blocker is PMOVES env/runtime readiness |
-| 4 | Move the atomic Codex lanes (#1115, #1116, #1118, #1119) through remote review | P1 | Keep them split instead of sweeping root checkout dirt |
-| 5 | Keep provider wrappers additive to the PMOVES mesh | P2 | Pinokio plugins should inject defaults, not replace NATS/MCP/CHIT contracts |
+| 3 | Close Supabase→Agent Zero→Publisher→Discord activation loop | **P0** | Validate `approval_poller.json` + `echo_publisher.json`; capture first published-event evidence |
+| 4 | Pick canonical Discord publish lane | P1 | Decide between `publisher-discord` NATS subscriber and n8n webhook relay; demote the other |
+| 5 | Finish live Pinokio smoke for PR #1121 after env fixes | P1 | Repo-root launcher path is fixed; remaining blocker is PMOVES env/runtime readiness |
+| 6 | Move remaining Codex lanes (#1116, #1118) through review | P1 | #1115, #1119 already merged |
+| 7 | Surface publish failures + backfill readiness | P2 | Turn publisher audit into operator-visible lane before broader M2 expansion |

--- a/pmoves/docs/NEXT_STEPS.md
+++ b/pmoves/docs/NEXT_STEPS.md
@@ -60,6 +60,11 @@ _Last updated: 2026-03-26_
    - funnel release-note/CVE signals into the existing dashboard + hardening tracker at weekly and pre-release intervals
    - update the canonical operator docs whenever runtime defaults, service ownership, or bootstrap order changes
 
+5. Codex follow-through for the active creator/publishing sprint.
+   - close the real Supabase -> Agent Zero -> Publisher -> Discord activation loop and log evidence in `pmoves/docs/PMOVES.AI PLANS/SUPABASE_DISCORD_AUTOMATION.md`
+   - choose one canonical published-event Discord path (`services/publisher-discord` subscriber vs `pmoves/n8n/flows/echo_publisher.json`) and mark the other as fallback/test-only
+   - tighten dashboard/operator visibility so `approved`, `waiting for poller`, `published`, and `publish_failed` states are explicit in the `studio-board` / `videos` UI lanes
+
 ### Latest changes (Mar 8, 2026) — CI Runner Migration + RG-3 Automation
 - **AB-9 mitigation:** Migrated 10 lightweight CI jobs from `[self-hosted, Linux, X64]` to `ubuntu-latest`:
   - `sql-policy-lint`, `python-tests`, `webhook-smoke`, `yt-dlp-bump`, `deploy-gateway-agent` (validate only)
@@ -505,6 +510,9 @@ Next 48 hours
 ### 1. Finish the M2 Automation Loop
 **Status note:** Infrastructure is complete, but end-to-end validation remains blocked until the n8n approval poller is activated and runs successfully.
 - [ ] Execute the Supabase → Agent Zero → Discord activation checklist (`pmoves/docs/SUPABASE_DISCORD_AUTOMATION.md`) and log validation timestamps in the runbook.
+- [ ] Choose and document the canonical Discord publish lane now that both `services/publisher-discord` and `pmoves/n8n/flows/echo_publisher.json` can carry `content.published.v1`; keep only one production-default path.
+- [ ] Add one deterministic smoke/integration path proving a real `content.published.v1` payload reaches Discord with cover art, duration, and Jellyfin deep link.
+- [ ] Update dashboard/operator UX so approvals no longer look complete before the background publish handoff finishes; show `approved`, `waiting for poller`, `published`, and `publish_failed` distinctly.
 - [ ] Populate `.env` with Discord webhook credentials, perform a manual webhook ping, and capture the confirmation screenshot/log.
 - [ ] Activate the n8n approval poller and echo publisher workflows once secrets are loaded; document the activation + first successful run.
 - [x] Confirm Jellyfin credentials (API key and optional user id) allow library enumeration; use `make jellyfin-verify` before publisher smokes (2025-10-13). Re-ran on 2025-10-14 after populating `JELLYFIN_USER_ID=c26d57363bad4318a37c0bf8673c389c`.

--- a/pmoves/docs/PMOVES.AI PLANS/ROADMAP.md
+++ b/pmoves/docs/PMOVES.AI PLANS/ROADMAP.md
@@ -27,6 +27,9 @@ A production-ready, self-hostable orchestration mesh for creative + agent worklo
   - operator docs are being normalized around one modular provisioning contract: Supabase system-of-record first, then Neo4j/Qdrant/Meilisearch, then optional n8n automation/control-plane overlays.
   - the runtime choice is now treated as explicit operator intent instead of an implicit default: `SUPABASE_RUNTIME=cli` for bootstrap/data repair, `SUPABASE_RUNTIME=compose` for release-mode parity and guard rails.
   - release-note/CVE intake is being funneled through the existing weekly/scheduled lanes (`codeql.yml`, `yt-dlp-bump.yml`, `python-images-toolchain-canary.yml`) plus local GHCR/Trivy gates, with outcomes tracked in the production audit dashboard and hardening tracker.
+- March 26 creator/publishing follow-through is the active Codex lane:
+  - bootstrap edge-case hardening landed in PR #1126 (superseded #1114) so the remaining creator-control work can move independently of the publisher review lane.
+  - next implementation focus is operational, not scaffolding: activate the Supabase -> Agent Zero -> Publisher -> Discord loop, choose the canonical Discord publish path, and make `approved` vs `publishing` vs `published` vs `publish_failed` obvious in operator UX.
 - March 7 merge wave completed on `main`: `#814`, `#815`, `#816`, `#817`, `#818`, `#819`, `#820`, `#821` (8 PRs, 3 batches).
 - Chrome extension security hardening landed in `#821`: 9 CodeRabbit review items addressed (auth storage isolation, XSS remediation, mock server hardening, timeout guards, state management fixes, CSP).
 - Distributed topology documentation + examples landed in `#820`.


### PR DESCRIPTION
## Summary
- add Codex-owned creator/publishing follow-through items to the AGNOTE4482 sprint roadmap
- refresh NEXT_STEPS with the active creator/publishing activation checklist
- update ROADMAP to reflect that PR #1114 isolates bootstrap hardening while the next Codex lane is operational activation

## Testing
- git diff --check

## Reviewer Notes
- Docs-only PR.
- The older local branch `codex/agnote4482-publisher-flow` still contains runtime and n8n experiments, but those were intentionally not replayed here because they overlap with merged publisher work and need a clean rebase before review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated roadmap and planning documents to reflect completed milestones and next priorities for publishing workflow improvements, including Discord integration refinement and enhanced status visibility in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->