### PR TITLE
docs(ops): align data services and release cadence

### DIFF
--- a/docs/hardening/PMOVES-hardening-tracker.md
+++ b/docs/hardening/PMOVES-hardening-tracker.md
@@ -2,7 +2,7 @@
 
 Comprehensive hardening posture, CI/CD build infrastructure, and service runtime status for the PMOVES.AI platform.
 
-Last updated: 2026-03-05
+Last updated: 2026-03-26
 
 Live snapshot (2026-03-04): `PMOVES.AI` open PRs `0`, CodeQL open alerts `0`, Dependabot open alerts `1` (`medium`). Use `pmoves/docs/PRODUCTION_AUDIT_DASHBOARD.md` as the source-of-truth for live counters.
 
@@ -142,6 +142,42 @@ Exception: `deepresearch` is amd64-only.
 - GHCR: `ghcr.io/powerfulmoves/*`
 - Docker Hub: `powerfulmoves/*`
 - Multi-arch: amd64 + arm64 (with `docker-compose.arm64.override.yml`)
+
+---
+
+## Release Notes / CVE Funnel
+
+Use two documentation sinks on purpose:
+- `pmoves/docs/PRODUCTION_AUDIT_DASHBOARD.md`
+  - live counters, open-alert snapshots, release evidence, and current blockers
+- `docs/hardening/PMOVES-hardening-tracker.md`
+  - recurring cadence, unresolved issue classes, and the operator policy for how signals are reviewed
+
+### Cadence
+
+| Cadence | Signal source | Operator action | Documentation sink |
+|----------|---------------|-----------------|--------------------|
+| Daily / active merge lane | Production Audit Dashboard, open PR checks, current CodeQL / Dependabot counts | Re-triage blockers, keep release lane clean, update ownership if a service group drifts | Audit dashboard first; `pmoves/docs/NEXT_STEPS.md` if priorities change |
+| Weekly | `.github/workflows/codeql.yml`, `.github/workflows/yt-dlp-bump.yml`, `.github/workflows/python-images-toolchain-canary.yml`, Dependabot queue | Review new alerts/PRs, confirm image/toolchain bumps still pass the intended gates, merge or re-scope follow-ups | Hardening tracker + audit dashboard |
+| Pre-release / infra touch | `make -C pmoves smoke-prod`, `make -C pmoves ghcr-prepublish-inrepo`, `make -C pmoves audit-layers-static` / `audit-layers-runtime`, `make -C pmoves ci-runners-check-strict` | Capture evidence, confirm runner capacity, close Trivy/hardening drift before promotion | Audit dashboard, plus `pmoves/docs/operations/FIRST_RUN.md` / `pmoves/docs/operations/MAKE_TARGETS.md` / `pmoves/docs/services/supabase/README.md` when command paths change |
+
+### Current funnel components
+
+- Code scanning:
+  - `codeql.yml` provides recurring code-level CVE/security signal.
+- Dependency freshness:
+  - `yt-dlp-bump.yml` keeps the extractor lane current on a weekly cadence.
+  - `python-images-toolchain-canary.yml` tests pinned Python image candidates weekly with a Trivy gate before opening a PR.
+- Image / runtime release gates:
+  - `make -C pmoves ghcr-prepublish-inrepo`
+  - `make -C pmoves ghcr-prepublish-all`
+  - `make -C pmoves smoke-prod`
+- Data-plane operator checks:
+  - `make -C pmoves supa-status`
+  - `make -C pmoves bootstrap-data`
+  - `make -C pmoves monitoring-smoke-prod`
+
+The goal is to keep release-note and CVE awareness on a predictable interval instead of waiting for a feature PR to stumble into stale dependencies or hidden infra drift.
 
 ---
 

--- a/pmoves/docs/NEXT_STEPS.md
+++ b/pmoves/docs/NEXT_STEPS.md
@@ -1,9 +1,21 @@
 
 # PMOVES v5 • NEXT_STEPS
 Note: Consolidated plan index at pmoves/docs/PMOVES.AI PLANS/README_DOCS_INDEX.md.
-_Last updated: 2026-03-12_
+_Last updated: 2026-03-26_
 
 ## Current Status
