### PR TITLE
feat(ui): expose publish pipeline states

### DIFF
--- a/pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md
+++ b/pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md
@@ -4,7 +4,7 @@ GRAPHITI_MARK: `PHI-4482-ROADMAP::W1-W6::PMOVES`
 
 > **Scratchpad**: All agents (5090-claude, z890-claude, 4090-claude, codex) read this before claiming workstream lanes.
 > **Origin**: 4090-claude session 2026-03-19, approved by DARKXSIDE.
-> **Status**: ACTIVE — refreshed 2026-03-28 after room/stage merge wave and upstream Agent Zero / ClaWz validation.
+> **Status**: ACTIVE — refreshed 2026-03-28 after room/stage merge wave, publish-state visibility (#1135), and upstream Agent Zero / ClaWz validation.
 
 ---
 
@@ -442,14 +442,14 @@ All resolved. No blockers.
 
 | PR | Lane | Status | Notes |
 |----|------|--------|-------|
-| #1135 | Publish-state visibility (`studio-board` + `videos`) | OPEN — blocked by shared Playwright gate | Fast checks are green, review fixes are pushed, and the only remaining failure matches the same 119-failure Playwright signature already reproducing on `main` |
+| #1135 | Publish-state visibility (`studio-board` + `videos`) | OPEN — merge-prep | CodeRabbit findings fixed locally; remaining failing UI checks are reproducing on `main` |
 | #1136 | Room catalog contracts + dashboard loader | OPEN | Base lane for the stacked room-entry flow |
 | #1137 | Home launcher room-entry routing | OPEN — stacked on #1136 | Review after the room-catalog base lane lands |
 | #1138 | z890 fleet networking + RustDesk relay + hardening | OPEN — CONFLICTING | Needs rebase/splitting; CodeRabbit flagged TAC/compose/Flute issues that still need follow-through |
 
 **March 26/27 merge wave already landed:** #1115, #1116, #1117, #1118, #1119, #1120, #1121, #1122, #1123, #1124, #1126.
 
-**Recommended review order:** decide the branch-protection path for #1135 first, then #1136, then #1137, then rebase/split #1138 before another serious review pass.
+**Recommended review order:** #1135 first, then #1136, then #1137, then rebase/split #1138 before another serious review pass.
 
 ---
 
@@ -485,8 +485,9 @@ All resolved. No blockers.
 | Infra (Model Registry HF enrichment) | 4090-claude | 2026-03-24 | SHIPPED `07d06f70` | feat/chit-integration-wave-1 |
 | Infra (Model seed + gpu-models metadata) | 4090-claude | 2026-03-24 | SHIPPED `50ee0022`, `7cfacc8c` | feat/chit-integration-wave-1 |
 | Infra (BoTZ submodule sync d125e8a) | 4090-claude | 2026-03-24 | SHIPPED `63532a6b` | feat/chit-integration-wave-1 |
+| W3/M2 (shared publish-state visibility across dashboards) | codex-gpt5 | 2026-03-27 | IN PR #1135 — review fixes applied locally | codex/agnote4482-publish-state-visibility |
 | W3/M2 (creator automation activation + Discord canonical lane audit) | codex-gpt5 | 2026-03-25 | RECOMMENDED — scan complete, pending implementation claim | — |
-| W3/M2 (studio-board status UX: approved -> published visibility) | codex-gpt5 | 2026-03-25 | RECOMMENDED — UI follow-through after canonical lane decision | — |
+| W3/M2 (studio-board status UX: approved→published visibility) | codex-gpt5 | 2026-03-26 | ACTIVE — #1120 merged, #1135 in review | — |
 | W2/W4 (rooms + stage prospectus alignment) | codex-gpt5 | 2026-03-28 | RECOMMENDED — docs update required after room manifest merge wave | — |
 | W2/W5 (Agent Zero upstream `v1.3` baseline vs PMOVES hardened suit gap report) | codex-gpt5 | 2026-03-28 | VERIFIED — upstream at `v1.3`, PMOVES pin still Mar 7 hardened commit | — |
 
@@ -525,10 +526,7 @@ All resolved. No blockers.
 | 1 | Publish the Agent Zero `v1.3` gap report for PMOVES hardened fork | **P0** | Use upstream `v1.3` as the baseline, then classify PMOVES-only overlays that must survive a sync |
 | 2 | Publish the PMOVES-ClawZ gap report | **P0** | Capture upstream/fork/orphaned-gitlink reality before more ClaW suit positioning |
 | 3 | Align AGNOTE/P7/website language around rooms + stage | **P0** | Make the prospectus consistent across school/company/site docs |
-| 4 | Keep ClaWz/Agent Zero suit config coding-plan aligned | **P0** | Tie the room-aware suit story back to real profile ids and approved remote coding lanes |
-| 5 | Close Supabase -> Agent Zero -> Publisher -> Discord activation loop | **P0** | Validate `approval_poller.json` + `echo_publisher.json`; capture first real published-event evidence |
-| 6 | Pick canonical Discord publish lane | **P0** | Decide between `publisher-discord` NATS subscriber and n8n webhook relay; demote the other to fallback/test-only |
-| 7 | Add creator dashboard state clarity | P1 | Make `studio-board` and `videos` distinguish `approved, waiting for poller` vs `published` |
-| 8 | Validate Discord approval workflow for creator-control | P1 | Exercise channel-monitor queue/review endpoints with messaging-gateway callbacks and record rejection UX gaps |
-| 9 | Surface publish failures + backfill readiness | P2 | Turn publisher audit/backfill work into an operator-visible lane before broader M2 expansion |
-| 7 | Surface publish failures + backfill readiness | P2 | Turn publisher audit/backfill work into an operator-visible lane before broader M2 expansion |
+| 4 | Close Supabase→Agent Zero→Publisher→Discord activation loop | **P0** | Validate `approval_poller.json` + `echo_publisher.json`; capture first published-event evidence |
+| 5 | Pick canonical Discord publish lane | **P0** | Decide between `publisher-discord` NATS subscriber and n8n webhook relay; demote the other |
+| 6 | Merge PR #1135 (publish-state visibility) | **P0** | CodeRabbit findings addressed; E2E red is reproducing on `main` |
+| 7 | Surface publish failures + backfill readiness | P2 | Turn publisher audit into an operator-visible lane after the real loop is proven end-to-end |

--- a/pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md
+++ b/pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md
@@ -4,7 +4,7 @@ GRAPHITI_MARK: `PHI-4482-ROADMAP::W1-W6::PMOVES`
 
 > **Scratchpad**: All agents (5090-claude, z890-claude, 4090-claude, codex) read this before claiming workstream lanes.
 > **Origin**: 4090-claude session 2026-03-19, approved by DARKXSIDE.
-> **Status**: ACTIVE — refreshed 2026-03-28 after room/stage merge wave, publish-state visibility (#1135), and upstream Agent Zero / ClaWz validation.
+> **Status**: ACTIVE — refreshed 2026-03-28 after room/stage merge wave and upstream Agent Zero / ClaWz validation.
 
 ---
 
@@ -442,14 +442,14 @@ All resolved. No blockers.
 
 | PR | Lane | Status | Notes |
 |----|------|--------|-------|
-| #1135 | Publish-state visibility (`studio-board` + `videos`) | OPEN — merge-prep | CodeRabbit findings fixed locally; remaining failing UI checks are reproducing on `main` |
+| #1135 | Publish-state visibility (`studio-board` + `videos`) | OPEN — blocked by shared Playwright gate | Fast checks are green, review fixes are pushed, and the only remaining failure matches the same 119-failure Playwright signature already reproducing on `main` |
 | #1136 | Room catalog contracts + dashboard loader | OPEN | Base lane for the stacked room-entry flow |
 | #1137 | Home launcher room-entry routing | OPEN — stacked on #1136 | Review after the room-catalog base lane lands |
 | #1138 | z890 fleet networking + RustDesk relay + hardening | OPEN — CONFLICTING | Needs rebase/splitting; CodeRabbit flagged TAC/compose/Flute issues that still need follow-through |
 
 **March 26/27 merge wave already landed:** #1115, #1116, #1117, #1118, #1119, #1120, #1121, #1122, #1123, #1124, #1126.
 
-**Recommended review order:** #1135 first, then #1136, then #1137, then rebase/split #1138 before another serious review pass.
+**Recommended review order:** decide the branch-protection path for #1135 first, then #1136, then #1137, then rebase/split #1138 before another serious review pass.
 
 ---
 
@@ -485,9 +485,8 @@ All resolved. No blockers.
 | Infra (Model Registry HF enrichment) | 4090-claude | 2026-03-24 | SHIPPED `07d06f70` | feat/chit-integration-wave-1 |
 | Infra (Model seed + gpu-models metadata) | 4090-claude | 2026-03-24 | SHIPPED `50ee0022`, `7cfacc8c` | feat/chit-integration-wave-1 |
 | Infra (BoTZ submodule sync d125e8a) | 4090-claude | 2026-03-24 | SHIPPED `63532a6b` | feat/chit-integration-wave-1 |
-| W3/M2 (shared publish-state visibility across dashboards) | codex-gpt5 | 2026-03-27 | IN PR #1135 — review fixes applied locally | codex/agnote4482-publish-state-visibility |
 | W3/M2 (creator automation activation + Discord canonical lane audit) | codex-gpt5 | 2026-03-25 | RECOMMENDED — scan complete, pending implementation claim | — |
-| W3/M2 (studio-board status UX: approved→published visibility) | codex-gpt5 | 2026-03-26 | ACTIVE — #1120 merged, #1135 in review | — |
+| W3/M2 (studio-board status UX: approved -> published visibility) | codex-gpt5 | 2026-03-25 | RECOMMENDED — UI follow-through after canonical lane decision | — |
 | W2/W4 (rooms + stage prospectus alignment) | codex-gpt5 | 2026-03-28 | RECOMMENDED — docs update required after room manifest merge wave | — |
 | W2/W5 (Agent Zero upstream `v1.3` baseline vs PMOVES hardened suit gap report) | codex-gpt5 | 2026-03-28 | VERIFIED — upstream at `v1.3`, PMOVES pin still Mar 7 hardened commit | — |
 
@@ -526,7 +525,10 @@ All resolved. No blockers.
 | 1 | Publish the Agent Zero `v1.3` gap report for PMOVES hardened fork | **P0** | Use upstream `v1.3` as the baseline, then classify PMOVES-only overlays that must survive a sync |
 | 2 | Publish the PMOVES-ClawZ gap report | **P0** | Capture upstream/fork/orphaned-gitlink reality before more ClaW suit positioning |
 | 3 | Align AGNOTE/P7/website language around rooms + stage | **P0** | Make the prospectus consistent across school/company/site docs |
-| 4 | Close Supabase→Agent Zero→Publisher→Discord activation loop | **P0** | Validate `approval_poller.json` + `echo_publisher.json`; capture first published-event evidence |
-| 5 | Pick canonical Discord publish lane | **P0** | Decide between `publisher-discord` NATS subscriber and n8n webhook relay; demote the other |
-| 6 | Merge PR #1135 (publish-state visibility) | **P0** | CodeRabbit findings addressed; E2E red is reproducing on `main` |
-| 7 | Surface publish failures + backfill readiness | P2 | Turn publisher audit into an operator-visible lane after the real loop is proven end-to-end |
+| 4 | Keep ClaWz/Agent Zero suit config coding-plan aligned | **P0** | Tie the room-aware suit story back to real profile ids and approved remote coding lanes |
+| 5 | Close Supabase -> Agent Zero -> Publisher -> Discord activation loop | **P0** | Validate `approval_poller.json` + `echo_publisher.json`; capture first real published-event evidence |
+| 6 | Pick canonical Discord publish lane | **P0** | Decide between `publisher-discord` NATS subscriber and n8n webhook relay; demote the other to fallback/test-only |
+| 7 | Add creator dashboard state clarity | P1 | Make `studio-board` and `videos` distinguish `approved, waiting for poller` vs `published` |
+| 8 | Validate Discord approval workflow for creator-control | P1 | Exercise channel-monitor queue/review endpoints with messaging-gateway callbacks and record rejection UX gaps |
+| 9 | Surface publish failures + backfill readiness | P2 | Turn publisher audit/backfill work into an operator-visible lane before broader M2 expansion |
+| 7 | Surface publish failures + backfill readiness | P2 | Turn publisher audit/backfill work into an operator-visible lane before broader M2 expansion |

--- a/pmoves/ui/__tests__/publishState.test.ts
+++ b/pmoves/ui/__tests__/publishState.test.ts
@@ -109,4 +109,19 @@ describe("describePublishState", () => {
       tone: "danger",
     });
   });
