### PR TITLE
fix(schema): add IF EXISTS guard + idempotent claim predicate to publisher RPCs

### DIFF
--- a/pmoves/docs/NEXT_STEPS.md
+++ b/pmoves/docs/NEXT_STEPS.md
@@ -1,7 +1,7 @@
 
 # PMOVES v5 • NEXT_STEPS
 Note: Consolidated plan index at pmoves/docs/PMOVES.AI PLANS/README_DOCS_INDEX.md.
-_Last updated: 2026-03-12_
+_Last updated: 2026-03-26_
 
 ## Current Status
 

--- a/pmoves/supabase/initdb/18_publisher_publish_state.sql
+++ b/pmoves/supabase/initdb/18_publisher_publish_state.sql
@@ -1,9 +1,16 @@
 alter table if exists public.studio_board
   add column if not exists updated_at timestamptz default now();
 
-update public.studio_board
-set updated_at = coalesce(updated_at, created_at, now())
-where updated_at is null;
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'studio_board'
+  ) THEN
+    UPDATE public.studio_board
+    SET updated_at = coalesce(updated_at, created_at, now())
+    WHERE updated_at IS NULL;
+  END IF;
+END $$;
 
 create or replace function public.set_studio_board_updated_at()
 returns trigger
@@ -110,6 +117,16 @@ begin
     return false;
   end if;
 
+  -- Idempotency: already claimed with this request_id → no-op success
+  if exists (
+    select 1 from public.studio_board
+    where id = p_row_id
+      and status = 'publishing'
+      and coalesce(meta->>'publish_request_id', '') = p_publish_event_id
+  ) then
+    return true;
+  end if;
+
   update public.studio_board
   set status = 'publishing',
       meta = (
@@ -130,13 +147,7 @@ begin
       )
   where id = p_row_id
     and coalesce(meta->>'publish_event_sent_at', '') = ''
-    and (
-      status = 'approved'
-      or (
-        status = 'publishing'
-        and coalesce(meta->>'publish_request_id', '') = p_publish_event_id
-      )
-    );
+    and status = 'approved';
 
   get diagnostics updated_rows = row_count;
   return updated_rows > 0;

--- a/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
+++ b/pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql
@@ -1,9 +1,16 @@
 alter table if exists public.studio_board
   add column if not exists updated_at timestamptz default now();
 
-update public.studio_board
-set updated_at = coalesce(updated_at, created_at, now())
-where updated_at is null;
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'studio_board'
+  ) THEN
+    UPDATE public.studio_board
+    SET updated_at = coalesce(updated_at, created_at, now())
+    WHERE updated_at IS NULL;
+  END IF;
+END $$;
 
 create or replace function public.set_studio_board_updated_at()
 returns trigger
@@ -110,6 +117,16 @@ begin
     return false;
   end if;
 
+  -- Idempotency: already claimed with this request_id → no-op success
+  if exists (
+    select 1 from public.studio_board
+    where id = p_row_id
+      and status = 'publishing'
+      and coalesce(meta->>'publish_request_id', '') = p_publish_event_id
+  ) then
+    return true;
+  end if;
+
   update public.studio_board
   set status = 'publishing',
       meta = (
@@ -130,13 +147,7 @@ begin
       )
   where id = p_row_id
     and coalesce(meta->>'publish_event_sent_at', '') = ''
-    and (
-      status = 'approved'
-      or (
-        status = 'publishing'
-        and coalesce(meta->>'publish_request_id', '') = p_publish_event_id
-      )
-    );
+    and status = 'approved';
 
   get diagnostics updated_rows = row_count;
   return updated_rows > 0;