+
+### Latest changes (Mar 26, 2026) — Data Services Provisioning + Release Cadence Alignment
+- Operator docs are being tightened around one modular data-plane story instead of multiple overlapping setup paths:
+  - Supabase remains the system of record and runtime control plane.
+  - Qdrant + Meilisearch are the retrieval indexes seeded after Supabase.
+  - Neo4j is the graph/mind-map layer seeded alongside geometry aliases.
+  - n8n stays optional for base bring-up but is the preferred automation/control-plane add-on once the base data services are healthy.
+- Release-note/CVE intake is being funneled through the existing signals instead of ad-hoc checks:
+  - scheduled `codeql.yml`, `yt-dlp-bump.yml`, and `python-images-toolchain-canary.yml`
+  - local GHCR/Trivy gates via `make -C pmoves ghcr-prepublish-inrepo`
+  - runtime/release evidence via `pmoves/docs/PRODUCTION_AUDIT_DASHBOARD.md` and `docs/hardening/PMOVES-hardening-tracker.md`
+- Next focus: finish Supabase runtime alignment, validate the modular bring-up against the live node stack, and keep the docs in sync whenever the data-plane command path changes.
 
 ### Latest changes (Mar 12, 2026) — PMOVES.YT Authoritative Runtime Refresh
 - `PMOVES.YT` is now the authoritative runtime/docs lane for `pmoves-yt`; the root repo now builds the service from the submodule Dockerfile instead of treating `pmoves/services/pmoves-yt` as the source of truth.
@@ -42,6 +54,11 @@ _Last updated: 2026-03-12_
    - validate Postgres-backed `PMOVES-n8n` bootstrap end-to-end
    - decide which BotZ/MCP workflows become canonical shared automation flows
    - keep Supabase workflow registry sync green as creator automation expands
+
+4. Button up modular data services provisioning and release/CVE cadence.
+   - keep one explicit provisioning contract for Supabase, Neo4j, Qdrant, Meilisearch, and optional n8n instead of letting setup drift across docs
+   - funnel release-note/CVE signals into the existing dashboard + hardening tracker at weekly and pre-release intervals
+   - update the canonical operator docs whenever runtime defaults, service ownership, or bootstrap order changes
 
 ### Latest changes (Mar 8, 2026) — CI Runner Migration + RG-3 Automation
 - **AB-9 mitigation:** Migrated 10 lightweight CI jobs from `[self-hosted, Linux, X64]` to `ubuntu-latest`:

--- a/pmoves/docs/PMOVES.AI PLANS/README_DOCS_INDEX.md
+++ b/pmoves/docs/PMOVES.AI PLANS/README_DOCS_INDEX.md
@@ -1,5 +1,5 @@
 # PMOVES v5 • Documentation Index
-_Last updated: 2026-03-12 — add PMOVES.YT authoritative runtime path_
+_Last updated: 2026-03-26 — data services provisioning + release cadence refresh_
 
 ## Directory Map
 
@@ -47,8 +47,11 @@ After the 2026-02-18 reorganization, `pmoves/docs/` is organized as:
 - **Submodule Production Release Checklist (deterministic gates + merge order)** — `../integrations/SUBMODULE_PRODUCTION_RELEASE_CHECKLIST.md`
 - **Docker Build Operator Guide** — `../operations/DOCKER_BUILD_GUIDE.md`
 - **First-Run Bootstrap** — `../operations/FIRST_RUN.md`
+- **Data Services Provisioning** — `../operations/FIRST_RUN.md` + `../services/supabase/README.md`
+- **Data Services Commands** — `../operations/MAKE_TARGETS.md`
 - **Archon Updates + Supabase wiring** — `archonupdateforpmoves.md`
 - **Supabase Service Guide** — `../services/supabase/README.md`
+- **Hardening Tracker** — `../../../docs/hardening/PMOVES-hardening-tracker.md`
 - **Archon Service README** — `../services/archon/README.md`
 - **Monitoring Stack (Prometheus, Grafana, Loki)** — `../services/monitoring/README.md`
 - **n8n Setup (Supabase→Agent Zero→Discord)** — `N8N_SETUP.md`