+
+  it("treats failure stage metadata alone as a retry signal", () => {
+    expect(
+      describePublishState({
+        meta: {
+          publish_failure_stage: "discord_webhook",
+        },
+      })
+    ).toEqual({
+      label: "needs retry",
+      detailLabel: "failure stage:",
+      detailValue: "discord_webhook",
+      tone: "danger",
+    });
+  });
 });

--- a/pmoves/ui/__tests__/publishState.test.ts
+++ b/pmoves/ui/__tests__/publishState.test.ts
@@ -1,4 +1,7 @@
-import { describePublishState } from "../app/dashboard/publishState";
+import {
+  describePublishState,
+  shouldRenderSupplementalPublishFailureDetail,
+} from "../app/dashboard/publishState";
 
 describe("describePublishState", () => {
   it("returns waiting for poller after approval before publisher metadata arrives", () => {
@@ -123,5 +126,45 @@ describe("describePublishState", () => {
       detailValue: "discord_webhook",
       tone: "danger",
     });
+  });
+
+  it("returns null when no approval or publish signals are present", () => {
+    expect(describePublishState({ meta: {} })).toBeNull();
+  });
+});
+
+describe("shouldRenderSupplementalPublishFailureDetail", () => {
+  it("hides duplicate failure text when the summary already shows a failure timestamp", () => {
+    expect(
+      shouldRenderSupplementalPublishFailureDetail(
+        {
+          label: "needs retry",
+          detailLabel: "failed @",
+          detailValue: "2026-03-27T09:21:00Z",
+          tone: "danger",
+        },
+        "publish failure:"
+      )
+    ).toBe(false);
+  });
+
+  it("shows supplemental failure text when the summary is empty", () => {
+    expect(
+      shouldRenderSupplementalPublishFailureDetail(null, "failure stage:")
+    ).toBe(true);
+  });
+
+  it("hides supplemental failure text when the current summary is not a failure", () => {
+    expect(
+      shouldRenderSupplementalPublishFailureDetail(
+        {
+          label: "publish complete",
+          detailLabel: "published @",
+          detailValue: "2026-03-27T09:20:00Z",
+          tone: "success",
+        },
+        "publish failure:"
+      )
+    ).toBe(false);
   });
 });

