### PR TITLE
feat(pinokio): add PMOVES Codex plugin and Agent Zero launcher

### DIFF
--- a/pbnj/pinokio/api/pmoves-agent-zero/.gitignore
+++ b/pbnj/pinokio/api/pmoves-agent-zero/.gitignore
@@ -1,0 +1,2 @@
+logs/
+repo-root.txt

--- a/pbnj/pinokio/api/pmoves-agent-zero/README.md
+++ b/pbnj/pinokio/api/pmoves-agent-zero/README.md
@@ -1,0 +1,91 @@
+# PMOVES Agent Zero
+
+Pinokio launcher for the PMOVES Agent Zero mesh entrypoint.
+
+This launcher is a thin wrapper over the repo-supported PMOVES startup flow. It does not fork Agent Zero application logic into a separate Pinokio app folder. Instead, it launches the current PMOVES stack from `../../pmoves`, seeds the runtime MCP map, and exposes the Agent Zero UI and API endpoints through Pinokio.
+
+## Quick Start
+
+1. Click **Install** to bootstrap `pmoves/env.shared` and seed Agent Zero MCP defaults.
+2. Click **Start Agent Tier** to launch Agent Zero plus the supported PMOVES agent stack.
+3. Open the **Agent Zero UI** at `http://localhost:8081`.
+4. Use **Status** to inspect health and current MCP commands.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `install.js` | Bootstrap PMOVES env files and seed `data/agent-zero/runtime/mcp/servers.env` |
+| `start.js` | Start the supported PMOVES agent tier and tail Agent Zero logs |
+| `status.js` | Show container status, `/healthz`, and `/mcp/commands` |
+| `update.js` | Pull latest PMOVES changes, refresh submodules, and reseed MCP runtime |
+| `reset.js` | Stop Agent Zero and clear runtime/log state before reseeding |
+
+## What Start Launches
+
+The launcher uses the repo-supported `make up-agents-ui` path from `pmoves/Makefile`. That brings up:
+
+- NATS + JetStream bootstrap
+- Agent Zero API and UI
+- Archon API and UI
+- DeepResearch
+- SupaSerch
+- Mesh Agent
+- Publisher-Discord
+
+That matches the current PMOVES control-plane bring-up better than a fake standalone Agent Zero package.
+
+## API Reference
+
+### Agent Zero API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `http://localhost:8080/healthz` | GET | Health check and controller status |
+| `http://localhost:8080/config/environment` | GET | Resolved runtime configuration |
+| `http://localhost:8080/mcp/commands` | GET | List MCP helpers and runtime metadata |
+| `http://localhost:8080/mcp/execute` | POST | Execute an MCP command |
+| `http://localhost:8080/docs` | GET | FastAPI docs |
+| `http://localhost:8081` | GET | Agent Zero UI |
+
+**Curl**
+
+```bash
+curl http://localhost:8080/healthz
+curl http://localhost:8080/mcp/commands
+curl -X POST http://localhost:8080/mcp/execute \
+  -H "Content-Type: application/json" \
+  -d '{"cmd":"geometry.jump","arguments":{"point_id":"demo"}}'
+```
+
+**Python**
+
+```python
+import requests
+
+print(requests.get("http://localhost:8080/healthz").json())
+print(requests.get("http://localhost:8080/mcp/commands").json())
+result = requests.post(
+    "http://localhost:8080/mcp/execute",
+    json={"cmd": "geometry.jump", "arguments": {"point_id": "demo"}},
+)
+print(result.json())
+```
+
+**JavaScript**
+
+```javascript
+const health = await fetch("http://localhost:8080/healthz").then(r => r.json())
+const commands = await fetch("http://localhost:8080/mcp/commands").then(r => r.json())
+const result = await fetch("http://localhost:8080/mcp/execute", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ cmd: "geometry.jump", arguments: { point_id: "demo" } })
+}).then(r => r.json())
+```
+
+## Notes
+
+- MCP defaults are seeded into `pmoves/data/agent-zero/runtime/mcp/servers.env`.
+- This launcher intentionally tracks the PMOVES repo layout instead of a separate `app/` clone.
+- Provider-specific agent customization belongs in Pinokio plugins such as `pmoves-codex`, not inside this launcher.