@@ -63,6 +66,22 @@ After the 2026-02-18 reorganization, `pmoves/docs/` is organized as:
 - Quickstart: [`LOCAL_DEV.md` – Web UI quick links](../operations/LOCAL_DEV.md#web-ui-quick-links)
   - Supabase CLI prerequisites: run `make supa-start` then `make supa-status` to refresh Supabase keys. `npm run dev` now layers `env.shared` + `.env.local` automatically, so keep those root files current.
 - Notebook Workbench: [`UI_NOTEBOOK_WORKBENCH.md`](../infrastructure/UI_NOTEBOOK_WORKBENCH.md) — Supabase prerequisites, smoketest target, and troubleshooting tips for the `/notebook-workbench` page.
+
+## Data Plane & Release Ops
+
+- Bootstrap / repair path:
+  - `../operations/FIRST_RUN.md`
+  - `../operations/MAKE_TARGETS.md`
+  - `../services/supabase/README.md`
+- Core data-store service docs:
+  - `../services/qdrant/README.md`
+  - `../services/meilisearch/README.md`
+  - `../services/neo4j/README.md`
+  - `../services/n8n/README.md`
+- Release-note / CVE cadence and evidence:
+  - `../PRODUCTION_AUDIT_DASHBOARD.md`
+  - `../../../docs/hardening/PMOVES-hardening-tracker.md`
+  - `../../../docs/hardening/PYTHON_IMAGES_TOOLCHAIN_CANARY.md`
 
 ## Creative Tutorials (Automation Inputs)
 - Qwen Image Edit Plus — `pmoves/creator/tutorials/qwen_image_edit_plus_tutorial.md`

--- a/pmoves/docs/PMOVES.AI PLANS/ROADMAP.md
+++ b/pmoves/docs/PMOVES.AI PLANS/ROADMAP.md
@@ -1,5 +1,5 @@
 # PMOVES v5 • ROADMAP
-Last updated: 2026-03-12
+Last updated: 2026-03-26
 
 ## Vision
 A production-ready, self-hostable orchestration mesh for creative + agent workloads across GPU boxes and Jetsons: **hybrid Hi‑RAG**, **Supabase Studio**, **n8n orchestration**, **Jellyfin publishing**, and **graph-aware retrieval**.
@@ -23,6 +23,10 @@ A production-ready, self-hostable orchestration mesh for creative + agent worklo
   - workflow activation now targets the n8n 2.1 Public API (`/api/v1/workflows/{id}/activate|deactivate`) instead of the brittle CLI publish fallback.
   - Supabase tracking contract added: `pmoves_core.n8n_workflow_registry` stores live workflow state synced from n8n.
   - creator-control traversal now explicitly routes through `PMOVES-Creator`, `PMOVES-Open-Notebook`, and `CATACLYSM_STUDIOS_INC` so strategy, drafting, and platform-governance context are part of the operator path instead of living outside the service runbooks.
+- March 26 data-plane ops cleanup is active:
+  - operator docs are being normalized around one modular provisioning contract: Supabase system-of-record first, then Neo4j/Qdrant/Meilisearch, then optional n8n automation/control-plane overlays.
+  - the runtime choice is now treated as explicit operator intent instead of an implicit default: `SUPABASE_RUNTIME=cli` for bootstrap/data repair, `SUPABASE_RUNTIME=compose` for release-mode parity and guard rails.
+  - release-note/CVE intake is being funneled through the existing weekly/scheduled lanes (`codeql.yml`, `yt-dlp-bump.yml`, `python-images-toolchain-canary.yml`) plus local GHCR/Trivy gates, with outcomes tracked in the production audit dashboard and hardening tracker.
 - March 7 merge wave completed on `main`: `#814`, `#815`, `#816`, `#817`, `#818`, `#819`, `#820`, `#821` (8 PRs, 3 batches).
 - Chrome extension security hardening landed in `#821`: 9 CodeRabbit review items addressed (auth storage isolation, XSS remediation, mock server hardening, timeout guards, state management fixes, CSP).
 - Distributed topology documentation + examples landed in `#820`.

--- a/pmoves/docs/operations/FIRST_RUN.md
+++ b/pmoves/docs/operations/FIRST_RUN.md
@@ -1,7 +1,7 @@
 # First-Run Bootstrap Overview
-_Last updated: 2025-01-17_
+_Last updated: 2026-03-26_
 
-`make first-run` is the guided path for bringing a fresh PMOVES checkout online. It chains the critical environment, database, and container steps so operators land on a fully functional stack (Supabase CLI, mesh agents, external integrations, and seeded demo data) without manual orchestration.
+`make first-run` is the guided path for bringing a fresh PMOVES checkout online. It chains the critical environment, database, and container steps so operators land on a fully functional stack without hand-wiring each layer. Use it as the umbrella command, but keep the underlying data-service layers explicit so Supabase, retrieval stores, optional automation, and release gates stay modular instead of drifting together.
 
 ## Quick Start
 
@@ -18,6 +18,18 @@ This single command will:
 5. ✓ Start core services (data tier, workers)
 6. ✓ Start agents (Agent Zero, Archon)
 7. ✓ Seed Agent Zero MCP servers
+
+## Provisioning Layers
+
+| Layer | Required | Canonical path | What it owns |
+|---------|---------|----------------|--------------|
+| Supabase control plane | Yes | `make supa-start` + `make supabase-bootstrap` for CLI-backed bootstrap, or `SUPABASE_RUNTIME=compose make up` when intentionally certifying the compose/Kong lane | Postgres, PostgREST, GoTrue, Realtime, Storage, operator auth |
+| Retrieval stores | Yes for Hi-RAG and creator indexing | `make bootstrap-data` or the subset `make neo4j-bootstrap` + `make seed-data` | Neo4j graph aliases, Qdrant vectors, Meilisearch lexical index |
+| Core consumers | Yes | `make up` | Hi-RAG gateways, retrieval-eval, presign, render-webhook, extract workers, PMOVES.YT, Jellyfin bridge |
+| Automation/control plane | Optional for base bring-up, recommended for creator/publishing work | `make up-n8n` + `make n8n-api-bootstrap` | n8n workflows, Supabase workflow registry sync, approval/publish orchestration |
+| Observability + release gates | Required before release or promotion | `make up-monitoring`, `make monitoring-smoke-prod`, `make ghcr-prepublish-inrepo` | Prometheus/Grafana/Loki health, Trivy-backed image validation, release evidence |
+
+Supabase Storage is the default S3-compatible backend for the current single-env path. Treat standalone MinIO as a compatibility lane, not the primary object-store story.
 
 ## Tool Requirements
 
@@ -41,21 +53,27 @@ If tools are missing or outdated, the bootstrap will provide installation/update
 - If not, runs `make supa-start` (CLI mode)
 - **New:** Handles port conflicts automatically with cleanup steps
 - **New:** Provides troubleshooting hints for common issues
+- When you bypass `make first-run`, choose `SUPABASE_RUNTIME` explicitly instead of assuming the same runtime fits bootstrap, daily development, and release certification.
 
-### 3. Schema + Demo Data
+### 3. Schema + Modular Data Bootstrap
 - `make bootstrap-data` triggers:
-   - `make supabase-bootstrap` → replays migrations via `supabase db reset`
+   - `make supabase-bootstrap` → replays pending SQL in Supabase first
    - `make neo4j-bootstrap` → applies persona aliases and CHIT geometry fixtures
-   - `make seed-data` → feeds the hi-rag demo corpus into Qdrant/Meili
+   - `make seed-data` → feeds the Hi-RAG demo corpus into Qdrant/Meili
+- This keeps the system-of-record layer (Supabase) ahead of graph/vector/lexical stores instead of treating all data services as one opaque bundle.
 
 ### 4. Core Services
-- `make up` starts the default compose profiles (Qdrant, Neo4j, MinIO, Meilisearch, presign, hi-rag gateways, langextract, extract-worker, render-webhook, pmoves-yt, Jellyfin bridge)
+- `make up` starts the default compose profiles (Qdrant, Neo4j, Meilisearch, MinIO compatibility service, presign, hi-rag gateways, langextract, extract-worker, render-webhook, pmoves-yt, Jellyfin bridge)
 
 ### 5. Agent Mesh
 - `make up-agents-ui` launches NATS, Agent Zero, Archon, Archon UI, mesh-agent, publisher-discord
 
 ### 6. MCP Server Seeding
 - `make a0-mcp-seed` writes MCP server configurations to Agent Zero runtime
+
+### 7. Optional Automation + Release Ops
+- `make up-n8n` adds the workflow layer after the base data plane is healthy.
+- `make monitoring-smoke-prod`, `make ghcr-prepublish-inrepo`, and the hardening tracker close the loop from provisioning into release readiness and CVE intake.
 
 ## Enhanced Error Handling
 
@@ -96,6 +114,17 @@ Troubleshooting:
 | PMOVES UI | http://localhost:4482 | Main dashboard |
 | Grafana | http://localhost:3002 | Metrics (admin/admin) |
 | Prometheus | http://localhost:9090 | Metrics scraping |
+| n8n | http://localhost:5678 | Optional workflow control plane |
+
+## Integration Checkpoints
+
+| Checkpoint | Command | Why it matters |
+|---------|---------|----------------|
+| Runtime export | `make supa-status` | Regenerates `pmoves/env.supa.runtime` so services consume the active Supabase endpoints/keys |
+| Cross-store bootstrap | `make bootstrap-data` | Reconciles Supabase schema, Neo4j aliases, and Qdrant/Meili indexes in the intended order |
+| Retrieval integration | `make smoke` | Verifies PostgREST, graph warmup, and vector/lexical retrieval paths together |
+| Automation layer | `make up-n8n` then `make n8n-api-bootstrap` | Adds workflow orchestration without changing the base data-plane contract |
+| Release/CVE posture | `make monitoring-smoke-prod` and `make ghcr-prepublish-inrepo` | Confirms runtime health and image-scan posture before promotion |
 
 ## Re-running Portions
 
@@ -105,20 +134,28 @@ Troubleshooting:
 | `make supa-start` | Start Supabase CLI |
 | `make supa-stop` | Stop Supabase CLI |
 | `make supa-status` | Check Supabase status |
+| `make supa-runtime-guard SUPABASE_RUNTIME=<cli\|compose>` | Fail fast on mixed-runtime drift |
 | `make supabase-bootstrap` | Replay migrations/seeds |
 | `make neo4j-bootstrap` | Seed Neo4j |
 | `make seed-data` | Seed Qdrant/Meili |
 | `make bootstrap-data` | Full data bootstrap |
 | `make up` | Start core services |
 | `make up-agents-ui` | Start agents + UIs |
+| `make up-n8n` | Start optional workflow control plane |
 | `make status-all` | Check all service health |
 | `make smoke` | Run smoke tests |
+| `make monitoring-smoke-prod` | Production-profile observability verification |
+| `make ghcr-prepublish-inrepo` | Local-first image + Trivy release gate |
 
 The first-run command is safe to repeat; it will only restart services or reapply seeds where necessary and provides clear output when manual follow-up is required.
 
 ## Additional Docs
 
 - [Local Development & Networking](LOCAL_DEV.md) — service ports, Supabase runtime modes, and Cloudflare tunnel guidance
+- [Make Targets](MAKE_TARGETS.md) — canonical command map for bring-up, smokes, GHCR gates, and runner checks
+- [Supabase Service Guide](../services/supabase/README.md) — runtime choices, data-service contract, and maintenance notes
 - [Local Tooling Reference](LOCAL_TOOLING_REFERENCE.md) — make/CLI helpers, mini CLI commands, env scripts
 - [External Integrations Bring-Up](../EXTERNAL_INTEGRATIONS_BRINGUP.md) — deeper dives on Wger, Firefly, Jellyfin, Open Notebook runbooks
-- [PMOVES Docs Index](PMOVES.AI%20PLANS/README_DOCS_INDEX.md) — curated links by integration or roadmap item
+- [Production Audit Dashboard](../PRODUCTION_AUDIT_DASHBOARD.md) — live counters and release evidence surface
+- [Hardening Tracker](../../../docs/hardening/PMOVES-hardening-tracker.md) — recurring release-note / CVE cadence and unresolved posture items
+- [PMOVES Docs Index](../PMOVES.AI%20PLANS/README_DOCS_INDEX.md) — curated links by integration or roadmap item

--- a/pmoves/docs/operations/MAKE_TARGETS.md
+++ b/pmoves/docs/operations/MAKE_TARGETS.md
@@ -11,6 +11,23 @@ This file summarizes the most-used targets and maps them to what they do under d
 - `make down`
   - Stops the compose project containers.
 
+## Data Services Provisioning
+- `make first-run`
+  - Guided umbrella path for a fresh checkout: env prep, Supabase bootstrap, data seeding, core services, agent mesh.
+- `make bringup-layered`
+  - Deterministic operator path when you want each layer explicit: minimal -> model-management -> workers -> agents -> monitoring -> prod smoke.
+  - Layered helpers default to `SUPABASE_RUNTIME=cli` unless you override it, which is useful for schema/bootstrap parity.
+- `make bootstrap-data`
+  - Canonical cross-store seed path: Supabase SQL first, then Neo4j aliases/geometry, then Qdrant + Meilisearch corpus.
+- `make neo4j-bootstrap`
+  - Rebuilds only the graph/alias layer.
+- `make seed-data`
+  - Rebuilds only the vector + lexical retrieval layer (Qdrant / Meilisearch).
+- `make up-n8n`
+  - Starts the optional workflow/control-plane layer after the base data plane is healthy.
+- `make n8n-api-bootstrap`
+  - Bootstraps n8n owner/API state so workflow registry sync and creator automation do not depend on manual UI setup.
+
 ## GPU / Gateways
 - `make up-gpu-gateways`
   - Soft-starts qdrant + neo4j, then brings up `hi-rag-gateway-v2-gpu` (and v1-gpu if profile enabled).
@@ -71,7 +88,7 @@ This file summarizes the most-used targets and maps them to what they do under d
     - `SUPABASE_RUNTIME=cli` → Supabase CLI stack (`supabase start --network-id pmoves-net`)
     - `SUPABASE_RUNTIME=kong|compose` → Compose-backed Supabase + Kong path
   - Runtime guard is enforced before startup (prevents mixed CLI+compose state). Set `SUPABASE_RUNTIME_RECONCILE=1` to auto-stop the conflicting runtime.
-  - Branch default is `SUPABASE_RUNTIME=compose` (CLI is backup/bootstrap only).
+  - `pmoves/Makefile` currently defaults to `SUPABASE_RUNTIME=compose`, but operators should set the runtime explicitly so bootstrap/data repair (`cli`) and release-mode parity (`compose`) do not silently diverge.
   - Uses the port overrides from `supabase/config.toml` for CLI mode (65421/65432/etc.).
 - `make supa-runtime-guard SUPABASE_RUNTIME=cli|compose`
   - Verifies only the selected Supabase runtime is active.
@@ -158,6 +175,31 @@ This file summarizes the most-used targets and maps them to what they do under d
   - Hits the nginx proxy on `http://localhost:8000` (override via `WGER_ROOT_URL`) plus `/static/images/logos/logo-font.svg` to ensure collectstatic artifacts and the Django backend are available.
 - `make smoke-firefly`
   - Pings the Firefly III login landing page and `/api/v1/about` (using `FIREFLY_ACCESS_TOKEN` from your shell or `env.shared`) to confirm the finance stack and API token are wired up. Override `FIREFLY_ROOT_URL` / `FIREFLY_PORT` when testing remote hosts.
+
+## Release Notes / CVE Intake
+- Scheduled workflow signals
+  - `.github/workflows/codeql.yml`
+    - Continuous code scanning on push/PR plus scheduled sweeps.
+  - `.github/workflows/yt-dlp-bump.yml`
+    - Weekly dependency freshness lane for the PMOVES.YT extractor/tooling surface.
+  - `.github/workflows/python-images-toolchain-canary.yml`
+    - Weekly pinned Python image canary: candidate bump -> build -> Trivy gate -> PR on pass.
+- Operator gates before release or promotion
+  - `make ghcr-prepublish-inrepo`
+    - Local-first build + Trivy validation for in-repo integration images.
+  - `make ghcr-prepublish-all`
+    - Same idea, expanded across the full matrix including external integrations.
+  - `make smoke-prod`
+    - Runtime + observability confirmation before a release decision.
+  - `make audit-layers-static` / `make audit-layers-runtime`
+    - Full certification gates when submodule, runtime, or hardening drift needs to be closed out.
+  - `make ci-runners-check-strict`
+    - Fails early when the runner lanes needed for CodeQL/GHCR release work are offline.
+- Documentation sinks
+  - `pmoves/docs/PRODUCTION_AUDIT_DASHBOARD.md`
+    - Live counters, release evidence, and current blocker view.
+  - `docs/hardening/PMOVES-hardening-tracker.md`
+    - Recurring cadence, unresolved issue classes, and how release-note/CVE signals are funneled.
 
 ## Preflight & Bring-up UX
 - `make env-setup`

--- a/pmoves/docs/services/README.md
+++ b/pmoves/docs/services/README.md
@@ -2,6 +2,13 @@
 
 This index groups service docs by role. Each service page follows a common structure: Overview, Compose/Ports, Dependencies, Env, API/Contracts, Runbook, Smoke Tests, Next Steps, and Roadmap alignment.
 
+Core data plane
+- [supabase](supabase/README.md) — system-of-record, auth, REST/realtime, storage runtime choices
+- [qdrant](qdrant/README.md) — vector retrieval store
+- [meilisearch](meilisearch/README.md) — lexical retrieval store
+- [neo4j](neo4j/README.md) — graph aliases, mind-map, geometry support
+- [n8n](n8n/README.md) — optional automation/control plane layered on top of Supabase
+
 Implemented (compose-managed)
 - [agent-zero](agent-zero/README.md)
 - [archon](archon/README.md)

--- a/pmoves/docs/services/supabase/README.md
+++ b/pmoves/docs/services/supabase/README.md
@@ -16,9 +16,21 @@ Docs
 | **Lightweight fallback** — use PMOVES’ compose shim | `SUPABASE_RUNTIME=compose make up` (or `SUPA_PROVIDER=compose make up`) | Spins up Postgres + PostgREST and optional GoTrue/Storage/Realtime via `docker-compose.supabase.yml`. Good for quick smokes or when the CLI is unavailable. |
 | **Remote Supabase** — point at an existing hosted project | Populate `.env.supa.remote`, then `make supa-use-remote` → `make up` | Keeps local services lean while targeting shared data. |
 
-The Makefile picks the CLI path by default. Override with `SUPABASE_RUNTIME=compose` if you intentionally want the lightweight compose stack.
+The service guide prefers the CLI path for bootstrap parity, but `pmoves/Makefile` currently defaults to `SUPABASE_RUNTIME=compose`. Set the runtime explicitly so bootstrap/data repair (`cli`) and release-mode parity (`compose`) do not silently drift apart.
 
-## 2. Wiring the Supabase CLI stack
+## 2. Data services provisioning contract
+
+| Plane | Canonical owner | Bring-up / seed path | Main consumers |
+| --- | --- | --- | --- |
+| System of record | Supabase | `make supa-start` + `make supabase-bootstrap` or `SUPABASE_RUNTIME=compose make up` when intentionally validating the compose lane | UI, Agent Zero, publisher, channel-monitor, model registry, n8n registry |
+| Vector retrieval | Qdrant | `make seed-data` or `make bootstrap-data` | Hi-RAG v1/v2, extract-worker, pdf-ingest, PMOVES.YT |
+| Lexical retrieval | Meilisearch | `make seed-data` or `make bootstrap-data` | Hi-RAG v2, extract-worker |
+| Graph/mind-map | Neo4j | `make neo4j-bootstrap` or `make bootstrap-data` | Hi-RAG entity warmup, CHIT geometry, mind-map overlays |
+| Automation/control plane | n8n | `make up-n8n` + `make n8n-api-bootstrap` | Creator/publishing workflows, workflow registry sync, approval automation |
+
+The intended order is Supabase first, then graph/vector/lexical stores, then optional automation. `make bootstrap-data` is the canonical shortcut because it keeps those boundaries intact without forcing everything to be rebuilt every time.
+
+## 3. Wiring the Supabase CLI stack
 
 1. **Install the CLI** (one-time): `winget install supabase.supabase` on Windows or `npm i -g supabase` on macOS/Linux.  
 2. **Initialise the project** (one-time): `make supa-init` → creates `supabase/config.toml`.
@@ -54,7 +66,11 @@ The Makefile picks the CLI path by default. Override with `SUPABASE_RUNTIME=comp
 | `make supabase-stop` / `make supabase-clean` | Stop or clear the compose-based Supabase services (no-op under CLI runtime) |
 | `SUPABASE_RUNTIME=compose make up` | Run PMOVES with compose-backed Postgres/PostgREST |
 
-## 3. Avoiding “service missing” errors
+For modular operator work, prefer explicit commands instead of relying on whichever runtime default happens to be active:
+- `SUPABASE_RUNTIME=cli make up` when you are repairing bootstrap, keys, migrations, or cross-store data seeding.
+- `SUPABASE_RUNTIME=compose make up` plus `make supa-runtime-guard` when you are certifying release-mode topology or Kong-facing behavior.
+
+## 4. Avoiding “service missing” errors
 
 **Neo4j / Qdrant / MinIO**  
 The hi-rag gateways and geometry smokes expect the data profile to be running. `make up` already brings the `data` profile online; if you start services manually, ensure you include it:
@@ -71,7 +87,7 @@ Realtime must be running when you mirror the production stack. Start the CLI wit
 **CLI vs Compose PostgREST**  
 When the CLI stack is active, the Makefile detects `supabase_db_<project>` containers and applies migrations there. If you stop the CLI stack and flip to compose, run `SUPABASE_RUNTIME=compose make up` followed by `make supabase-up` to ensure PostgREST and the ancillary services are reachable at `http://postgrest:3000`.
 
-## 4. Health checklist
+## 5. Health checklist
 
 | Check | Command | Expected |
 | --- | --- | --- |
@@ -80,7 +96,7 @@ When the CLI stack is active, the Makefile detects `supabase_db_<project>` conta
 | Supabase status | `make supa-status` | Lists service ports + anon/service keys |
 | Geometry warmup | `docker logs pmoves-hi-rag-gateway-v2-gpu-1 | grep 'Supabase realtime geometry listener started'` | Confirms the gateway subscribed to `geometry.cgp.v1` over WebSocket |
 
-## 5. Troubleshooting
+## 6. Troubleshooting
 
 | Symptom | Resolution |
 | --- | --- |
@@ -90,7 +106,7 @@ When the CLI stack is active, the Makefile detects `supabase_db_<project>` conta
 | Need to reset CLI data | `make supa-stop` → delete the `.supabase` Docker volumes → `make supa-start` → `make supabase-bootstrap`. |
 | Supabase CLI fails to start with `no space left on device` | Stop the stack (`make supa-stop`), inspect disk usage (`docker system df`, `df -h`), free space by pruning unused images/volumes (`docker system prune -a`) or expanding the storage pool, then restart (`make supa-start`) and rerun `make supabase-bootstrap`. |
 
-## 6. Upgrade & maintenance
+## 7. Upgrade & maintenance
 
 Keep the CLI aligned with upstream releases so Postgres extensions, GoTrue, and Storage stay compatible.
 
@@ -120,7 +136,19 @@ Keep the CLI aligned with upstream releases so Postgres extensions, GoTrue, and 
 - Snapshot your `.supabase` Docker volumes (`docker run --rm -v supabase_db:/data busybox tar -czf /backups/supabase_db.tgz /data`) before a major upgrade when you need a rollback option.
 - After large upgrades, verify Supabase Studio loads and PostgREST returns `200` before resuming feature work.
 
-## 7. References
+## 8. Release notes, CVEs, and docs touchpoints
+
+- Use `pmoves/docs/PRODUCTION_AUDIT_DASHBOARD.md` for live CodeQL/Dependabot/open-PR counters.
+- Use `docs/hardening/PMOVES-hardening-tracker.md` for the recurring cadence around release notes, Trivy gates, and weekly update lanes.
+- When the Supabase command path or data-service ownership changes, update these docs in the same PR:
+  - `pmoves/docs/operations/FIRST_RUN.md`
+  - `pmoves/docs/operations/MAKE_TARGETS.md`
+  - `pmoves/docs/PMOVES.AI PLANS/README_DOCS_INDEX.md`
+  - `pmoves/docs/NEXT_STEPS.md`
+  - `pmoves/docs/PMOVES.AI PLANS/ROADMAP.md`
+- Treat scheduled CodeQL, `yt-dlp-bump`, and the Python toolchain canary as the routine release-note/CVE intake funnel; use `make ghcr-prepublish-inrepo` and `make smoke-prod` before promotion when a data-plane dependency changes.
+
+## 9. References
 
 - [Supabase CLI configuration (`config.toml` service toggles)](https://supabase.com/docs/reference/cli/config#service-options)
 - [Supabase CLI `start` command options (`-x/--exclude`)](https://supabase.com/docs/reference/cli/start#options)


### PR DESCRIPTION
## Summary
- align the canonical operator docs around one modular data-services provisioning contract across Supabase, Neo4j, Qdrant, Meilisearch, and optional n8n
- make the Supabase runtime choice explicit so bootstrap/data-repair and release-mode parity do not silently drift
- document the existing release-note / CVE intake funnel using CodeQL, weekly bump/canary workflows, local GHCR+Trivy gates, and the dashboard/hardening docs

## Testing
- git diff --check

## Reviewer Notes
- Docs-only PR.
- This intentionally updates existing canonical docs instead of adding another parallel runbook.
- The goal is to give the z890 node and the in-flight Supabase work one operator-facing source of truth for data-plane layering and maintenance cadence.
- Operational note: this PR documents the intended contract, but the live Supabase/runtime lane still needs to be reconciled against the running node work when Claude is available again.