--- a/pmoves/supabase/migrations/20260326001000_claim_if_exists_and_idempotent.sql
+++ b/pmoves/supabase/migrations/20260326001000_claim_if_exists_and_idempotent.sql
@@ -1,0 +1,70 @@
+-- P1 fix: wrap bare UPDATE in IF EXISTS guard so fresh DBs without
+-- studio_board do not crash during migration.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'studio_board'
+  ) THEN
+    UPDATE public.studio_board
+    SET updated_at = coalesce(updated_at, created_at, now())
+    WHERE updated_at IS NULL;
+  END IF;
+END $$;
+
+-- P1 fix: replace claim_studio_board_publish with idempotent variant.
+-- Previously the WHERE clause re-ran the full UPDATE on rows already in
+-- 'publishing' status with the same publish_request_id, creating a TOCTOU
+-- race window.  The new version checks for already-claimed rows first and
+-- returns true (no-op) without touching the row.
+create or replace function public.claim_studio_board_publish(
+  p_row_id bigint,
+  p_publish_event_id text,
+  p_requested_at timestamptz default now()
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_rows integer := 0;
+begin
+  if p_row_id is null or p_publish_event_id is null or btrim(p_publish_event_id) = '' then
+    return false;
+  end if;
+
+  -- Idempotency: already claimed with this request_id -> no-op success
+  if exists (
+    select 1 from public.studio_board
+    where id = p_row_id
+      and status = 'publishing'
+      and coalesce(meta->>'publish_request_id', '') = p_publish_event_id
+  ) then
+    return true;
+  end if;
+
+  update public.studio_board
+  set status = 'publishing',
+      meta = (
+        (
+          coalesce(meta, '{}'::jsonb)
+          - 'publish_failed_at'
+          - 'publish_failure_reason'
+          - 'publish_failure_stage'
+          - 'publish_failure_meta'
+        )
+        || jsonb_build_object(
+          'studio_board_id', id,
+          'publish_state', 'publishing',
+          'publish_request_id', p_publish_event_id,
+          'publish_requested_at', p_requested_at,
+          'publish_request_source', 'publisher'
+        )
+      )
+  where id = p_row_id
+    and coalesce(meta->>'publish_event_sent_at', '') = ''
+    and status = 'approved';
+
+  get diagnostics updated_rows = row_count;
+  return updated_rows > 0;
+end;
+$$;


### PR DESCRIPTION
## Summary

- **P1-1**: Wrap bare `UPDATE public.studio_board` in `DO $$ IF EXISTS` block so fresh databases without the table do not crash during bootstrap migration
- **P1-2**: Separate idempotency check from claim UPDATE in `claim_studio_board_publish()` — previously the WHERE clause re-ran the full UPDATE on rows already in `publishing` with the same `publish_request_id`, creating a TOCTOU race window. Now: EXISTS check returns true (no-op), UPDATE only fires from `approved`
- Add incremental migration `20260326001000` that applies both fixes to live databases
- Update NEXT_STEPS.md timestamp to 2026-03-26

Fixes review findings from #1114 (which is fully subsumed by #1100/#1105/#1106/#1107 on main).

**Supersedes #1114** — that PR's 3 commits are all already on main; a rebase would produce empty commits.

## Files Changed

| File | Change |
|------|--------|
| `pmoves/supabase/initdb/18_publisher_publish_state.sql` | IF EXISTS guard + idempotent claim |
| `pmoves/supabase/migrations/20260325110000_publisher_publish_state.sql` | Same (kept in sync) |
| `pmoves/supabase/migrations/20260326001000_claim_if_exists_and_idempotent.sql` | **NEW** incremental migration |
| `pmoves/docs/NEXT_STEPS.md` | Timestamp update |

## Test plan

- [ ] SQL Policy Lint CI passes
- [ ] CHIT Contract Check CI passes
- [ ] Python Tests pass
- [ ] Verify initdb and migration claim functions are identical (`diff` shows no differences)
- [ ] Trace claim flow: first call (approved→publishing), second call (idempotent true), different request_id (false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced publishing reliability with idempotency checks to prevent unintended state changes when operations are retried
  * Improved database safety by adding conditional schema validation before executing critical updates, ensuring stable operations across different database states

* **Chores**
  * Updated documentation metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->