--- a/pbnj/pinokio/api/pmoves-agent-zero/README.md
+++ b/pbnj/pinokio/api/pmoves-agent-zero/README.md
@@ -2,20 +2,22 @@
 
 Pinokio launcher for the PMOVES Agent Zero mesh entrypoint.
 
-This launcher is a thin wrapper over the repo-supported PMOVES startup flow. It does not fork Agent Zero application logic into a separate Pinokio app folder. Instead, it launches the current PMOVES stack from `../../pmoves`, seeds the runtime MCP map, and exposes the Agent Zero UI and API endpoints through Pinokio.
+This launcher is a thin wrapper over the repo-supported PMOVES startup flow. It does not fork Agent Zero application logic into a separate Pinokio app folder. Instead, it targets a user-selected local `PMOVES.AI` checkout, launches the current PMOVES stack from `<repo-root>/pmoves`, seeds the runtime MCP map, and exposes the Agent Zero UI and API endpoints through Pinokio.
 
 ## Quick Start
 
-1. Click **Install** to bootstrap `pmoves/env.shared` and seed Agent Zero MCP defaults.
-2. Click **Start Agent Tier** to launch Agent Zero plus the supported PMOVES agent stack.
-3. Open the **Agent Zero UI** at `http://localhost:8081`.
-4. Use **Status** to inspect health and current MCP commands.
+1. Click **Install** and select the local `PMOVES.AI` repo root.
+2. The launcher stores that selection in `repo-root.txt`.
+3. Pinokio bootstraps `pmoves/env.shared` and seeds Agent Zero MCP defaults from that selected checkout.
+4. Click **Start Agent Tier** to launch Agent Zero plus the supported PMOVES agent stack.
+5. Open the **Agent Zero UI** at `http://localhost:8081`.
+6. Use **Status** to inspect health and current MCP commands.
 
 ## Scripts
 
 | Script | Purpose |
 |--------|---------|
-| `install.js` | Bootstrap PMOVES env files and seed `data/agent-zero/runtime/mcp/servers.env` |
+| `install.js` | Select a PMOVES checkout, bootstrap env files, and seed `data/agent-zero/runtime/mcp/servers.env` |
 | `start.js` | Start the supported PMOVES agent tier and tail Agent Zero logs |
 | `status.js` | Show container status, `/healthz`, and `/mcp/commands` |
 | `update.js` | Pull latest PMOVES changes, refresh submodules, and reseed MCP runtime |