--- a/pmoves/ui/__tests__/publishState.test.ts
+++ b/pmoves/ui/__tests__/publishState.test.ts
@@ -1,0 +1,82 @@
+import { describePublishState } from "../app/dashboard/publishState";
+
+describe("describePublishState", () => {
+  it("returns waiting for poller after approval before publisher metadata arrives", () => {
+    expect(
+      describePublishState({
+        approvalStatus: "approved",
+        reviewedAt: "2026-03-27T09:15:00Z",
+        meta: {},
+      })
+    ).toEqual({
+      label: "waiting for poller",
+      detailLabel: "approved @",
+      detailValue: "2026-03-27T09:15:00Z",
+      tone: "default",
+    });
+  });
+
+  it("shows approval relayed after the poller stamps handoff metadata", () => {
+    expect(
+      describePublishState({
+        rowStatus: "publishing",
+        meta: {
+          publish_approval_event_sent_at: "2026-03-27T09:18:00Z",
+        },
+      })
+    ).toEqual({
+      label: "approval relayed",
+      detailLabel: "approval relayed @",
+      detailValue: "2026-03-27T09:18:00Z",
+      tone: "default",
+    });
+  });
+
+  it("shows publisher active once the publisher starts processing", () => {
+    expect(
+      describePublishState({
+        rowStatus: "publishing",
+        meta: {
+          publish_started_at: "2026-03-27T09:19:00Z",
+        },
+      })
+    ).toEqual({
+      label: "publisher active",
+      detailLabel: "publisher started @",
+      detailValue: "2026-03-27T09:19:00Z",
+      tone: "default",
+    });
+  });
+
+  it("shows publish complete once a publish event is recorded", () => {
+    expect(
+      describePublishState({
+        rowStatus: "published",
+        meta: {
+          publish_event_sent_at: "2026-03-27T09:20:00Z",
+        },
+      })
+    ).toEqual({
+      label: "publish complete",
+      detailLabel: "published @",
+      detailValue: "2026-03-27T09:20:00Z",
+      tone: "success",
+    });
+  });
+
+  it("surfaces retry guidance for failed publish attempts", () => {
+    expect(
+      describePublishState({
+        rowStatus: "publish_failed",
+        meta: {
+          publish_failure_stage: "discord_webhook",
+        },
+      })
+    ).toEqual({
+      label: "needs retry",
+      detailLabel: "failure stage:",
+      detailValue: "discord_webhook",
+      tone: "danger",
+    });
+  });
+});