@@ -87,5 +89,6 @@ const result = await fetch("http://localhost:8080/mcp/execute", {
 ## Notes
 
 - MCP defaults are seeded into `pmoves/data/agent-zero/runtime/mcp/servers.env`.
-- This launcher intentionally tracks the PMOVES repo layout instead of a separate `app/` clone.
+- This launcher intentionally tracks a selected PMOVES repo checkout instead of a separate `app/` clone.
+- Re-run **Install** any time you want to point Pinokio at a different PMOVES checkout.
 - Provider-specific agent customization belongs in Pinokio plugins such as `pmoves-codex`, not inside this launcher.

--- a/pbnj/pinokio/api/pmoves-agent-zero/icon.svg
+++ b/pbnj/pinokio/api/pmoves-agent-zero/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="PMOVES Agent Zero icon">
+  <rect width="256" height="256" rx="48" fill="#0b132b"/>
+  <path d="M128 48l56 32v64c0 34-20 52-56 64-36-12-56-30-56-64V80l56-32z" fill="#1c2541" stroke="#5bc0be" stroke-width="10"/>
+  <circle cx="128" cy="112" r="22" fill="#ffffff"/>
+  <path d="M92 176c12-18 28-27 36-27s24 9 36 27" fill="none" stroke="#ffffff" stroke-width="14" stroke-linecap="round"/>
+</svg>

--- a/pbnj/pinokio/api/pmoves-agent-zero/install.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/install.js
@@ -1,0 +1,20 @@
+module.exports = {
+  run: [{
+    method: "shell.run",
+    params: {
+      path: "../../../../pmoves",
+      message: [
+        "python tools/env_setup_unified.py",
+        "make a0-mcp-seed"
+      ]
+    }
+  }, {
+    method: "notify",
+    params: {
+      html: "PMOVES environment bootstrapped for Agent Zero. Start the agent tier when ready.",
+      type: "success"
+    }
+  }]
+}
+
+

--- a/pbnj/pinokio/api/pmoves-agent-zero/install.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/install.js
@@ -1,10 +1,28 @@
 module.exports = {
   run: [{
+    method: "filepicker.open",
+    params: {
+      title: "Select PMOVES.AI repository root",
+      type: "folder"
+    }
+  }, {
+    method: "local.set",
+    params: {
+      repo_root: "{{input.paths[0]}}"
+    }
+  }, {
+    method: "fs.write",
+    params: {
+      path: "repo-root.txt",
+      text: "{{local.repo_root}}"
+    }
+  }, {
     method: "shell.run",
     params: {
-      path: "../../../../pmoves",
+      path: "{{path.resolve(local.repo_root, 'pmoves')}}",
       message: [
-        "python tools/env_setup_unified.py",
+        "if not exist Makefile ( echo Expected pmoves/Makefile under the selected PMOVES.AI repo root & exit /b 1 )",
+        "py -3 tools/env_setup_unified.py",
         "make a0-mcp-seed"
       ]
     }
@@ -16,5 +34,3 @@ module.exports = {
     }
   }]
 }
-
-

--- a/pbnj/pinokio/api/pmoves-agent-zero/pinokio.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/pinokio.js
@@ -4,7 +4,7 @@ module.exports = {
   description: "Launch Agent Zero from the PMOVES mesh and seed its MCP runtime.",
   icon: "icon.svg",
   menu: async (kernel, info) => {
-    let configured = info.exists("../../../../pmoves/env.shared")
+    let configured = info.exists("repo-root.txt")
     let running = {
       install: info.running("install.js"),
       start: info.running("start.js"),
@@ -44,7 +44,7 @@ module.exports = {
       return [{
         default: true,
         icon: "fa-solid fa-plug",
-        text: "Install (Bootstrap PMOVES env)",
+        text: "Install (Select PMOVES Repo)",
         href: "install.js"
       }]
     }
@@ -74,6 +74,10 @@ module.exports = {
       text: "MCP Commands",
       href: "http://localhost:8080/mcp/commands"
     }, {
+      icon: "fa-solid fa-folder-tree",
+      text: "Re-select PMOVES Repo",
+      href: "install.js"
+    }, {
       icon: "fa-solid fa-circle-info",
       text: "Status",
       href: "status.js"
@@ -90,4 +94,3 @@ module.exports = {
     return items
   }
 }
-

--- a/pbnj/pinokio/api/pmoves-agent-zero/pinokio.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/pinokio.js
@@ -1,0 +1,93 @@
+module.exports = {
+  version: "5.0",
+  title: "PMOVES Agent Zero",
+  description: "Launch Agent Zero from the PMOVES mesh and seed its MCP runtime.",
+  icon: "icon.svg",
+  menu: async (kernel, info) => {
+    let configured = info.exists("../../../../pmoves/env.shared")
+    let running = {
+      install: info.running("install.js"),
+      start: info.running("start.js"),
+      status: info.running("status.js"),
+      reset: info.running("reset.js"),
+      update: info.running("update.js")
+    }
+
+    if (running.install) {
+      return [{
+        default: true,
+        icon: "fa-solid fa-plug",
+        text: "Bootstrapping Agent Zero...",
+        href: "install.js"
+      }]
+    }
+
+    if (running.reset) {
+      return [{
+        default: true,
+        icon: "fa-solid fa-broom",
+        text: "Resetting Agent Zero...",
+        href: "reset.js"
+      }]
+    }
+
+    if (running.update) {
+      return [{
+        default: true,
+        icon: "fa-solid fa-arrows-rotate",
+        text: "Updating Agent Zero...",
+        href: "update.js"
+      }]
+    }
+
+    if (!configured) {
+      return [{
+        default: true,
+        icon: "fa-solid fa-plug",
+        text: "Install (Bootstrap PMOVES env)",
+        href: "install.js"
+      }]
+    }
+
+    let local = info.local("start.js")
+    let uiUrl = local && local.url ? local.url : "http://localhost:8081"
+
+    let items = [{
+      default: true,
+      icon: running.start ? "fa-solid fa-terminal" : "fa-solid fa-play",
+      text: running.start ? "Agent Zero Terminal" : "Start Agent Tier",
+      href: "start.js"
+    }, {
+      icon: "fa-solid fa-globe",
+      text: "Open Agent Zero UI",
+      href: uiUrl
+    }, {
+      icon: "fa-solid fa-book",
+      text: "Open API Docs",
+      href: "http://localhost:8080/docs"
+    }, {
+      icon: "fa-solid fa-heart-pulse",
+      text: "Health Check",
+      href: "http://localhost:8080/healthz"
+    }, {
+      icon: "fa-solid fa-diagram-project",
+      text: "MCP Commands",
+      href: "http://localhost:8080/mcp/commands"
+    }, {
+      icon: "fa-solid fa-circle-info",
+      text: "Status",
+      href: "status.js"
+    }, {
+      icon: "fa-solid fa-arrows-rotate",
+      text: "Update + Reseed MCP",
+      href: "update.js"
+    }, {
+      icon: "fa-solid fa-broom",
+      text: "Reset Runtime",
+      href: "reset.js"
+    }]
+
+    return items
+  }
+}
+

--- a/pbnj/pinokio/api/pmoves-agent-zero/pinokio.json
+++ b/pbnj/pinokio/api/pmoves-agent-zero/pinokio.json
@@ -1,0 +1,5 @@
+{
+  "title": "PMOVES Agent Zero",
+  "description": "One-click PMOVES Agent Zero launcher with API/UI startup and MCP runtime seeding.",
+  "icon": "icon.svg"
+}

--- a/pbnj/pinokio/api/pmoves-agent-zero/reset.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/reset.js
@@ -1,0 +1,21 @@
+module.exports = {
+  run: [{
+    method: "shell.run",
+    params: {
+      path: "../../../../pmoves",
+      message: [
+        "docker compose stop agent-zero || true",
+        "rm -rf data/agent-zero/runtime/* data/agent-zero/logs/*",
+        "mkdir -p data/agent-zero/runtime/mcp data/agent-zero/logs",
+        "make a0-mcp-seed"
+      ]
+    }
+  }, {
+    method: "notify",
+    params: {
+      html: "Agent Zero runtime reset complete. Start again to relaunch the service and UI.",
+      type: "warning"
+    }
+  }]
+}
+

--- a/pbnj/pinokio/api/pmoves-agent-zero/reset.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/reset.js
@@ -1,12 +1,27 @@
 module.exports = {
   run: [{
+    method: "fs.read",
+    params: {
+      path: "repo-root.txt",
+      encoding: "utf8"
+    }
+  }, {
+    method: "local.set",
+    params: {
+      repo_root: "{{input.trim()}}"
+    }
+  }, {
     method: "shell.run",
     params: {
-      path: "../../../../pmoves",
+      path: "{{path.resolve(local.repo_root, 'pmoves')}}",
       message: [
-        "docker compose stop agent-zero || true",
-        "rm -rf data/agent-zero/runtime/* data/agent-zero/logs/*",
-        "mkdir -p data/agent-zero/runtime/mcp data/agent-zero/logs",
+        "docker compose stop agent-zero || echo agent-zero already stopped",
+        "if exist data\\agent-zero\\runtime rmdir /s /q data\\agent-zero\\runtime",
+        "if exist data\\agent-zero\\logs rmdir /s /q data\\agent-zero\\logs",
+        "if not exist data\\agent-zero mkdir data\\agent-zero",
+        "mkdir data\\agent-zero\\runtime",
+        "mkdir data\\agent-zero\\runtime\\mcp",
+        "mkdir data\\agent-zero\\logs",
         "make a0-mcp-seed"
       ]
     }

--- a/pbnj/pinokio/api/pmoves-agent-zero/start.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/start.js
@@ -1,0 +1,25 @@
+module.exports = {
+  daemon: true,
+  run: [{
+    method: "shell.run",
+    params: {
+      path: "../../../../pmoves",
+      message: [
+        "make up-agents-ui",
+        "make a0-mcp-seed",
+        "echo http://localhost:8081",
+        "docker compose logs -f --tail=100 agent-zero"
+      ],
+      on: [{
+        event: "/(http:\/\/[0-9.:]+)/",
+        done: true
+      }]
+    }
+  }, {
+    method: "local.set",
+    params: {
+      url: "{{input.event[1]}}"
+    }
+  }]
+}
+

--- a/pbnj/pinokio/api/pmoves-agent-zero/start.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/start.js
@@ -1,9 +1,20 @@
 module.exports = {
   daemon: true,
   run: [{
+    method: "fs.read",
+    params: {
+      path: "repo-root.txt",
+      encoding: "utf8"
+    }
+  }, {
+    method: "local.set",
+    params: {
+      repo_root: "{{input.trim()}}"
+    }
+  }, {
     method: "shell.run",
     params: {
-      path: "../../../../pmoves",
+      path: "{{path.resolve(local.repo_root, 'pmoves')}}",
       message: [
         "make up-agents-ui",
         "make a0-mcp-seed",
@@ -11,7 +22,7 @@ module.exports = {
         "docker compose logs -f --tail=100 agent-zero"
       ],
       on: [{
-        event: "/(http:\/\/[0-9.:]+)/",
+        event: "/(http:\\/\\/[0-9.:]+)/",
         done: true
       }]
     }

--- a/pbnj/pinokio/api/pmoves-agent-zero/status.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/status.js
@@ -1,0 +1,14 @@
+module.exports = {
+  run: [{
+    method: "shell.run",
+    params: {
+      path: "../../../../pmoves",
+      message: [
+        "docker ps --format \"table {{.Names}}\t{{.Status}}\t{{.Ports}}\" | grep agent-zero || true",
+        "curl -fsS http://localhost:8080/healthz || true",
+        "curl -fsS http://localhost:8080/mcp/commands || true"
+      ]
+    }
+  }]
+}
+

--- a/pbnj/pinokio/api/pmoves-agent-zero/status.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/status.js
@@ -1,12 +1,23 @@
 module.exports = {
   run: [{
+    method: "fs.read",
+    params: {
+      path: "repo-root.txt",
+      encoding: "utf8"
+    }
+  }, {
+    method: "local.set",
+    params: {
+      repo_root: "{{input.trim()}}"
+    }
+  }, {
     method: "shell.run",
     params: {
-      path: "../../../../pmoves",
+      path: "{{path.resolve(local.repo_root, 'pmoves')}}",
       message: [
-        "docker ps --format \"table {{.Names}}\t{{.Status}}\t{{.Ports}}\" | grep agent-zero || true",
-        "curl -fsS http://localhost:8080/healthz || true",
-        "curl -fsS http://localhost:8080/mcp/commands || true"
+        "docker compose ps agent-zero",
+        "py -3 -c \"import urllib.request,sys; sys.stdout.write(urllib.request.urlopen('http://localhost:8080/healthz').read().decode())\" 2>nul || echo healthz unavailable",
+        "py -3 -c \"import urllib.request,sys; sys.stdout.write(urllib.request.urlopen('http://localhost:8080/mcp/commands').read().decode())\" 2>nul || echo mcp commands unavailable"
       ]
     }
   }]

--- a/pbnj/pinokio/api/pmoves-agent-zero/update.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/update.js
@@ -1,0 +1,27 @@
+module.exports = {
+  run: [{
+    method: "shell.run",
+    params: {
+      path: "../../../..",
+      message: [
+        "git pull --ff-only origin main",
+        "git submodule update --init --recursive"
+      ]
+    }
+  }, {
+    method: "shell.run",
+    params: {
+      path: "../../../../pmoves",
+      message: [
+        "python tools/env_setup_unified.py",
+        "make a0-mcp-seed"
+      ]
+    }
+  }, {
+    method: "notify",
+    params: {
+      html: "PMOVES Agent Zero launcher updated and MCP runtime reseeded.",
+      type: "success"
+    }
+  }]
+}

--- a/pbnj/pinokio/api/pmoves-agent-zero/update.js
+++ b/pbnj/pinokio/api/pmoves-agent-zero/update.js
@@ -1,8 +1,19 @@
 module.exports = {
   run: [{
+    method: "fs.read",
+    params: {
+      path: "repo-root.txt",
+      encoding: "utf8"
+    }
+  }, {
+    method: "local.set",
+    params: {
+      repo_root: "{{input.trim()}}"
+    }
+  }, {
     method: "shell.run",
     params: {
-      path: "../../../..",
+      path: "{{local.repo_root}}",
       message: [
         "git pull --ff-only origin main",
         "git submodule update --init --recursive"
@@ -11,9 +22,9 @@ module.exports = {
   }, {
     method: "shell.run",
     params: {
-      path: "../../../../pmoves",
+      path: "{{path.resolve(local.repo_root, 'pmoves')}}",
       message: [
-        "python tools/env_setup_unified.py",
+        "py -3 tools/env_setup_unified.py",
         "make a0-mcp-seed"
       ]
     }
@@ -25,3 +36,4 @@ module.exports = {
     }
   }]
 }
+

--- a/pbnj/pinokio/plugin/code/pmoves-codex/README.md
+++ b/pbnj/pinokio/plugin/code/pmoves-codex/README.md
@@ -1,0 +1,42 @@
+# PMOVES Codex Pinokio Plugin
+
+PMOVES wrapper plugin for OpenAI Codex inside Pinokio.
+
+## Purpose
+
+This plugin keeps the upstream Codex terminal flow but injects PMOVES mesh defaults into the target workspace:
+
+- `PMOVES_AGENT_ZERO_URL`
+- `PMOVES_AGENT_ZERO_UI_URL`
+- `PMOVES_ARCHON_URL`
+- `PMOVES_HIRAG_URL`
+- `PMOVES_NOTEBOOK_API_URL`
+- `PMOVES_NATS_URL`
+
+The goal is to keep provider-native behavior while giving Codex a stable PMOVES contract to build against.
+
+## Install
+
+Copy or symlink this folder into your Pinokio plugin directory:
+
+```bash
+~/pinokio/plugin/pmoves-codex
+```
+
+On this node the live Pinokio home is `D:/pinokio`, so the effective install target is:
+
+```text
+D:/pinokio/plugin/pmoves-codex
+```
+
+## Usage
+
+1. Open any Pinokio workspace or installed PMOVES app.
+2. Choose `PMOVES Codex` from Ask AI or Plugins.
+3. Codex launches in the selected workspace with PMOVES mesh defaults available in the environment.
+
+## Notes
+
+- This plugin does not replace Pinokio's built-in `codex` plugin.
+- It is the PMOVES-customized wrapper layer for Codex-specific defaults.
+- Keep direct agent-to-agent communication on the PMOVES mesh, not inside the plugin itself.

--- a/pbnj/pinokio/plugin/code/pmoves-codex/icon.svg
+++ b/pbnj/pinokio/plugin/code/pmoves-codex/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="PMOVES Codex icon">
+  <rect width="256" height="256" rx="48" fill="#111111"/>
+  <circle cx="72" cy="128" r="32" fill="#f4f4f4"/>
+  <path d="M124 80h60c11 0 20 9 20 20v56c0 11-9 20-20 20h-60" fill="none" stroke="#f4f4f4" stroke-width="20" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M104 108l32 20-32 20" fill="none" stroke="#59c3c3" stroke-width="18" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pbnj/pinokio/plugin/code/pmoves-codex/pinokio.js
+++ b/pbnj/pinokio/plugin/code/pmoves-codex/pinokio.js
@@ -1,0 +1,51 @@
+module.exports = {
+  title: "PMOVES Codex",
+  icon: "icon.svg",
+  description: "OpenAI Codex with PMOVES mesh defaults for Pinokio workspaces.",
+  link: "https://github.com/openai/codex",
+  run: [{
+    when: "{{platform === 'win32'}}",
+    id: "run",
+    method: "shell.run",
+    params: {
+      shell: "{{kernel.path('bin/miniconda/Library/bin/bash.exe')}}",
+      conda: {
+        skip: true
+      },
+      env: {
+        PMOVES_PROVIDER: "openai-codex",
+        PMOVES_PINOKIO_PLUGIN: "pmoves-codex",
+        PMOVES_AGENT_ZERO_URL: "{{envs.PMOVES_AGENT_ZERO_URL || 'http://localhost:8080'}}",
+        PMOVES_AGENT_ZERO_UI_URL: "{{envs.PMOVES_AGENT_ZERO_UI_URL || 'http://localhost:8081'}}",
+        PMOVES_ARCHON_URL: "{{envs.PMOVES_ARCHON_URL || 'http://localhost:8091'}}",
+        PMOVES_HIRAG_URL: "{{envs.PMOVES_HIRAG_URL || 'http://localhost:8086'}}",
+        PMOVES_NOTEBOOK_API_URL: "{{envs.PMOVES_NOTEBOOK_API_URL || 'http://localhost:4110'}}",
+        PMOVES_NATS_URL: "{{envs.PMOVES_NATS_URL || 'nats://localhost:4222'}}"
+      },
+      message: "npx -y @openai/codex@latest {{args.prompt ? JSON.stringify(args.prompt) : ''}}",
+      path: "{{args.cwd}}",
+      input: true,
+      buffer: 1024
+    }
+  }, {
+    when: "{{platform !== 'win32'}}",
+    id: "run",
+    method: "shell.run",
+    params: {
+      env: {
+        PMOVES_PROVIDER: "openai-codex",
+        PMOVES_PINOKIO_PLUGIN: "pmoves-codex",
+        PMOVES_AGENT_ZERO_URL: "{{envs.PMOVES_AGENT_ZERO_URL || 'http://localhost:8080'}}",
+        PMOVES_AGENT_ZERO_UI_URL: "{{envs.PMOVES_AGENT_ZERO_UI_URL || 'http://localhost:8081'}}",
+        PMOVES_ARCHON_URL: "{{envs.PMOVES_ARCHON_URL || 'http://localhost:8091'}}",
+        PMOVES_HIRAG_URL: "{{envs.PMOVES_HIRAG_URL || 'http://localhost:8086'}}",
+        PMOVES_NOTEBOOK_API_URL: "{{envs.PMOVES_NOTEBOOK_API_URL || 'http://localhost:4110'}}",
+        PMOVES_NATS_URL: "{{envs.PMOVES_NATS_URL || 'nats://localhost:4222'}}"
+      },
+      message: "npx -y @openai/codex@latest {{args.prompt ? JSON.stringify(args.prompt) : ''}}",
+      path: "{{args.cwd}}",
+      input: true,
+      buffer: 1024
+    }
+  }]
+}


### PR DESCRIPTION
## Summary
- add a PMOVES-specific Codex Pinokio plugin that preserves the upstream Codex terminal flow while injecting PMOVES mesh defaults
- add a real `pmoves-agent-zero` Pinokio launcher package with install, start, status, update, reset, metadata, and docs
- keep Agent Zero launcher as a thin wrapper over supported PMOVES bring-up paths instead of a fake standalone app clone

## Validation
- `node -e "require('./pbnj/pinokio/plugin/code/pmoves-codex/pinokio.js'); require('./pbnj/pinokio/api/pmoves-agent-zero/pinokio.js'); require('./pbnj/pinokio/api/pmoves-agent-zero/install.js'); require('./pbnj/pinokio/api/pmoves-agent-zero/start.js'); require('./pbnj/pinokio/api/pmoves-agent-zero/status.js'); require('./pbnj/pinokio/api/pmoves-agent-zero/reset.js'); require('./pbnj/pinokio/api/pmoves-agent-zero/update.js');"`
- `node -e "JSON.parse(require('fs').readFileSync('./pbnj/pinokio/api/pmoves-agent-zero/pinokio.json', 'utf8'));"`

## Notes
- this branch scaffolds the first provider-native PMOVES plugin pack lane (`pmoves-codex`)
- no live Pinokio run was executed in this pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added PMOVES Agent Zero launcher with one-click startup for Agent Zero API and UI endpoints, health monitoring, and MCP command interface
* Added PMOVES Codex plugin to run OpenAI Codex with preconfigured PMOVES environment defaults and integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->