--- a/pmoves/ui/__tests__/publishState.test.ts
+++ b/pmoves/ui/__tests__/publishState.test.ts
@@ -64,6 +64,36 @@ describe("describePublishState", () => {
     });
   });
 
+  it("treats publish completion metadata as complete even before the row status flips", () => {
+    expect(
+      describePublishState({
+        meta: {
+          publish_completed_at: "2026-03-27T09:20:00Z",
+        },
+      })
+    ).toEqual({
+      label: "publish complete",
+      detailLabel: "published @",
+      detailValue: "2026-03-27T09:20:00Z",
+      tone: "success",
+    });
+  });
+
+  it("shows publisher active when only the publish start metadata is available", () => {
+    expect(
+      describePublishState({
+        meta: {
+          publish_started_at: "2026-03-27T09:19:00Z",
+        },
+      })
+    ).toEqual({
+      label: "publisher active",
+      detailLabel: "publisher started @",
+      detailValue: "2026-03-27T09:19:00Z",
+      tone: "default",
+    });
+  });
+
   it("surfaces retry guidance for failed publish attempts", () => {
     expect(
       describePublishState({

--- a/pmoves/ui/app/dashboard/publishState.ts
+++ b/pmoves/ui/app/dashboard/publishState.ts
@@ -1,0 +1,146 @@
+export interface PublishMetaLike {
+  reviewed_at?: string | null;
+  publish_started_at?: string | null;
+  publish_completed_at?: string | null;
+  publish_event_sent_at?: string | null;
+  publish_requested_at?: string | null;
+  publish_approval_event_sent_at?: string | null;
+  publish_failed_at?: string | null;
+  publish_failure_reason?: string | null;
+  publish_failure_stage?: string | null;
+}
+
+export interface PublishStateSummary {
+  label: string;
+  detailLabel?: string;
+  detailValue?: string | null;
+  tone: "default" | "success" | "danger";
+}
+
+interface DescribePublishStateInput {
+  rowStatus?: string | null;
+  approvalStatus?: string | null;
+  reviewedAt?: string | null;
+  meta?: PublishMetaLike | null;
+}
+
+const normalize = (value?: string | null) => (value || "").trim().toLowerCase();
+
+export function describePublishState({
+  rowStatus,
+  approvalStatus,
+  reviewedAt,
+  meta,
+}: DescribePublishStateInput): PublishStateSummary | null {
+  const status = normalize(rowStatus);
+  const approval = normalize(approvalStatus);
+  const reviewed = reviewedAt || meta?.reviewed_at || null;
+  const publishRequestedAt = meta?.publish_requested_at || null;
+  const approvalRelayedAt = meta?.publish_approval_event_sent_at || null;
+  const publishStartedAt = meta?.publish_started_at || null;
+  const publishCompletedAt = meta?.publish_completed_at || null;
+  const publishedAt = meta?.publish_event_sent_at || null;
+  const publishFailedAt = meta?.publish_failed_at || null;
+  const publishFailureReason = meta?.publish_failure_reason || null;
+  const publishFailureStage = meta?.publish_failure_stage || null;
+
+  if (publishedAt || status === "published" || approval === "published") {
+    return {
+      label: "publish complete",
+      detailLabel: publishedAt || publishCompletedAt ? "published @" : undefined,
+      detailValue: publishedAt || publishCompletedAt,
+      tone: "success",
+    };
+  }
+
+  if (
+    status === "publish_failed" ||
+    approval === "publish_failed" ||
+    publishFailedAt ||
+    publishFailureReason
+  ) {
+    if (publishFailedAt) {
+      return {
+        label: "needs retry",
+        detailLabel: "failed @",
+        detailValue: publishFailedAt,
+        tone: "danger",
+      };
+    }
+    if (publishFailureStage) {
+      return {
+        label: "needs retry",
+        detailLabel: "failure stage:",
+        detailValue: publishFailureStage,
+        tone: "danger",
+      };
+    }
+    if (publishFailureReason) {
+      return {
+        label: "needs retry",
+        detailLabel: "publish failure:",
+        detailValue: publishFailureReason,
+        tone: "danger",
+      };
+    }
+    return { label: "needs retry", tone: "danger" };
+  }
+
+  if (status === "publishing") {
+    if (publishStartedAt) {
+      return {
+        label: "publisher active",
+        detailLabel: "publisher started @",
+        detailValue: publishStartedAt,
+        tone: "default",
+      };
+    }
+    if (approvalRelayedAt) {
+      return {
+        label: "approval relayed",
+        detailLabel: "approval relayed @",
+        detailValue: approvalRelayedAt,
+        tone: "default",
+      };
+    }
+    if (publishRequestedAt) {
+      return {
+        label: "publish requested",
+        detailLabel: "publish requested @",
+        detailValue: publishRequestedAt,
+        tone: "default",
+      };
+    }
+    return { label: "publishing", tone: "default" };
+  }
+
+  if (status === "approved" || approval === "approved") {
+    if (approvalRelayedAt) {
+      return {
+        label: "approval relayed",
+        detailLabel: "approval relayed @",
+        detailValue: approvalRelayedAt,
+        tone: "default",
+      };
+    }
+    if (publishRequestedAt) {
+      return {
+        label: "publish requested",
+        detailLabel: "publish requested @",
+        detailValue: publishRequestedAt,
+        tone: "default",
+      };
+    }
+    if (reviewed) {
+      return {
+        label: "waiting for poller",
+        detailLabel: "approved @",
+        detailValue: reviewed,
+        tone: "default",
+      };
+    }
+    return { label: "approved", tone: "default" };
+  }
+
+  return null;
+}

--- a/pmoves/ui/app/dashboard/publishState.ts
+++ b/pmoves/ui/app/dashboard/publishState.ts
@@ -26,6 +26,10 @@ interface DescribePublishStateInput {
 
 const normalize = (value?: string | null) => (value || "").trim().toLowerCase();
 
+/**
+ * Collapse publish metadata from the studio-board and videos dashboards into
+ * one operator-facing state summary.
+ */
 export function describePublishState({
   rowStatus,
   approvalStatus,
@@ -44,7 +48,12 @@ export function describePublishState({
   const publishFailureReason = meta?.publish_failure_reason || null;
   const publishFailureStage = meta?.publish_failure_stage || null;
 
-  if (publishedAt || status === "published" || approval === "published") {
+  if (
+    publishedAt ||
+    publishCompletedAt ||
+    status === "published" ||
+    approval === "published"
+  ) {
     return {
       label: "publish complete",
       detailLabel: publishedAt || publishCompletedAt ? "published @" : undefined,
@@ -86,7 +95,7 @@ export function describePublishState({
     return { label: "needs retry", tone: "danger" };
   }
 
-  if (status === "publishing") {
+  if (status === "publishing" || publishStartedAt) {
     if (publishStartedAt) {
       return {
         label: "publisher active",
@@ -114,7 +123,13 @@ export function describePublishState({
     return { label: "publishing", tone: "default" };
   }
 
-  if (status === "approved" || approval === "approved") {
+  if (
+    status === "approved" ||
+    approval === "approved" ||
+    approvalRelayedAt ||
+    publishRequestedAt ||
+    reviewed
+  ) {
     if (approvalRelayedAt) {
       return {
         label: "approval relayed",

--- a/pmoves/ui/app/dashboard/publishState.ts
+++ b/pmoves/ui/app/dashboard/publishState.ts
@@ -26,6 +26,32 @@ interface DescribePublishStateInput {
 
 const normalize = (value?: string | null) => (value || "").trim().toLowerCase();
 
+const describeQueuedPublishState = ({
+  approvalRelayedAt,
+  publishRequestedAt,
+}: {
+  approvalRelayedAt?: string | null;
+  publishRequestedAt?: string | null;
+}): PublishStateSummary | null => {
+  if (approvalRelayedAt) {
+    return {
+      label: "approval relayed",
+      detailLabel: "approval relayed @",
+      detailValue: approvalRelayedAt,
+      tone: "default",
+    };
+  }
+  if (publishRequestedAt) {
+    return {
+      label: "publish requested",
+      detailLabel: "publish requested @",
+      detailValue: publishRequestedAt,
+      tone: "default",
+    };
+  }
+  return null;
+};
+
 /**
  * Collapse publish metadata from the studio-board and videos dashboards into
  * one operator-facing state summary.
@@ -66,7 +92,8 @@ export function describePublishState({
     status === "publish_failed" ||
     approval === "publish_failed" ||
     publishFailedAt ||
-    publishFailureReason
+    publishFailureReason ||
+    publishFailureStage
   ) {
     if (publishFailedAt) {
       return {
@@ -104,22 +131,11 @@ export function describePublishState({
         tone: "default",
       };
     }
-    if (approvalRelayedAt) {
-      return {
-        label: "approval relayed",
-        detailLabel: "approval relayed @",
-        detailValue: approvalRelayedAt,
-        tone: "default",
-      };
-    }
-    if (publishRequestedAt) {
-      return {
-        label: "publish requested",
-        detailLabel: "publish requested @",
-        detailValue: publishRequestedAt,
-        tone: "default",
-      };
-    }
+    const queuedState = describeQueuedPublishState({
+      approvalRelayedAt,
+      publishRequestedAt,
+    });
+    if (queuedState) return queuedState;
     return { label: "publishing", tone: "default" };
   }
 
@@ -130,22 +146,11 @@ export function describePublishState({
     publishRequestedAt ||
     reviewed
   ) {
-    if (approvalRelayedAt) {
-      return {
-        label: "approval relayed",
-        detailLabel: "approval relayed @",
-        detailValue: approvalRelayedAt,
-        tone: "default",
-      };
-    }
-    if (publishRequestedAt) {
-      return {
-        label: "publish requested",
-        detailLabel: "publish requested @",
-        detailValue: publishRequestedAt,
-        tone: "default",
-      };
-    }
+    const queuedState = describeQueuedPublishState({
+      approvalRelayedAt,
+      publishRequestedAt,
+    });
+    if (queuedState) return queuedState;
     if (reviewed) {
       return {
         label: "waiting for poller",

--- a/pmoves/ui/app/dashboard/publishState.ts
+++ b/pmoves/ui/app/dashboard/publishState.ts
@@ -17,6 +17,8 @@ export interface PublishStateSummary {
   tone: "default" | "success" | "danger";
 }
 
+export type PublishTone = PublishStateSummary["tone"];
+
 interface DescribePublishStateInput {
   rowStatus?: string | null;
   approvalStatus?: string | null;
@@ -51,6 +53,31 @@ const describeQueuedPublishState = ({
   }
   return null;
 };
+
+export const PUBLISH_TONE_CLASS: Record<PublishTone, string> = {
+  default: "text-brand-sky",
+  success: "text-brand-forest",
+  danger: "text-brand-crimson",
+};
+
+export const PUBLISH_DETAIL_CLASS: Record<PublishTone, string> = {
+  default: "text-brand-subtle",
+  success: "text-brand-forest",
+  danger: "text-brand-crimson",
+};
+
+export function shouldRenderSupplementalPublishFailureDetail(
+  publishState: PublishStateSummary | null | undefined,
+  detailLabel: "publish failure:" | "failure stage:"
+): boolean {
+  if (publishState && publishState.tone !== "danger") {
+    return false;
+  }
+  return (
+    publishState?.detailLabel !== detailLabel &&
+    publishState?.detailLabel !== "failed @"
+  );
+}
 
 /**
  * Collapse publish metadata from the studio-board and videos dashboards into

--- a/pmoves/ui/app/dashboard/studio-board/page.tsx
+++ b/pmoves/ui/app/dashboard/studio-board/page.tsx
@@ -2,7 +2,12 @@
 
 import { useCallback, useMemo, useState } from "react";
 import useInfiniteSupabaseQuery from "../../../hooks/useInfiniteSupabaseQuery";
-import { describePublishState } from "../publishState";
+import {
+  describePublishState,
+  PUBLISH_DETAIL_CLASS,
+  PUBLISH_TONE_CLASS,
+  shouldRenderSupplementalPublishFailureDetail,
+} from "../publishState";
 import {
   getSupabaseBrowserClient,
   getSupabaseRestUrl,
@@ -67,18 +72,6 @@ const mergeMeta = (
   return Object.fromEntries(
     Object.entries(merged).filter(([, v]) => v !== undefined)
   ) as StudioBoardRowMeta;
-};
-
-const PUBLISH_TONE_CLASS: Record<"default" | "success" | "danger", string> = {
-  default: "text-brand-sky",
-  success: "text-brand-forest",
-  danger: "text-brand-crimson",
-};
-
-const PUBLISH_DETAIL_CLASS: Record<"default" | "success" | "danger", string> = {
-  default: "text-brand-subtle",
-  success: "text-brand-forest",
-  danger: "text-brand-crimson",
 };
 
 export default function StudioBoardDashboardPage() {
@@ -432,15 +425,19 @@ export default function StudioBoardDashboardPage() {
                       </div>
                     ) : null}
                     {meta.publish_failure_reason &&
-                    (!publishState || publishState.tone === "danger") &&
-                    publishState?.detailLabel !== "publish failure:" ? (
+                    shouldRenderSupplementalPublishFailureDetail(
+                      publishState,
+                      "publish failure:"
+                    ) ? (
                       <div className="text-xs text-brand-crimson">
                         publish failure: {meta.publish_failure_reason}
                       </div>
                     ) : null}
                     {meta.publish_failure_stage &&
-                    (!publishState || publishState.tone === "danger") &&
-                    publishState?.detailLabel !== "failure stage:" ? (
+                    shouldRenderSupplementalPublishFailureDetail(
+                      publishState,
+                      "failure stage:"
+                    ) ? (
                       <div className="text-xs text-brand-crimson">
                         failure stage: {meta.publish_failure_stage}
                       </div>

--- a/pmoves/ui/app/dashboard/studio-board/page.tsx
+++ b/pmoves/ui/app/dashboard/studio-board/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import useInfiniteSupabaseQuery from "../../../hooks/useInfiniteSupabaseQuery";
+import { describePublishState } from "../publishState";
 import {
   getSupabaseBrowserClient,
   getSupabaseRestUrl,
@@ -66,6 +67,18 @@ const mergeMeta = (
   return Object.fromEntries(
     Object.entries(merged).filter(([, v]) => v !== undefined)
   ) as StudioBoardRowMeta;
+};
+
+const PUBLISH_TONE_CLASS: Record<"default" | "success" | "danger", string> = {
+  default: "text-brand-sky",
+  success: "text-brand-forest",
+  danger: "text-brand-crimson",
+};
+
+const PUBLISH_DETAIL_CLASS: Record<"default" | "success" | "danger", string> = {
+  default: "text-brand-subtle",
+  success: "text-brand-forest",
+  danger: "text-brand-crimson",
 };
 
 export default function StudioBoardDashboardPage() {
@@ -377,6 +390,11 @@ export default function StudioBoardDashboardPage() {
                 ? meta.review_history
                 : [];
               const lastReview = history.length > 0 ? history[history.length - 1] : null;
+              const publishState = describePublishState({
+                rowStatus: row.status,
+                reviewedAt: meta.reviewed_at,
+                meta,
+              });
               return (
                 <tr key={row.id} className="align-top">
                   <td className="px-3 py-2 text-brand-subtle">
@@ -400,39 +418,25 @@ export default function StudioBoardDashboardPage() {
                   <td className="px-3 py-2 text-brand-ink">{row.namespace || "—"}</td>
                   <td className="px-3 py-2">
                     <div className="font-medium capitalize text-brand-ink">{row.status || "unknown"}</div>
-                    {row.status === "publishing" && meta.publish_started_at ? (
-                      <div className="text-xs text-brand-subtle">
-                        publisher started @ {formatDate(meta.publish_started_at)}
+                    {publishState ? (
+                      <div className={`text-xs font-semibold uppercase tracking-wide ${PUBLISH_TONE_CLASS[publishState.tone]}`}>
+                        {publishState.label}
                       </div>
                     ) : null}
-                    {row.status === "publishing" &&
-                    !meta.publish_started_at &&
-                    meta.publish_approval_event_sent_at ? (
-                      <div className="text-xs text-brand-subtle">
-                        approval relayed @ {formatDate(meta.publish_approval_event_sent_at)}
+                    {publishState?.detailLabel && publishState.detailValue ? (
+                      <div className={`text-xs ${PUBLISH_DETAIL_CLASS[publishState.tone]}`}>
+                        {publishState.detailLabel}{" "}
+                        {publishState.detailLabel.endsWith("@")
+                          ? formatDate(publishState.detailValue)
+                          : publishState.detailValue}
                       </div>
                     ) : null}
-                    {meta.publish_event_sent_at ? (
-                      <div className="text-xs text-brand-subtle">
-                        published @ {formatDate(meta.publish_event_sent_at)}
-                      </div>
-                    ) : null}
-                    {meta.publish_requested_at && !meta.publish_event_sent_at ? (
-                      <div className="text-xs text-brand-subtle">
-                        publish requested @ {formatDate(meta.publish_requested_at)}
-                      </div>
-                    ) : null}
-                    {row.status === "publish_failed" && meta.publish_failed_at ? (
-                      <div className="text-xs text-brand-crimson">
-                        failed @ {formatDate(meta.publish_failed_at)}
-                      </div>
-                    ) : null}
-                    {meta.publish_failure_reason ? (
+                    {publishState?.tone !== "danger" && meta.publish_failure_reason ? (
                       <div className="text-xs text-brand-crimson">
                         publish failure: {meta.publish_failure_reason}
                       </div>
                     ) : null}
-                    {meta.publish_failure_stage ? (
+                    {publishState?.tone !== "danger" && meta.publish_failure_stage ? (
                       <div className="text-xs text-brand-crimson">
                         failure stage: {meta.publish_failure_stage}
                       </div>

--- a/pmoves/ui/app/dashboard/studio-board/page.tsx
+++ b/pmoves/ui/app/dashboard/studio-board/page.tsx
@@ -431,12 +431,16 @@ export default function StudioBoardDashboardPage() {
                           : publishState.detailValue}
                       </div>
                     ) : null}
-                    {publishState?.tone !== "danger" && meta.publish_failure_reason ? (
+                    {meta.publish_failure_reason &&
+                    (!publishState || publishState.tone === "danger") &&
+                    publishState?.detailLabel !== "publish failure:" ? (
                       <div className="text-xs text-brand-crimson">
                         publish failure: {meta.publish_failure_reason}
                       </div>
                     ) : null}
-                    {publishState?.tone !== "danger" && meta.publish_failure_stage ? (
+                    {meta.publish_failure_stage &&
+                    (!publishState || publishState.tone === "danger") &&
+                    publishState?.detailLabel !== "failure stage:" ? (
                       <div className="text-xs text-brand-crimson">
                         failure stage: {meta.publish_failure_stage}
                       </div>

--- a/pmoves/ui/app/dashboard/videos/page.tsx
+++ b/pmoves/ui/app/dashboard/videos/page.tsx
@@ -3,7 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import DashboardNavigation from "../../../components/DashboardNavigation";
 import useInfiniteSupabaseQuery from "../../../hooks/useInfiniteSupabaseQuery";
-import { describePublishState } from "../publishState";
+import {
+  describePublishState,
+  PUBLISH_DETAIL_CLASS,
+  PUBLISH_TONE_CLASS,
+  shouldRenderSupplementalPublishFailureDetail,
+} from "../publishState";
 import {
   getSupabaseBrowserClient,
   getSupabaseRestUrl,
@@ -78,18 +83,6 @@ const mergeMeta = (
   return Object.fromEntries(
     Object.entries(merged).filter(([, v]) => v !== undefined)
   ) as VideoRowMeta;
-};
-
-const PUBLISH_TONE_CLASS: Record<"default" | "success" | "danger", string> = {
-  default: "text-brand-sky",
-  success: "text-brand-forest",
-  danger: "text-brand-crimson",
-};
-
-const PUBLISH_DETAIL_CLASS: Record<"default" | "success" | "danger", string> = {
-  default: "text-brand-subtle",
-  success: "text-brand-forest",
-  danger: "text-brand-crimson",
 };
 
 export default function VideosDashboardPage() {
@@ -559,6 +552,24 @@ export default function VideosDashboardPage() {
                         {publishState.detailLabel.endsWith("@")
                           ? formatDate(publishState.detailValue)
                           : publishState.detailValue}
+                      </div>
+                    ) : null}
+                    {meta.publish_failure_reason &&
+                    shouldRenderSupplementalPublishFailureDetail(
+                      publishState,
+                      "publish failure:"
+                    ) ? (
+                      <div className="text-xs text-brand-crimson">
+                        publish failure: {meta.publish_failure_reason}
+                      </div>
+                    ) : null}
+                    {meta.publish_failure_stage &&
+                    shouldRenderSupplementalPublishFailureDetail(
+                      publishState,
+                      "failure stage:"
+                    ) ? (
+                      <div className="text-xs text-brand-crimson">
+                        failure stage: {meta.publish_failure_stage}
                       </div>
                     ) : null}
                     {meta.rejection_reason ? (

--- a/pmoves/ui/app/dashboard/videos/page.tsx
+++ b/pmoves/ui/app/dashboard/videos/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import DashboardNavigation from "../../../components/DashboardNavigation";
 import useInfiniteSupabaseQuery from "../../../hooks/useInfiniteSupabaseQuery";
+import { describePublishState } from "../publishState";
 import {
   getSupabaseBrowserClient,
   getSupabaseRestUrl,
@@ -20,6 +21,14 @@ interface VideoRowMeta {
   rejection_reason?: string | null;
   reviewed_at?: string | null;
   reviewed_by?: string | null;
+  publish_started_at?: string | null;
+  publish_completed_at?: string | null;
+  publish_event_sent_at?: string | null;
+  publish_requested_at?: string | null;
+  publish_approval_event_sent_at?: string | null;
+  publish_failed_at?: string | null;
+  publish_failure_reason?: string | null;
+  publish_failure_stage?: string | null;
   thumb?: string | null;
   channel?: {
     title?: string | null;
@@ -69,6 +78,18 @@ const mergeMeta = (
   return Object.fromEntries(
     Object.entries(merged).filter(([, v]) => v !== undefined)
   ) as VideoRowMeta;
+};
+
+const PUBLISH_TONE_CLASS: Record<"default" | "success" | "danger", string> = {
+  default: "text-brand-sky",
+  success: "text-brand-forest",
+  danger: "text-brand-crimson",
+};
+
+const PUBLISH_DETAIL_CLASS: Record<"default" | "success" | "danger", string> = {
+  default: "text-brand-subtle",
+  success: "text-brand-forest",
+  danger: "text-brand-crimson",
 };
 
 export default function VideosDashboardPage() {
@@ -501,6 +522,11 @@ export default function VideosDashboardPage() {
               const lastReview = history.length
                 ? history[history.length - 1]
                 : null;
+              const publishState = describePublishState({
+                approvalStatus: status,
+                reviewedAt: meta.reviewed_at,
+                meta,
+              });
               return (
                 <tr key={row.id} className="align-top">
                   <td className="px-3 py-2 text-brand-subtle">
@@ -522,6 +548,19 @@ export default function VideosDashboardPage() {
                   <td className="px-3 py-2 text-brand-ink">{row.namespace || "—"}</td>
                   <td className="px-3 py-2">
                     <div className="font-medium capitalize text-brand-ink">{status}</div>
+                    {publishState ? (
+                      <div className={`text-xs font-semibold uppercase tracking-wide ${PUBLISH_TONE_CLASS[publishState.tone]}`}>
+                        {publishState.label}
+                      </div>
+                    ) : null}
+                    {publishState?.detailLabel && publishState.detailValue ? (
+                      <div className={`text-xs ${PUBLISH_DETAIL_CLASS[publishState.tone]}`}>
+                        {publishState.detailLabel}{" "}
+                        {publishState.detailLabel.endsWith("@")
+                          ? formatDate(publishState.detailValue)
+                          : publishState.detailValue}
+                      </div>
+                    ) : null}
                     {meta.rejection_reason ? (
                       <div className="text-xs text-brand-crimson">
                         rejected: {meta.rejection_reason}

--- a/pmoves/ui/jest.config.js
+++ b/pmoves/ui/jest.config.js
@@ -10,10 +10,10 @@ const customJestConfig = {
   testMatch: [
     '**/__tests__/**/*.test.ts',
     '**/__tests__/**/*.test.tsx',
-    'lib/api/**/*.test.ts',
-    'lib/api/**/*.test.tsx',
-    'components/**/*.test.ts',
-    'components/**/*.test.tsx',
+    '**/lib/api/**/*.test.ts',
+    '**/lib/api/**/*.test.tsx',
+    '**/components/**/*.test.ts',
+    '**/components/**/*.test.tsx',
   ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',

--- a/pmoves/ui/jest.config.js
+++ b/pmoves/ui/jest.config.js
@@ -8,10 +8,12 @@ const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'jsdom',
   testMatch: [
-    '<rootDir>/__tests__/**/*.test.(ts|tsx)',
-    '<rootDir>/lib/__tests__/**/*.test.(ts|tsx)',
-    '<rootDir>/lib/api/**/*.test.(ts|tsx)',
-    '<rootDir>/components/**/*.test.(ts|tsx)',
+    '**/__tests__/**/*.test.ts',
+    '**/__tests__/**/*.test.tsx',
+    'lib/api/**/*.test.ts',
+    'lib/api/**/*.test.tsx',
+    'components/**/*.test.ts',
+    'components/**/*.test.tsx',
   ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',


### PR DESCRIPTION
## Summary

- add a shared publish-state mapper so dashboard rows surface `waiting for poller`, `approval relayed`, `publisher active`, `publish complete`, and `needs retry` consistently
- wire the new publish-state callouts into the studio board and videos dashboards using the publish metadata already present on `main`
- add focused Jest coverage for the publish-state transitions and fix UI Jest discovery so the suite runs correctly from this Windows Codex worktree

## Testing

```text
npm run typecheck
npm run lint
npm test -- --runInBand
```

### Required Checks
- [ ] `CHIT Contract Check` (CI will block the merge until this passes)
- [x] Updated contracts, schemas, or topics if this change affects published events
- [ ] Added/updated documentation when altering behavior or workflows

### Review Coordination
- [x] Requested Codex review (coverage captured in Reviewer Notes)
- [ ] Requested GitHub Copilot review (use the PR “Copilot” button or `/copilot review` comment)

## Follow-up Tasks

- [ ] Run the end-to-end Supabase -> Agent Zero -> Publisher -> Discord activation evidence pass
- [ ] Finish the remaining M2 follow-through outside this UI slice, including the canonical Discord publish lane decision

## Reviewer Notes

- This PR intentionally does not modify publisher runtime logic or the approval-poller flow on current `main`; it only makes the existing publish metadata legible in the dashboard UI.
- `pmoves/ui/jest.config.js` is included because UI test discovery was broken in this Windows `.codex` worktree. After the glob fix, the full UI suite passes locally.
- Local validation run from `pmoves/ui`: `npm run typecheck`, `npm run lint`, `npm test -- --runInBand`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified publish-state summary used in dashboard and videos, showing a single labeled state line with optional timestamp/detail and tone-driven styling.

* **Tests**
  * Added unit tests covering publish-state outcomes for approved, publishing, published, completed, and failure scenarios.

* **Documentation**
  * Updated roadmap and agent notes to reflect publish-state rollout, PR statuses, and next-step adjustments.

* **Chores**
  * Refined Jest test-matching patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->