### PR TITLE
Add room catalog contracts and dashboard loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ downloads/
 eggs/
 .eggs/
 lib/
+!pmoves/ui/lib/
+!pmoves/ui/lib/rooms.ts
+!pmoves/ui/lib/__tests__/
+!pmoves/ui/lib/__tests__/rooms.test.ts
 lib64/
 parts/
 sdist/
@@ -189,3 +193,4 @@ NUL
 
 # Git worktrees
 .worktrees/
+

--- a/pmoves/config/rooms/4090-field.room.control.json
+++ b/pmoves/config/rooms/4090-field.room.control.json
@@ -1,0 +1,220 @@
+{
+  "room_id": "4090-field.room.control",
+  "version": "1.0.0",
+  "display_name": "4090 Field Control Room",
+  "description": "Noise-reduction room for review, topology, and handoff control.",
+  "agent_id": "4090-claude",
+  "alter": "4090-field",
+  "room_type": "scout",
+  "owner_mode": "alter",
+  "shell": {
+    "theme": {
+      "theme_id": "field-control",
+      "accent_color": "#065F46",
+      "skin": "signal-grid",
+      "icon": "fresnel"
+    },
+    "layout": {
+      "default_route": "/dashboard/notebook/runtime",
+      "panels": [
+        {
+          "panel_id": "chat-main",
+          "kind": "chat",
+          "position": "left",
+          "size": 26,
+          "pinned": true
+        },
+        {
+          "panel_id": "notebook-main",
+          "kind": "notebook",
+          "position": "center",
+          "size": 52,
+          "pinned": true
+        },
+        {
+          "panel_id": "graphiti-side",
+          "kind": "graph",
+          "position": "right",
+          "size": 22,
+          "pinned": false
+        }
+      ]
+    }
+  },
+  "apps": [
+    {
+      "app_id": "notebook-workbench",
+      "kind": "notebook",
+      "route": "/notebook-workbench",
+      "provider": "pmoves-notebook-workbench",
+      "action_namespace": "notebook",
+      "capabilities": ["threads", "entries", "snapshots", "search", "handoff-notes"],
+      "pinned": true
+    },
+    {
+      "app_id": "graphiti-status",
+      "kind": "graph",
+      "route": "/dashboard/graphiti",
+      "provider": "pmoves-ui",
+      "action_namespace": "graphiti",
+      "capabilities": ["trail", "audit", "handoff", "claim-register"],
+      "pinned": false
+    },
+    {
+      "app_id": "review-console",
+      "kind": "dashboard",
+      "route": "/dashboard/review",
+      "provider": "pmoves-ui",
+      "action_namespace": "review",
+      "capabilities": ["pr-triage", "thread-classify", "risk-notes"],
+      "pinned": false
+    }
+  ],
+  "notebook": {
+    "provider": "open-notebook",
+    "workspace_ref": "ops-control",
+    "thread_ref": "agent-handoffs",
+    "default_page": "current-lane",
+    "sync": {
+      "mode": "mirrored",
+      "writeback_targets": ["entries", "threads", "snapshots"],
+      "artifact_prefix": "rooms/4090-field"
+    }
+  },
+  "persona": {
+    "signature_ref": "4090-claude",
+    "voice": "terse",
+    "glyph": "◎",
+    "resonance": ["polymorphic-ops", "alter-discovery", "pattern-mining", "node-gateway"]
+  },
+  "skill_bindings": [
+    {
+      "binding_id": "handoff-scout",
+      "skill_id": "submodule-parity",
+      "room_id": "4090-field.room.control",
+      "display_name": "Scout Handoff",
+      "intent": ["handoff", "review", "triage"],
+      "activation": {
+        "invocation_mode": "suggested",
+        "trigger_phrases": ["prepare handoff", "review this lane", "triage this branch"],
+        "requires_selection": true
+      },
+      "surface": {
+        "app_id": "notebook-workbench",
+        "target": "toolbar",
+        "route": "/notebook-workbench"
+      },
+      "execution": {
+        "mode": "workflow",
+        "run_as": "agent",
+        "stream": "status",
+        "max_steps": 6
+      },
+      "context": {
+        "sources": ["notebook-thread", "graphiti-trail", "persona", "room-state"],
+        "include_last_turns": 8,
+        "notebook_writeback": true,
+        "artifact_types": ["text", "json"]
+      },
+      "outputs": [
+        {
+          "target": "notebook-entry",
+          "delivery": "append",
+          "path": "threads/agent-handoffs",
+          "artifact_type": "text"
+        },
+        {
+          "target": "chat-response",
+          "delivery": "notify",
+          "artifact_type": "text"
+        }
+      ],
+      "guardrails": {
+        "require_approval": false,
+        "max_runtime_sec": 300,
+        "fail_open": false,
+        "one_active_run": true
+      },
+      "enabled": true,
+      "tags": ["handoff", "graphiti", "control"]
+    },
+    {
+      "binding_id": "pattern-miner",
+      "skill_id": "persona-grounding",
+      "room_id": "4090-field.room.control",
+      "display_name": "Pattern Miner",
+      "intent": ["alter-discovery", "persona", "classification"],
+      "activation": {
+        "invocation_mode": "explicit",
+        "trigger_phrases": ["find the pattern", "discover the alter"],
+        "requires_selection": false
+      },
+      "surface": {
+        "app_id": "review-console",
+        "target": "panel",
+        "route": "/dashboard/review"
+      },
+      "execution": {
+        "mode": "panel",
+        "run_as": "agent",
+        "stream": "tokens",
+        "max_steps": 5
+      },
+      "context": {
+        "sources": ["graphiti-trail", "agent-registry", "search-results", "user-intent"],
+        "include_last_turns": 4,
+        "notebook_writeback": true,
+        "artifact_types": ["text", "json"]
+      },
+      "outputs": [
+        {
+          "target": "room-state",
+          "delivery": "replace",
+          "path": "analysis/persona-clusters",
+          "artifact_type": "json"
+        },
+        {
+          "target": "notebook-page",
+          "delivery": "append",
+          "path": "pages/identity-forensics",
+          "artifact_type": "text"
+        }
+      ],
+      "guardrails": {
+        "require_approval": false,
+        "max_runtime_sec": 240,
+        "fail_open": true,
+        "one_active_run": true
+      },
+      "enabled": true,
+      "tags": ["identity", "review", "discovery"]
+    }
+  ],
+  "policies": {
+    "model_routing": "hybrid",
+    "publish": {
+      "allow_nats_emit": true,
+      "allow_external_publish": false,
+      "allowed_subjects": ["agent.graphiti.signed.v1", "ops.pr.review.completed.v1"]
+    },
+    "memory": {
+      "graphiti": true,
+      "notebook_writeback": true,
+      "chit_handoff": true
+    }
+  },
+  "telemetry": {
+    "graphiti_phase": "Control Room",
+    "room_events_subject": "room.session.updated.v1",
+    "healthcheck_route": "/api/audit/summary"
+  },
+  "provenance": {
+    "source": "pmoves/config/rooms/catalog.json",
+    "updated_at": "2026-03-27T12:30:00Z",
+    "related_docs": [
+      "pmoves/docs/ROOM_MANIFEST_CONTRACT.md",
+      "pmoves/docs/infrastructure/UI_NOTEBOOK_WORKBENCH.md",
+      "pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md"
+    ]
+  }
+}

--- a/pmoves/config/rooms/4090-field.room.control.json
+++ b/pmoves/config/rooms/4090-field.room.control.json
@@ -67,7 +67,8 @@
       "provider": "pmoves-ui",
       "action_namespace": "review",
       "capabilities": ["pr-triage", "thread-classify", "risk-notes"],
-      "pinned": false
+      "pinned": false,
+      "status": "planned"
     }
   ],
   "notebook": {

--- a/pmoves/config/rooms/5090-voice.room.studio.json
+++ b/pmoves/config/rooms/5090-voice.room.studio.json
@@ -1,0 +1,220 @@
+{
+  "room_id": "5090-voice.room.studio",
+  "version": "1.0.0",
+  "display_name": "5090 Voice Studio",
+  "description": "Voice-first room for TTS, media pipelines, audition loops, and notebook-backed iteration.",
+  "agent_id": "5090-claude",
+  "alter": "5090-voice",
+  "room_type": "creator",
+  "owner_mode": "alter",
+  "shell": {
+    "theme": {
+      "theme_id": "voice-studio",
+      "accent_color": "#9333EA",
+      "skin": "waveform-stage",
+      "icon": "beamed-notes"
+    },
+    "layout": {
+      "default_route": "/dashboard/notebook/runtime",
+      "panels": [
+        {
+          "panel_id": "voice-chat",
+          "kind": "chat",
+          "position": "left",
+          "size": 24,
+          "pinned": true
+        },
+        {
+          "panel_id": "media-stage",
+          "kind": "media",
+          "position": "center",
+          "size": 50,
+          "pinned": true
+        },
+        {
+          "panel_id": "notebook-takes",
+          "kind": "notebook",
+          "position": "right",
+          "size": 26,
+          "pinned": true
+        }
+      ]
+    }
+  },
+  "apps": [
+    {
+      "app_id": "voice-console",
+      "kind": "media",
+      "route": "/dashboard/voice",
+      "provider": "pmoves-ui",
+      "action_namespace": "voice",
+      "capabilities": ["tts", "engine-status", "audition", "prosody"],
+      "pinned": true
+    },
+    {
+      "app_id": "notebook-workbench",
+      "kind": "notebook",
+      "route": "/notebook-workbench",
+      "provider": "pmoves-notebook-workbench",
+      "action_namespace": "notebook",
+      "capabilities": ["threads", "entries", "snapshots", "takes"],
+      "pinned": true
+    },
+    {
+      "app_id": "media-pipeline",
+      "kind": "dashboard",
+      "route": "/dashboard/media",
+      "provider": "pmoves-ui",
+      "action_namespace": "media",
+      "capabilities": ["pipeline-health", "artifact-preview", "render-status"],
+      "pinned": false
+    }
+  ],
+  "notebook": {
+    "provider": "open-notebook",
+    "workspace_ref": "voice-lab",
+    "thread_ref": "session-takes",
+    "default_page": "voice-iterations",
+    "sync": {
+      "mode": "authoritative",
+      "writeback_targets": ["entries", "pages", "snapshots"],
+      "artifact_prefix": "rooms/5090-voice"
+    }
+  },
+  "persona": {
+    "signature_ref": "5090-claude",
+    "voice": "conversational",
+    "glyph": "♫",
+    "resonance": ["voice-synthesis", "tts-pipeline", "pipecat-integration", "media"]
+  },
+  "skill_bindings": [
+    {
+      "binding_id": "voice-audition",
+      "skill_id": "multimodal-verifier",
+      "room_id": "5090-voice.room.studio",
+      "display_name": "Voice Audition",
+      "intent": ["voice", "audition", "verification"],
+      "activation": {
+        "invocation_mode": "suggested",
+        "trigger_phrases": ["audition this voice", "verify this take", "compare these outputs"],
+        "requires_selection": true
+      },
+      "surface": {
+        "app_id": "voice-console",
+        "target": "composer",
+        "route": "/dashboard/voice"
+      },
+      "execution": {
+        "mode": "inline",
+        "run_as": "agent",
+        "stream": "status",
+        "max_steps": 4
+      },
+      "context": {
+        "sources": ["notebook-selection", "persona", "room-state", "user-intent"],
+        "include_last_turns": 6,
+        "notebook_writeback": true,
+        "artifact_types": ["audio", "text", "json"]
+      },
+      "outputs": [
+        {
+          "target": "artifact-store",
+          "delivery": "append",
+          "path": "voice/takes",
+          "artifact_type": "audio"
+        },
+        {
+          "target": "notebook-entry",
+          "delivery": "append",
+          "path": "threads/session-takes",
+          "artifact_type": "text"
+        }
+      ],
+      "guardrails": {
+        "require_approval": false,
+        "max_runtime_sec": 420,
+        "fail_open": false,
+        "one_active_run": true
+      },
+      "enabled": true,
+      "tags": ["voice", "takes", "validation"]
+    },
+    {
+      "binding_id": "voice-publish-preflight",
+      "skill_id": "bringup-audit",
+      "room_id": "5090-voice.room.studio",
+      "display_name": "Voice Publish Preflight",
+      "intent": ["preflight", "media", "pipeline-health"],
+      "activation": {
+        "invocation_mode": "workflow",
+        "trigger_phrases": ["run voice preflight", "check the voice pipeline"],
+        "requires_selection": false
+      },
+      "surface": {
+        "app_id": "media-pipeline",
+        "target": "toolbar",
+        "route": "/dashboard/media"
+      },
+      "execution": {
+        "mode": "workflow",
+        "run_as": "worker",
+        "stream": "events",
+        "max_steps": 7
+      },
+      "context": {
+        "sources": ["open-apps", "persona", "graphiti-trail", "user-intent"],
+        "include_last_turns": 2,
+        "notebook_writeback": true,
+        "artifact_types": ["text", "json"]
+      },
+      "outputs": [
+        {
+          "target": "room-state",
+          "delivery": "replace",
+          "path": "preflight/voice",
+          "artifact_type": "json"
+        },
+        {
+          "target": "chat-response",
+          "delivery": "notify",
+          "artifact_type": "text"
+        }
+      ],
+      "guardrails": {
+        "require_approval": false,
+        "max_runtime_sec": 300,
+        "fail_open": true,
+        "one_active_run": true
+      },
+      "enabled": true,
+      "tags": ["preflight", "voice", "pipeline"]
+    }
+  ],
+  "policies": {
+    "model_routing": "hybrid",
+    "publish": {
+      "allow_nats_emit": true,
+      "allow_external_publish": false,
+      "allowed_subjects": ["voice.cast.completed.v1", "agent.graphiti.signed.v1"]
+    },
+    "memory": {
+      "graphiti": true,
+      "notebook_writeback": true,
+      "chit_handoff": true
+    }
+  },
+  "telemetry": {
+    "graphiti_phase": "Voice Studio",
+    "room_events_subject": "room.session.updated.v1",
+    "healthcheck_route": "/api/voice/health"
+  },
+  "provenance": {
+    "source": "pmoves/config/rooms/catalog.json",
+    "updated_at": "2026-03-27T12:30:00Z",
+    "related_docs": [
+      "pmoves/docs/ROOM_MANIFEST_CONTRACT.md",
+      "pmoves/docs/MODEL_FABRIC_CONTRACT.md",
+      "pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md"
+    ]
+  }
+}

--- a/pmoves/config/rooms/5090-voice.room.studio.json
+++ b/pmoves/config/rooms/5090-voice.room.studio.json
@@ -49,7 +49,8 @@
       "provider": "pmoves-ui",
       "action_namespace": "voice",
       "capabilities": ["tts", "engine-status", "audition", "prosody"],
-      "pinned": true
+      "pinned": true,
+      "status": "planned"
     },
     {
       "app_id": "notebook-workbench",
@@ -67,7 +68,8 @@
       "provider": "pmoves-ui",
       "action_namespace": "media",
       "capabilities": ["pipeline-health", "artifact-preview", "render-status"],
-      "pinned": false
+      "pinned": false,
+      "status": "planned"
     }
   ],
   "notebook": {
@@ -206,7 +208,7 @@
   "telemetry": {
     "graphiti_phase": "Voice Studio",
     "room_events_subject": "room.session.updated.v1",
-    "healthcheck_route": "/api/voice/health"
+    "healthcheck_route": "/api/health"
   },
   "provenance": {
     "source": "pmoves/config/rooms/catalog.json",

--- a/pmoves/config/rooms/catalog.json
+++ b/pmoves/config/rooms/catalog.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "rooms": [
+    {
+      "room_id": "4090-field.room.control",
+      "agent_id": "4090-claude",
+      "alter": "4090-field",
+      "display_name": "4090 Field Control Room",
+      "manifest": "4090-field.room.control.json",
+      "summary": "Scout/control room for review, topology, handoff, and notebook-backed triage."
+    },
+    {
+      "room_id": "5090-voice.room.studio",
+      "agent_id": "5090-claude",
+      "alter": "5090-voice",
+      "display_name": "5090 Voice Studio",
+      "manifest": "5090-voice.room.studio.json",
+      "summary": "Voice-first room for TTS, media pipelines, notebook-backed iteration, and audition workflows."
+    },
+    {
+      "room_id": "z890-infra.room.fabric",
+      "agent_id": "z890-claude",
+      "alter": "z890-infra",
+      "display_name": "Z890 Infra Fabric Room",
+      "manifest": "z890-infra.room.fabric.json",
+      "summary": "Infrastructure room for topology, service health, secrets discipline, and operator bring-up."
+    }
+  ]
+}

--- a/pmoves/config/rooms/z890-infra.room.fabric.json
+++ b/pmoves/config/rooms/z890-infra.room.fabric.json
@@ -1,0 +1,227 @@
+{
+  "room_id": "z890-infra.room.fabric",
+  "version": "1.0.0",
+  "display_name": "Z890 Infra Fabric Room",
+  "description": "Infrastructure room for topology, service health, secrets discipline, and operator bring-up.",
+  "agent_id": "z890-claude",
+  "alter": "z890-infra",
+  "room_type": "operator",
+  "owner_mode": "alter",
+  "shell": {
+    "theme": {
+      "theme_id": "infra-fabric",
+      "accent_color": "#1E40AF",
+      "skin": "mesh-control",
+      "icon": "gear"
+    },
+    "layout": {
+      "default_route": "/dashboard/services",
+      "panels": [
+        {
+          "panel_id": "ops-chat",
+          "kind": "chat",
+          "position": "left",
+          "size": 22,
+          "pinned": true
+        },
+        {
+          "panel_id": "service-grid",
+          "kind": "controls",
+          "position": "center",
+          "size": 46,
+          "pinned": true
+        },
+        {
+          "panel_id": "ops-notebook",
+          "kind": "notebook",
+          "position": "right",
+          "size": 18,
+          "pinned": true
+        },
+        {
+          "panel_id": "ops-logs",
+          "kind": "logs",
+          "position": "bottom",
+          "size": 14,
+          "pinned": false
+        }
+      ]
+    }
+  },
+  "apps": [
+    {
+      "app_id": "services-dashboard",
+      "kind": "dashboard",
+      "route": "/dashboard/services",
+      "provider": "pmoves-ui",
+      "action_namespace": "ops",
+      "capabilities": ["service-health", "compose-topology", "alerts", "rebuild-status"],
+      "pinned": true
+    },
+    {
+      "app_id": "notebook-workbench",
+      "kind": "notebook",
+      "route": "/notebook-workbench",
+      "provider": "pmoves-notebook-workbench",
+      "action_namespace": "notebook",
+      "capabilities": ["threads", "entries", "snapshots", "runbooks"],
+      "pinned": true
+    },
+    {
+      "app_id": "graphiti-status",
+      "kind": "graph",
+      "route": "/dashboard/graphiti",
+      "provider": "pmoves-ui",
+      "action_namespace": "graphiti",
+      "capabilities": ["trail", "audit", "release-state"],
+      "pinned": false
+    }
+  ],
+  "notebook": {
+    "provider": "open-notebook",
+    "workspace_ref": "infra-ops",
+    "thread_ref": "service-runbooks",
+    "default_page": "bringup",
+    "sync": {
+      "mode": "authoritative",
+      "writeback_targets": ["entries", "pages", "threads"],
+      "artifact_prefix": "rooms/z890-infra"
+    }
+  },
+  "persona": {
+    "signature_ref": "z890-claude",
+    "voice": "analytical",
+    "glyph": "⚙",
+    "resonance": ["infrastructure", "persistence-modeling", "supabase-integration", "docker-hardening"]
+  },
+  "skill_bindings": [
+    {
+      "binding_id": "infra-bringup-audit",
+      "skill_id": "bringup-audit",
+      "room_id": "z890-infra.room.fabric",
+      "display_name": "Infra Bring-up Audit",
+      "intent": ["bringup", "health", "ops"],
+      "activation": {
+        "invocation_mode": "workflow",
+        "trigger_phrases": ["audit the bringup", "check the stack", "verify infra health"],
+        "requires_selection": false
+      },
+      "surface": {
+        "app_id": "services-dashboard",
+        "target": "toolbar",
+        "route": "/dashboard/services"
+      },
+      "execution": {
+        "mode": "workflow",
+        "run_as": "worker",
+        "stream": "events",
+        "max_steps": 8
+      },
+      "context": {
+        "sources": ["room-state", "open-apps", "graphiti-trail", "user-intent"],
+        "include_last_turns": 3,
+        "notebook_writeback": true,
+        "artifact_types": ["text", "json"]
+      },
+      "outputs": [
+        {
+          "target": "room-state",
+          "delivery": "replace",
+          "path": "ops/bringup-audit",
+          "artifact_type": "json"
+        },
+        {
+          "target": "notebook-page",
+          "delivery": "append",
+          "path": "pages/bringup-audits",
+          "artifact_type": "text"
+        }
+      ],
+      "guardrails": {
+        "require_approval": false,
+        "max_runtime_sec": 360,
+        "fail_open": true,
+        "one_active_run": true
+      },
+      "enabled": true,
+      "tags": ["ops", "health", "bringup"]
+    },
+    {
+      "binding_id": "secrets-funnel",
+      "skill_id": "secrets-chit-funnel",
+      "room_id": "z890-infra.room.fabric",
+      "display_name": "Secrets Funnel",
+      "intent": ["secrets", "handoff", "compliance"],
+      "activation": {
+        "invocation_mode": "explicit",
+        "trigger_phrases": ["run the secrets funnel", "prepare secure handoff"],
+        "requires_selection": false
+      },
+      "surface": {
+        "app_id": "graphiti-status",
+        "target": "sidebar",
+        "route": "/dashboard/graphiti"
+      },
+      "execution": {
+        "mode": "panel",
+        "run_as": "agent",
+        "stream": "status",
+        "max_steps": 5
+      },
+      "context": {
+        "sources": ["graphiti-trail", "notebook-thread", "persona", "room-state"],
+        "include_last_turns": 5,
+        "notebook_writeback": true,
+        "artifact_types": ["text", "json"]
+      },
+      "outputs": [
+        {
+          "target": "nats-event",
+          "delivery": "emit",
+          "subject": "agent.graphiti.signed.v1",
+          "artifact_type": "json"
+        },
+        {
+          "target": "chat-response",
+          "delivery": "notify",
+          "artifact_type": "text"
+        }
+      ],
+      "guardrails": {
+        "require_approval": true,
+        "max_runtime_sec": 240,
+        "fail_open": false,
+        "one_active_run": true
+      },
+      "enabled": true,
+      "tags": ["secrets", "chit", "graphiti"]
+    }
+  ],
+  "policies": {
+    "model_routing": "tensorzero",
+    "publish": {
+      "allow_nats_emit": true,
+      "allow_external_publish": false,
+      "allowed_subjects": ["agent.graphiti.signed.v1", "ops.pr.monitor.completed.v1"]
+    },
+    "memory": {
+      "graphiti": true,
+      "notebook_writeback": true,
+      "chit_handoff": true
+    }
+  },
+  "telemetry": {
+    "graphiti_phase": "Infra Fabric",
+    "room_events_subject": "room.session.updated.v1",
+    "healthcheck_route": "/api/audit/summary"
+  },
+  "provenance": {
+    "source": "pmoves/config/rooms/catalog.json",
+    "updated_at": "2026-03-27T12:30:00Z",
+    "related_docs": [
+      "pmoves/docs/ROOM_MANIFEST_CONTRACT.md",
+      "pmoves/docs/MODEL_FABRIC_CONTRACT.md",
+      "pmoves/docs/BOTZ_SKILLS_MARKETPLACE.md"
+    ]
+  }
+}

--- a/pmoves/contracts/schemas/room/room.manifest.v1.schema.json
+++ b/pmoves/contracts/schemas/room/room.manifest.v1.schema.json
@@ -1,0 +1,314 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Room Manifest",
+  "description": "Declarative contract for an agent-owned room that binds persona, shell layout, notebook state, apps, and reusable skills.",
+  "type": "object",
+  "required": [
+    "room_id",
+    "version",
+    "display_name",
+    "agent_id",
+    "shell",
+    "apps",
+    "notebook",
+    "skill_bindings",
+    "policies"
+  ],
+  "properties": {
+    "room_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$",
+      "description": "Stable room identifier"
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic or dated manifest version"
+    },
+    "display_name": {
+      "type": "string",
+      "description": "Human-readable room title"
+    },
+    "description": {
+      "type": "string",
+      "description": "Short statement of the room's purpose"
+    },
+    "agent_id": {
+      "type": "string",
+      "description": "Primary PMOVES agent identity owning this room"
+    },
+    "alter": {
+      "type": "string",
+      "description": "Optional alter or room profile chosen for this manifestation"
+    },
+    "room_type": {
+      "type": "string",
+      "enum": ["operator", "builder", "scout", "creator", "viewer", "hybrid"],
+      "description": "Primary operating pattern for the room"
+    },
+    "owner_mode": {
+      "type": "string",
+      "enum": ["primary", "alter", "shared", "ephemeral"],
+      "description": "Identity mode for the room session"
+    },
+    "shell": {
+      "type": "object",
+      "required": ["theme", "layout"],
+      "properties": {
+        "theme": {
+          "type": "object",
+          "required": ["theme_id"],
+          "properties": {
+            "theme_id": {
+              "type": "string"
+            },
+            "accent_color": {
+              "type": "string",
+              "pattern": "^#[0-9A-Fa-f]{6}$"
+            },
+            "skin": {
+              "type": "string"
+            },
+            "icon": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "layout": {
+          "type": "object",
+          "required": ["default_route", "panels"],
+          "properties": {
+            "default_route": {
+              "type": "string"
+            },
+            "panels": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["panel_id", "kind", "position"],
+                "properties": {
+                  "panel_id": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["chat", "notebook", "graph", "media", "controls", "tasks", "logs", "custom"]
+                  },
+                  "position": {
+                    "type": "string",
+                    "enum": ["left", "right", "top", "bottom", "center", "floating"]
+                  },
+                  "size": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100
+                  },
+                  "pinned": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "apps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["app_id", "kind", "route", "capabilities"],
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["notebook", "chat", "media", "graph", "editor", "browser", "dashboard", "custom"]
+          },
+          "route": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "action_namespace": {
+            "type": "string",
+            "description": "Structured action namespace the room can call into"
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pinned": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "notebook": {
+      "type": "object",
+      "required": ["provider", "workspace_ref", "sync"],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["open-notebook", "pmoves-notebook-workbench", "external"]
+        },
+        "workspace_ref": {
+          "type": "string",
+          "description": "Notebook or workspace identifier"
+        },
+        "thread_ref": {
+          "type": "string",
+          "description": "Optional default conversation thread or page identifier"
+        },
+        "default_page": {
+          "type": "string"
+        },
+        "sync": {
+          "type": "object",
+          "required": ["mode", "writeback_targets"],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["authoritative", "mirrored", "read-only"]
+            },
+            "writeback_targets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["sources", "entries", "pages", "threads", "snapshots"]
+              }
+            },
+            "artifact_prefix": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "persona": {
+      "type": "object",
+      "properties": {
+        "signature_ref": {
+          "type": "string",
+          "description": "Reference into agent_signatures.yaml"
+        },
+        "voice": {
+          "type": "string"
+        },
+        "glyph": {
+          "type": "string",
+          "maxLength": 2
+        },
+        "resonance": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "skill_bindings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "skill.binding.v1.schema.json"
+      }
+    },
+    "policies": {
+      "type": "object",
+      "required": ["model_routing", "publish", "memory"],
+      "properties": {
+        "model_routing": {
+          "type": "string",
+          "enum": ["tensorzero", "hybrid", "native"],
+          "description": "Model routing plane for this room"
+        },
+        "publish": {
+          "type": "object",
+          "required": ["allow_nats_emit", "allow_external_publish"],
+          "properties": {
+            "allow_nats_emit": {
+              "type": "boolean"
+            },
+            "allow_external_publish": {
+              "type": "boolean"
+            },
+            "allowed_subjects": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "memory": {
+          "type": "object",
+          "required": ["graphiti", "notebook_writeback", "chit_handoff"],
+          "properties": {
+            "graphiti": {
+              "type": "boolean"
+            },
+            "notebook_writeback": {
+              "type": "boolean"
+            },
+            "chit_handoff": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "telemetry": {
+      "type": "object",
+      "properties": {
+        "graphiti_phase": {
+          "type": "string"
+        },
+        "room_events_subject": {
+          "type": "string"
+        },
+        "healthcheck_route": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["source", "updated_at"],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "related_docs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/pmoves/contracts/schemas/room/room.manifest.v1.schema.json
+++ b/pmoves/contracts/schemas/room/room.manifest.v1.schema.json
@@ -149,6 +149,11 @@
           },
           "pinned": {
             "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "planned", "deprecated"],
+            "description": "Lifecycle status of the app surface. Planned apps render as inactive in the room UI."
           }
         },
         "additionalProperties": false

--- a/pmoves/contracts/schemas/room/skill.binding.v1.schema.json
+++ b/pmoves/contracts/schemas/room/skill.binding.v1.schema.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Room Skill Binding",
+  "description": "Contract that binds a reusable skill to a room surface, context envelope, and output targets.",
+  "type": "object",
+  "required": [
+    "binding_id",
+    "skill_id",
+    "room_id",
+    "surface",
+    "execution",
+    "context",
+    "outputs"
+  ],
+  "properties": {
+    "binding_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$",
+      "description": "Stable identifier for this room-specific skill binding"
+    },
+    "skill_id": {
+      "type": "string",
+      "description": "Canonical skill identifier or marketplace key"
+    },
+    "room_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$",
+      "description": "Room manifest identifier that owns this binding"
+    },
+    "display_name": {
+      "type": "string",
+      "description": "Human-readable binding label shown in the room UI"
+    },
+    "intent": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "High-level intents this binding serves"
+    },
+    "activation": {
+      "type": "object",
+      "properties": {
+        "invocation_mode": {
+          "type": "string",
+          "enum": ["explicit", "suggested", "ambient", "workflow"],
+          "description": "How this binding becomes eligible to run"
+        },
+        "trigger_phrases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional natural-language hints for activation"
+        },
+        "requires_selection": {
+          "type": "boolean",
+          "description": "Whether the room must have a current notebook or UI selection"
+        }
+      },
+      "additionalProperties": false
+    },
+    "surface": {
+      "type": "object",
+      "required": ["app_id", "target"],
+      "properties": {
+        "app_id": {
+          "type": "string",
+          "description": "App or panel that hosts this skill"
+        },
+        "target": {
+          "type": "string",
+          "enum": ["panel", "canvas", "sidebar", "composer", "toolbar", "modal", "floating", "background"],
+          "description": "Primary room surface where the skill appears or runs"
+        },
+        "route": {
+          "type": "string",
+          "description": "Optional route or deep-link for the hosting surface"
+        },
+        "tab_id": {
+          "type": "string",
+          "description": "Optional sub-surface or tab identifier"
+        }
+      },
+      "additionalProperties": false
+    },
+    "execution": {
+      "type": "object",
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["inline", "panel", "workflow", "background", "deferred"],
+          "description": "Runtime execution pattern for the skill"
+        },
+        "run_as": {
+          "type": "string",
+          "enum": ["agent", "room-service", "worker"],
+          "description": "Execution principal"
+        },
+        "stream": {
+          "type": "string",
+          "enum": ["none", "status", "tokens", "events"],
+          "description": "Expected stream behavior during execution"
+        },
+        "max_steps": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional ceiling for multi-step skill workflows"
+        }
+      },
+      "additionalProperties": false
+    },
+    "context": {
+      "type": "object",
+      "required": ["sources"],
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "room-state",
+              "notebook-thread",
+              "notebook-selection",
+              "graphiti-trail",
+              "persona",
+              "agent-registry",
+              "clipboard",
+              "open-apps",
+              "search-results",
+              "user-intent"
+            ]
+          },
+          "description": "Context lanes injected before skill execution"
+        },
+        "include_last_turns": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "How many recent turns to include when a chat surface is active"
+        },
+        "notebook_writeback": {
+          "type": "boolean",
+          "description": "Whether the skill is allowed to persist structured notes back into notebook state"
+        },
+        "artifact_types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["text", "image", "audio", "video", "json", "graph"]
+          },
+          "description": "Artifact modalities the skill expects or emits"
+        }
+      },
+      "additionalProperties": false
+    },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "source"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "required": ["kind"],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["room", "notebook", "persona", "graphiti", "user", "literal"]
+              },
+              "path": {
+                "type": "string",
+                "description": "JSONPath-style selector or semantic handle inside the source"
+              },
+              "value": {
+                "type": ["string", "number", "boolean", "null"]
+              }
+            },
+            "additionalProperties": false
+          },
+          "required": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["target", "delivery"],
+        "properties": {
+          "target": {
+            "type": "string",
+            "enum": ["notebook-entry", "notebook-page", "room-state", "app-action", "nats-event", "artifact-store", "clipboard", "chat-response"]
+          },
+          "delivery": {
+            "type": "string",
+            "enum": ["append", "replace", "open", "emit", "notify", "none"]
+          },
+          "path": {
+            "type": "string",
+            "description": "Destination path, route, or logical state key"
+          },
+          "subject": {
+            "type": "string",
+            "description": "NATS subject when target is an event lane"
+          },
+          "artifact_type": {
+            "type": "string",
+            "enum": ["text", "image", "audio", "video", "json", "graph"]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "permissions": {
+      "type": "object",
+      "properties": {
+        "tool_groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "network": {
+          "type": "boolean"
+        },
+        "filesystem": {
+          "type": "boolean"
+        },
+        "publish_subjects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "guardrails": {
+      "type": "object",
+      "properties": {
+        "require_approval": {
+          "type": "boolean"
+        },
+        "max_runtime_sec": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "fail_open": {
+          "type": "boolean"
+        },
+        "one_active_run": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Whether the room should expose this binding at runtime"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean"]
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/pmoves/docs/ROOM_MANIFEST_CONTRACT.md
+++ b/pmoves/docs/ROOM_MANIFEST_CONTRACT.md
@@ -1,0 +1,315 @@
+# PMOVES Room Manifest Contract
+_Last updated: 2026-03-27_
+
+## Purpose
+Define one interface contract for agent-owned rooms so OpenRoom-style browser desktops and Open Notebook-style durable workspaces can converge on a shared PMOVES control plane.
+
+This contract makes four things explicit:
+- the room shell an agent sees
+- the notebook state the room reads and writes
+- the apps/actions available inside the room
+- the skills bound to those surfaces
+
+## Why This Exists
+OpenRoom demonstrates a useful shape: a browser desktop where an agent operates apps through a structured action system. PMOVES already has the other half of that system in Open Notebook, Notebook Workbench, Graphiti, persona/alter identity, and BoTZ skills.
+
+The gap is the interface contract.
+
+Without a room manifest:
+- agent shells are implied by docs and local setup, not declared
+- notebook persistence and UI state are coupled informally
+- skills exist as catalogs, but not as room-aware bindings
+- alters can change voice and identity, but not their workspace layout or action affordances
+
+## Contract Model
+### 1. Room
+A room is the agent-facing operating shell.
+
+It owns:
+- shell theme and layout
+- installed apps and default routes
+- room-local policy decisions
+- bindings between skills and surfaces
+
+It does not own durable memory.
+
+### 2. Notebook
+The notebook is the durable state plane.
+
+It owns:
+- threads, entries, pages, sources, and snapshots
+- writeback targets for skills and apps
+- durable artifacts the room can reopen later
+
+A room may mirror notebook state or treat it as authoritative, but it should not replace it.
+
+### 3. Apps and Actions
+Apps are surface providers inside the room. They expose structured actions instead of free-form UI assumptions.
+
+Examples:
+- notebook workbench
+- chat panel
+- media panel
+- graph canvas
+- dashboard/operator views
+
+The room manifest declares which apps are present and which action namespace they speak.
+
+### 4. Skill Bindings
+Skills are reusable capabilities. A room binding makes a skill executable in context.
+
+A binding answers:
+- where the skill appears
+- what context it receives
+- how it runs
+- where outputs go
+- what permissions and guardrails apply
+
+## Core Rules
+1. Room owns presentation and session ergonomics; notebook owns durable state.
+2. Skills never bind directly to raw UI assumptions; they bind to declared surfaces and action namespaces.
+3. Persona and alter selection may change room defaults, but should not fork the contract shape.
+4. Skills may write back into notebook state only through declared targets.
+5. Room policy must remain compatible with PMOVES model routing, Graphiti, and CHIT rails.
+6. Rooms should be additive overlays, not hard forks of upstream interface systems.
+
+## Schema Files
+- `pmoves/contracts/schemas/room/room.manifest.v1.schema.json`
+- `pmoves/contracts/schemas/room/skill.binding.v1.schema.json`
+
+## Canonical Seed Location
+Git is now the canonical seed for room manifests.
+
+- Catalog: `pmoves/config/rooms/catalog.json`
+- Seed manifests:
+  - `pmoves/config/rooms/4090-field.room.control.json`
+  - `pmoves/config/rooms/5090-voice.room.studio.json`
+  - `pmoves/config/rooms/z890-infra.room.fabric.json`
+
+Supabase or another runtime store can mirror these later, but the seed shape starts here so rooms can be reviewed, diffed, and versioned like any other PMOVES control-plane asset.
+
+Validation command:
+- `python pmoves/scripts/validate_room_manifests.py`
+
+## Room Manifest Shape
+The room manifest declares:
+- identity: `room_id`, `agent_id`, optional `alter`
+- shell: theme, layout, panels
+- apps: routes, capabilities, action namespaces
+- notebook: provider, workspace/thread refs, sync mode
+- skill bindings: room-local binding records
+- policies: model routing, publish policy, memory policy
+- telemetry/provenance: optional observability and trace context
+
+## Skill-to-Room Binding Model
+A skill binding is intentionally separate from the skill definition.
+
+The skill definition says what a skill is.
+The binding says how this room uses it.
+
+Binding dimensions:
+- activation: explicit, suggested, ambient, or workflow
+- surface: panel, canvas, toolbar, sidebar, modal, floating, background
+- execution: inline, workflow, background, deferred
+- context: notebook thread, selection, graphiti trail, persona, room state, open apps
+- outputs: notebook entry/page, room state, app action, NATS event, artifact store, chat response
+- guardrails: approval, runtime cap, one-run-at-a-time, fail-open vs fail-closed
+
+This keeps the marketplace portable while letting each agent room feel distinct.
+
+## Example Manifest
+```json
+{
+  "room_id": "4090-field.room.control",
+  "version": "1.0.0",
+  "display_name": "4090 Field Control Room",
+  "description": "Noise-reduction room for review, topology, and handoff control.",
+  "agent_id": "4090-claude",
+  "alter": "4090-field",
+  "room_type": "scout",
+  "owner_mode": "alter",
+  "shell": {
+    "theme": {
+      "theme_id": "field-control",
+      "accent_color": "#065F46",
+      "skin": "signal-grid",
+      "icon": "fresnel"
+    },
+    "layout": {
+      "default_route": "/dashboard/notebook/runtime",
+      "panels": [
+        {
+          "panel_id": "chat-main",
+          "kind": "chat",
+          "position": "left",
+          "size": 28,
+          "pinned": true
+        },
+        {
+          "panel_id": "notebook-main",
+          "kind": "notebook",
+          "position": "center",
+          "size": 52,
+          "pinned": true
+        },
+        {
+          "panel_id": "graphiti-side",
+          "kind": "graph",
+          "position": "right",
+          "size": 20,
+          "pinned": false
+        }
+      ]
+    }
+  },
+  "apps": [
+    {
+      "app_id": "notebook-workbench",
+      "kind": "notebook",
+      "route": "/notebook-workbench",
+      "provider": "pmoves-notebook-workbench",
+      "action_namespace": "notebook",
+      "capabilities": ["threads", "entries", "snapshots", "search"],
+      "pinned": true
+    },
+    {
+      "app_id": "graphiti-status",
+      "kind": "graph",
+      "route": "/dashboard/graphiti",
+      "provider": "pmoves-ui",
+      "action_namespace": "graphiti",
+      "capabilities": ["trail", "audit", "handoff"],
+      "pinned": false
+    }
+  ],
+  "notebook": {
+    "provider": "open-notebook",
+    "workspace_ref": "ops-control",
+    "thread_ref": "agent-handoffs",
+    "default_page": "current-lane",
+    "sync": {
+      "mode": "mirrored",
+      "writeback_targets": ["entries", "threads", "snapshots"],
+      "artifact_prefix": "rooms/4090-field"
+    }
+  },
+  "skill_bindings": [
+    {
+      "binding_id": "handoff-scout",
+      "skill_id": "submodule-parity",
+      "room_id": "4090-field.room.control",
+      "display_name": "Scout Handoff",
+      "intent": ["handoff", "review", "triage"],
+      "activation": {
+        "invocation_mode": "suggested",
+        "trigger_phrases": ["prepare handoff", "review this lane"],
+        "requires_selection": true
+      },
+      "surface": {
+        "app_id": "notebook-workbench",
+        "target": "toolbar",
+        "route": "/notebook-workbench"
+      },
+      "execution": {
+        "mode": "workflow",
+        "run_as": "agent",
+        "stream": "status",
+        "max_steps": 6
+      },
+      "context": {
+        "sources": ["notebook-thread", "graphiti-trail", "persona", "room-state"],
+        "include_last_turns": 8,
+        "notebook_writeback": true,
+        "artifact_types": ["text", "json"]
+      },
+      "outputs": [
+        {
+          "target": "notebook-entry",
+          "delivery": "append",
+          "path": "threads/agent-handoffs",
+          "artifact_type": "text"
+        },
+        {
+          "target": "chat-response",
+          "delivery": "notify",
+          "artifact_type": "text"
+        }
+      ],
+      "guardrails": {
+        "require_approval": false,
+        "max_runtime_sec": 300,
+        "fail_open": false,
+        "one_active_run": true
+      },
+      "enabled": true,
+      "tags": ["handoff", "graphiti", "control"]
+    }
+  ],
+  "policies": {
+    "model_routing": "hybrid",
+    "publish": {
+      "allow_nats_emit": true,
+      "allow_external_publish": false,
+      "allowed_subjects": ["agent.graphiti.signed.v1", "ops.pr.review.completed.v1"]
+    },
+    "memory": {
+      "graphiti": true,
+      "notebook_writeback": true,
+      "chit_handoff": true
+    }
+  },
+  "telemetry": {
+    "graphiti_phase": "Control Room",
+    "room_events_subject": "room.session.updated.v1",
+    "healthcheck_route": "/api/audit/summary"
+  },
+  "provenance": {
+    "source": "PMOVES room contract draft",
+    "updated_at": "2026-03-27T12:00:00Z",
+    "related_docs": [
+      "pmoves/docs/MODEL_FABRIC_CONTRACT.md",
+      "pmoves/docs/infrastructure/UI_NOTEBOOK_WORKBENCH.md",
+      "pmoves/docs/BOTZ_SKILLS_MARKETPLACE.md"
+    ]
+  }
+}
+```
+
+## Integration Guidance
+### OpenRoom-style interfaces
+Use the room manifest as the browser-desktop declaration layer.
+
+That means:
+- window/panel composition comes from `shell.layout`
+- installed apps come from `apps`
+- chat/app interoperability comes from `action_namespace`
+- per-agent flavor comes from `agent_id` + `alter` + `theme`
+
+### Open Notebook / Notebook Workbench
+Use notebook as the durable substrate.
+
+That means:
+- room sessions can reopen the same threads/pages/snapshots
+- skills can persist outputs without inventing a second storage model
+- room shells stay swappable while notebook history remains stable
+
+### PMOVES skills marketplace
+Keep skill definitions portable and context-light.
+Bind them into rooms locally through `skill.binding.v1`.
+
+This prevents one marketplace skill from assuming every agent needs the same panel, model lane, or notebook target.
+
+## Recommended Next Implementation Steps
+1. Add a `room_events_subject` consumer in the UI/launcher layer so room changes become observable.
+2. Map existing Notebook Workbench surfaces onto declared `action_namespace` values.
+3. Add room defaults for `5090-voice`, `4090-field`, and `z890-infra` as first manifest examples. DONE — seeded under `pmoves/config/rooms/`.
+4. Mirror room manifests into Supabase or another runtime store only after a loader exists; keep git as canonical seed.
+5. Add one smoke path that loads a manifest and verifies app routes, notebook refs, and skill bindings resolve.
+
+## Related References
+- `pmoves/docs/MODEL_FABRIC_CONTRACT.md`
+- `pmoves/docs/infrastructure/UI_NOTEBOOK_WORKBENCH.md`
+- `pmoves/docs/BOTZ_SKILLS_MARKETPLACE.md`
+- `pmoves/config/agent_signatures.yaml`
+- `plans/KILOCODE_PMOVES_INTEGRATION_PLAN.md`
+

--- a/pmoves/scripts/validate_room_manifests.py
+++ b/pmoves/scripts/validate_room_manifests.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Validate PMOVES room manifest seeds against the room schema and catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import jsonschema
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency should exist in PMOVES envs
+    raise SystemExit("jsonschema is required to validate room manifests") from exc
+
+try:
+    from referencing import Registry, Resource
+except ModuleNotFoundError:  # pragma: no cover - fallback for older envs
+    Registry = None
+    Resource = None
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PMOVES_ROOT = SCRIPT_DIR.parent
+ROOM_DIR = PMOVES_ROOT / "config" / "rooms"
+SCHEMA_DIR = PMOVES_ROOT / "contracts" / "schemas" / "room"
+CATALOG_PATH = ROOM_DIR / "catalog.json"
+ROOM_SCHEMA_PATH = SCHEMA_DIR / "room.manifest.v1.schema.json"
+SKILL_SCHEMA_PATH = SCHEMA_DIR / "skill.binding.v1.schema.json"
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def build_validator() -> jsonschema.Draft202012Validator:
+    room_schema = read_json(ROOM_SCHEMA_PATH)
+    skill_schema = read_json(SKILL_SCHEMA_PATH)
+
+    room_schema.setdefault("$id", ROOM_SCHEMA_PATH.resolve().as_uri())
+    skill_schema.setdefault("$id", SKILL_SCHEMA_PATH.resolve().as_uri())
+
+    if Registry is not None and Resource is not None:
+        registry = Registry().with_resources(
+            [
+                (room_schema["$id"], Resource.from_contents(room_schema)),
+                (skill_schema["$id"], Resource.from_contents(skill_schema)),
+            ]
+        )
+        return jsonschema.Draft202012Validator(room_schema, registry=registry)
+
+    resolver = jsonschema.RefResolver(base_uri=room_schema["$id"], referrer=room_schema)
+    return jsonschema.Draft202012Validator(room_schema, resolver=resolver)
+
+
+def iter_catalog_entries(catalog: dict, only_room_id: str | None) -> Iterable[dict]:
+    rooms = catalog.get("rooms", [])
+    for entry in rooms:
+        if only_room_id and entry.get("room_id") != only_room_id:
+            continue
+        yield entry
+
+
+def validate_entry(entry: dict, validator: jsonschema.Draft202012Validator) -> tuple[Path, dict]:
+    manifest_name = entry.get("manifest")
+    if not manifest_name:
+        raise ValueError(f"catalog entry {entry.get('room_id', '<unknown>')} is missing 'manifest'")
+
+    manifest_path = ROOM_DIR / manifest_name
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"manifest not found: {manifest_path}")
+
+    manifest = read_json(manifest_path)
+    validator.validate(manifest)
+
+    for key in ("room_id", "agent_id", "alter", "display_name"):
+        catalog_value = entry.get(key)
+        manifest_value = manifest.get(key)
+        if catalog_value is not None and manifest_value != catalog_value:
+            raise ValueError(
+                f"catalog mismatch for {manifest_name}: {key}={manifest_value!r} != {catalog_value!r}"
+            )
+
+    return manifest_path, manifest
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--room-id", help="Validate a single room_id from the catalog")
+    parser.add_argument("--quiet", action="store_true", help="Suppress per-room summary output")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    catalog = read_json(CATALOG_PATH)
+    validator = build_validator()
+    matched = list(iter_catalog_entries(catalog, args.room_id))
+
+    if not matched:
+        raise SystemExit(f"No catalog entries found for room_id={args.room_id!r}")
+
+    seen_ids: set[str] = set()
+    for entry in matched:
+        manifest_path, manifest = validate_entry(entry, validator)
+        room_id = manifest["room_id"]
+        if room_id in seen_ids:
+            raise ValueError(f"duplicate room_id in selection: {room_id}")
+        seen_ids.add(room_id)
+
+        if not args.quiet:
+            apps = len(manifest.get("apps", []))
+            skills = len(manifest.get("skill_bindings", []))
+            route = manifest.get("shell", {}).get("layout", {}).get("default_route", "-")
+            print(f"OK {manifest_path.name} room_id={room_id} apps={apps} skills={skills} route={route}")
+
+    if args.quiet:
+        print(f"validated {len(matched)} room manifest(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pmoves/ui/app/api/rooms/route.ts
+++ b/pmoves/ui/app/api/rooms/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
 
   const roomId = request.nextUrl.searchParams.get('room_id');
   const headers = {
-    'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+    'Cache-Control': 'private, max-age=30, stale-while-revalidate=60',
     'Content-Type': 'application/json',
   };
 
@@ -43,11 +43,9 @@ export async function GET(request: NextRequest) {
       { headers }
     );
   } catch (error) {
+    console.error('Failed to load rooms:', error);
     return NextResponse.json(
-      {
-        error: 'Failed to load rooms',
-        message: error instanceof Error ? error.message : String(error),
-      },
+      { error: 'Failed to load rooms' },
       { status: 500, headers }
     );
   }

--- a/pmoves/ui/app/api/rooms/route.ts
+++ b/pmoves/ui/app/api/rooms/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ownerFromJwt } from '@/lib/jwtUtils';
+import { loadRoom, loadRooms } from '@/lib/rooms';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const { ownerId, error: authError } = ownerFromJwt('rooms');
+  if (authError || !ownerId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const roomId = request.nextUrl.searchParams.get('room_id');
+  const headers = {
+    'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+    'Content-Type': 'application/json',
+  };
+
+  try {
+    if (roomId) {
+      const room = await loadRoom(roomId);
+      if (!room) {
+        return NextResponse.json({ error: 'Room not found' }, { status: 404, headers });
+      }
+
+      return NextResponse.json(
+        {
+          room,
+          generatedAt: new Date().toISOString(),
+        },
+        { headers }
+      );
+    }
+
+    const rooms = await loadRooms();
+    return NextResponse.json(
+      {
+        rooms,
+        total: rooms.length,
+        generatedAt: new Date().toISOString(),
+      },
+      { headers }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Failed to load rooms',
+        message: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500, headers }
+    );
+  }
+}

--- a/pmoves/ui/app/dashboard/rooms/page.tsx
+++ b/pmoves/ui/app/dashboard/rooms/page.tsx
@@ -123,15 +123,26 @@ export default async function RoomsPage() {
                 <div className="space-y-2">
                   <div className="font-pixel text-[7px] uppercase tracking-[0.18em] text-ink-muted">Pinned apps</div>
                   <div className="flex flex-wrap gap-2">
-                    {pinnedApps.map((app) => (
-                      <Link
-                        key={app.app_id}
-                        href={app.route}
-                        className="border border-border-subtle bg-void-soft px-2.5 py-1 font-mono text-2xs uppercase tracking-wider text-ink-secondary transition-colors hover:border-ink-primary hover:text-ink-primary"
-                      >
-                        {app.app_id}
-                      </Link>
-                    ))}
+                    {pinnedApps.map((app) => {
+                      const isPlanned = app.status === 'planned';
+                      return isPlanned ? (
+                        <span
+                          key={app.app_id}
+                          className="border border-border-subtle bg-void-soft px-2.5 py-1 font-mono text-2xs uppercase tracking-wider text-ink-muted opacity-50"
+                          title="Route not yet implemented"
+                        >
+                          {app.app_id}
+                        </span>
+                      ) : (
+                        <Link
+                          key={app.app_id}
+                          href={app.route}
+                          className="border border-border-subtle bg-void-soft px-2.5 py-1 font-mono text-2xs uppercase tracking-wider text-ink-secondary transition-colors hover:border-ink-primary hover:text-ink-primary"
+                        >
+                          {app.app_id}
+                        </Link>
+                      );
+                    })}
                     {pinnedApps.length === 0 && (
                       <span className="font-mono text-2xs uppercase tracking-wider text-ink-muted">No pinned apps</span>
                     )}
@@ -144,12 +155,12 @@ export default async function RoomsPage() {
                     {activeSkills.slice(0, 2).map((binding) => (
                       <div key={binding.binding_id} className="border border-border-subtle bg-void-soft px-3 py-2">
                         <div className="flex items-center justify-between gap-3">
-                          <span className="font-medium text-ink-primary">{binding.display_name}</span>
+                          <span className="font-medium text-ink-primary">{binding.display_name ?? binding.binding_id}</span>
                           <span className="font-mono text-2xs uppercase tracking-wider text-ink-muted">
                             {binding.execution?.mode ?? 'direct'}
                           </span>
                         </div>
-                        <p className="mt-1 text-xs text-ink-secondary">{binding.intent.join(', ')}</p>
+                        <p className="mt-1 text-xs text-ink-secondary">{Array.isArray(binding.intent) ? binding.intent.join(', ') : ''}</p>
                       </div>
                     ))}
                     {activeSkills.length === 0 && (

--- a/pmoves/ui/app/dashboard/rooms/page.tsx
+++ b/pmoves/ui/app/dashboard/rooms/page.tsx
@@ -1,0 +1,196 @@
+import Link from 'next/link';
+import { DashboardShell } from '@/components/DashboardNavigation';
+import { loadRooms, type RoomDefinition } from '@/lib/rooms';
+
+export const dynamic = 'force-dynamic';
+
+function formatToken(value: string | undefined): string {
+  if (!value) {
+    return 'unset';
+  }
+
+  return value.replace(/[-_.]/g, ' ');
+}
+
+function summarizePanels(room: RoomDefinition): string {
+  return room.manifest.shell.layout.panels.map((panel) => panel.kind).join(' / ');
+}
+
+export default async function RoomsPage() {
+  const rooms = await loadRooms();
+  const totalApps = rooms.reduce((sum, room) => sum + room.manifest.apps.length, 0);
+  const totalSkills = rooms.reduce((sum, room) => sum + room.manifest.skill_bindings.filter((binding) => binding.enabled !== false).length, 0);
+  const notebookProviders = new Set(rooms.map((room) => room.manifest.notebook.provider));
+
+  return (
+    <DashboardShell
+      title="Rooms"
+      subtitle="Agent-owned room shells loaded from the PMOVES room catalog"
+      active="rooms"
+      actions={
+        <Link href="/api/rooms" className="tag tag-cyan">
+          JSON API
+        </Link>
+      }
+    >
+      <div className="p-6 lg:p-8 space-y-8">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="card-brutal border border-cata-cyan/30 p-4">
+            <div className="font-pixel text-[7px] uppercase tracking-wider text-cata-cyan">Rooms</div>
+            <div className="mt-3 font-display text-3xl font-bold">{rooms.length}</div>
+            <p className="mt-2 text-sm text-ink-secondary">Seeded room profiles available to the launcher and workbench.</p>
+          </div>
+          <div className="card-brutal border border-cata-forest/30 p-4">
+            <div className="font-pixel text-[7px] uppercase tracking-wider text-cata-forest">Apps</div>
+            <div className="mt-3 font-display text-3xl font-bold">{totalApps}</div>
+            <p className="mt-2 text-sm text-ink-secondary">Declared app surfaces bound into room shells.</p>
+          </div>
+          <div className="card-brutal border border-cata-gold/30 p-4">
+            <div className="font-pixel text-[7px] uppercase tracking-wider text-cata-gold">Skills</div>
+            <div className="mt-3 font-display text-3xl font-bold">{totalSkills}</div>
+            <p className="mt-2 text-sm text-ink-secondary">Enabled skill bindings ready for room-local invocation.</p>
+          </div>
+          <div className="card-brutal border border-cata-violet/30 p-4">
+            <div className="font-pixel text-[7px] uppercase tracking-wider text-cata-violet">Notebook Providers</div>
+            <div className="mt-3 font-display text-3xl font-bold">{notebookProviders.size}</div>
+            <p className="mt-2 text-sm text-ink-secondary">Notebook backplanes currently represented in the catalog.</p>
+          </div>
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-3">
+          {rooms.map((room) => {
+            const accent = room.manifest.shell.theme.accent_color ?? '#22C55E';
+            const glyph = room.manifest.persona?.glyph ?? room.display_name.charAt(0).toUpperCase();
+            const pinnedApps = room.manifest.apps.filter((app) => app.pinned);
+            const activeSkills = room.manifest.skill_bindings.filter((binding) => binding.enabled !== false);
+
+            return (
+              <article
+                key={room.room_id}
+                className="card-brutal border p-6 flex flex-col gap-5"
+                style={{ borderColor: accent, boxShadow: `0 0 0 1px ${accent}22` }}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="space-y-2">
+                    <div className="font-pixel text-[7px] uppercase tracking-[0.22em]" style={{ color: accent }}>
+                      {room.agent_id}
+                      {room.alter ? ` / ${room.alter}` : ''}
+                    </div>
+                    <div>
+                      <h2 className="font-display text-2xl font-bold leading-tight text-ink-primary">
+                        {room.display_name}
+                      </h2>
+                      <p className="mt-2 text-sm leading-relaxed text-ink-secondary">
+                        {room.summary ?? room.manifest.description ?? 'Room manifest loaded from catalog.'}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div
+                    className="flex h-12 w-12 shrink-0 items-center justify-center border text-xl font-display font-bold"
+                    style={{ borderColor: accent, backgroundColor: `${accent}12`, color: accent }}
+                    aria-hidden="true"
+                  >
+                    {glyph}
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  <span className="tag tag-forest">{formatToken(room.manifest.room_type)}</span>
+                  <span className="tag tag-violet">{formatToken(room.manifest.owner_mode)}</span>
+                  <span className="tag tag-gold">{formatToken(room.manifest.policies.model_routing)}</span>
+                </div>
+
+                <dl className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <dt className="text-ink-muted">Default route</dt>
+                    <dd className="mt-1 font-mono text-xs text-ink-primary">{room.manifest.shell.layout.default_route}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-ink-muted">Workspace</dt>
+                    <dd className="mt-1 font-mono text-xs text-ink-primary">{room.manifest.notebook.workspace_ref}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-ink-muted">Panels</dt>
+                    <dd className="mt-1 text-ink-primary">{room.manifest.shell.layout.panels.length} ({summarizePanels(room)})</dd>
+                  </div>
+                  <div>
+                    <dt className="text-ink-muted">Writeback</dt>
+                    <dd className="mt-1 text-ink-primary">{room.manifest.notebook.sync.writeback_targets.join(', ')}</dd>
+                  </div>
+                </dl>
+
+                <div className="space-y-2">
+                  <div className="font-pixel text-[7px] uppercase tracking-[0.18em] text-ink-muted">Pinned apps</div>
+                  <div className="flex flex-wrap gap-2">
+                    {pinnedApps.map((app) => (
+                      <Link
+                        key={app.app_id}
+                        href={app.route}
+                        className="border border-border-subtle bg-void-soft px-2.5 py-1 font-mono text-2xs uppercase tracking-wider text-ink-secondary transition-colors hover:border-ink-primary hover:text-ink-primary"
+                      >
+                        {app.app_id}
+                      </Link>
+                    ))}
+                    {pinnedApps.length === 0 && (
+                      <span className="font-mono text-2xs uppercase tracking-wider text-ink-muted">No pinned apps</span>
+                    )}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="font-pixel text-[7px] uppercase tracking-[0.18em] text-ink-muted">Skill bindings</div>
+                  <div className="space-y-2">
+                    {activeSkills.slice(0, 2).map((binding) => (
+                      <div key={binding.binding_id} className="border border-border-subtle bg-void-soft px-3 py-2">
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="font-medium text-ink-primary">{binding.display_name}</span>
+                          <span className="font-mono text-2xs uppercase tracking-wider text-ink-muted">
+                            {binding.execution?.mode ?? 'direct'}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs text-ink-secondary">{binding.intent.join(', ')}</p>
+                      </div>
+                    ))}
+                    {activeSkills.length === 0 && (
+                      <div className="border border-border-subtle bg-void-soft px-3 py-2 text-xs text-ink-muted">
+                        No enabled bindings in this room.
+                      </div>
+                    )}
+                    {activeSkills.length > 2 && (
+                      <div className="font-mono text-2xs uppercase tracking-wider text-ink-muted">
+                        +{activeSkills.length - 2} more bindings in manifest
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-auto flex items-center justify-between gap-3 border-t border-border-subtle pt-4">
+                  <Link
+                    href={room.manifest.shell.layout.default_route}
+                    className="inline-flex items-center gap-2 border px-3 py-2 text-xs font-mono uppercase tracking-wider transition-colors hover:text-void"
+                    style={{ borderColor: accent, color: accent }}
+                  >
+                    Launch room
+                  </Link>
+                  <Link
+                    href={`/api/rooms?room_id=${encodeURIComponent(room.room_id)}`}
+                    className="font-mono text-2xs uppercase tracking-wider text-ink-secondary transition-colors hover:text-ink-primary"
+                  >
+                    Manifest JSON
+                  </Link>
+                </div>
+              </article>
+            );
+          })}
+        </section>
+
+        {rooms.length === 0 && (
+          <div className="card-brutal border border-border-subtle p-6 text-sm text-ink-secondary">
+            No room manifests were found. Seed the catalog under <code>pmoves/config/rooms</code> and reload the dashboard.
+          </div>
+        )}
+      </div>
+    </DashboardShell>
+  );
+}

--- a/pmoves/ui/components/DashboardNavigation.tsx
+++ b/pmoves/ui/components/DashboardNavigation.tsx
@@ -26,6 +26,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/dashboard/notebook/runtime', label: 'Runtime', key: 'notebook-runtime' },
   { href: '/notebook-workbench', label: 'Workbench', key: 'notebook-workbench' },
   { href: '/dashboard/personas', label: 'Personas', key: 'personas', accent: 'gold' },
+  { href: '/dashboard/rooms', label: 'Rooms', key: 'rooms', accent: 'cyan' },
   { href: '/dashboard/chat', label: 'Chat', key: 'chat' },
   { href: '/dashboard/services', label: 'Services', key: 'services' },
   { href: '/dashboard/chit', label: 'Chit', key: 'chit', accent: 'cyan' },
@@ -47,6 +48,7 @@ export type NavKey =
   | 'notebook-runtime'
   | 'notebook-workbench'
   | 'personas'
+  | 'rooms'
   | 'chat'
   | 'services'
   | 'chit'

--- a/pmoves/ui/lib/__tests__/rooms.test.ts
+++ b/pmoves/ui/lib/__tests__/rooms.test.ts
@@ -1,0 +1,41 @@
+import { getRoomConfigDir, loadRoom, loadRoomCatalog, loadRooms } from '../rooms';
+
+describe('room catalog loader', () => {
+  it('resolves the seeded room catalog directory', () => {
+    expect(getRoomConfigDir().replace(/\\/g, '/')).toMatch(/pmoves\/config\/rooms$/);
+  });
+
+  it('loads the room catalog entries', async () => {
+    const catalog = await loadRoomCatalog();
+    expect(catalog.schema_version).toBe('1.0.0');
+    expect(catalog.rooms.map((room) => room.room_id)).toEqual(
+      expect.arrayContaining([
+        '4090-field.room.control',
+        '5090-voice.room.studio',
+        'z890-infra.room.fabric',
+      ])
+    );
+  });
+
+  it('hydrates room manifests with catalog parity checks', async () => {
+    const rooms = await loadRooms();
+    const fieldRoom = rooms.find((room) => room.room_id === '4090-field.room.control');
+
+    expect(fieldRoom).toBeDefined();
+    expect(fieldRoom?.manifest.shell.layout.default_route).toBe('/dashboard/notebook/runtime');
+    expect(fieldRoom?.manifest.apps.some((app) => app.pinned)).toBe(true);
+    expect(fieldRoom?.manifest.skill_bindings.length).toBeGreaterThan(0);
+  });
+
+  it('loads a single room by id', async () => {
+    const voiceRoom = await loadRoom('5090-voice.room.studio');
+
+    expect(voiceRoom?.agent_id).toBe('5090-claude');
+    expect(voiceRoom?.manifest.notebook.provider).toBe('open-notebook');
+    expect(voiceRoom?.manifest.policies.model_routing).toBe('hybrid');
+  });
+
+  it('returns null for unknown rooms', async () => {
+    await expect(loadRoom('missing-room')).resolves.toBeNull();
+  });
+});

--- a/pmoves/ui/lib/rooms.ts
+++ b/pmoves/ui/lib/rooms.ts
@@ -1,0 +1,189 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface RoomCatalogEntry {
+  room_id: string;
+  agent_id: string;
+  alter?: string;
+  display_name: string;
+  manifest: string;
+  summary?: string;
+}
+
+export interface RoomCatalog {
+  schema_version: string;
+  rooms: RoomCatalogEntry[];
+}
+
+export interface RoomPanel {
+  panel_id: string;
+  kind: string;
+  position: string;
+  size?: number;
+  pinned?: boolean;
+}
+
+export interface RoomApp {
+  app_id: string;
+  kind: string;
+  route: string;
+  provider?: string;
+  action_namespace?: string;
+  capabilities: string[];
+  pinned?: boolean;
+}
+
+export interface RoomSkillBinding {
+  binding_id: string;
+  display_name: string;
+  intent: string[];
+  enabled?: boolean;
+  tags?: string[];
+  surface?: {
+    app_id: string;
+    target?: string;
+    route?: string;
+  };
+  execution?: {
+    mode?: string;
+    run_as?: string;
+    stream?: string;
+    max_steps?: number;
+  };
+}
+
+export interface RoomManifest {
+  room_id: string;
+  version: string;
+  display_name: string;
+  description?: string;
+  agent_id: string;
+  alter?: string;
+  room_type?: string;
+  owner_mode?: string;
+  shell: {
+    theme: {
+      theme_id: string;
+      accent_color?: string;
+      skin?: string;
+      icon?: string;
+    };
+    layout: {
+      default_route: string;
+      panels: RoomPanel[];
+    };
+  };
+  apps: RoomApp[];
+  notebook: {
+    provider: string;
+    workspace_ref: string;
+    thread_ref?: string;
+    default_page?: string;
+    sync: {
+      mode: string;
+      writeback_targets: string[];
+      artifact_prefix?: string;
+    };
+  };
+  persona?: {
+    signature_ref?: string;
+    voice?: string;
+    glyph?: string;
+    resonance?: string[];
+  };
+  skill_bindings: RoomSkillBinding[];
+  policies: {
+    model_routing: string;
+    publish: {
+      allow_nats_emit: boolean;
+      allow_external_publish: boolean;
+      allowed_subjects?: string[];
+    };
+    memory: {
+      graphiti: boolean;
+      notebook_writeback: boolean;
+      chit_handoff: boolean;
+    };
+  };
+  telemetry?: {
+    graphiti_phase?: string;
+    room_events_subject?: string;
+    healthcheck_route?: string;
+  };
+  provenance?: {
+    source: string;
+    updated_at: string;
+    related_docs?: string[];
+  };
+}
+
+export interface RoomDefinition extends Omit<RoomCatalogEntry, 'manifest'> {
+  manifestFile: string;
+  manifestPath: string;
+  manifest: RoomManifest;
+}
+
+const DEFAULT_ROOM_CONFIG_DIR = process.env.PMOVES_ROOM_CONFIG_DIR
+  ? path.resolve(process.env.PMOVES_ROOM_CONFIG_DIR)
+  : path.resolve(process.cwd(), '..', 'config', 'rooms');
+
+function stripBom(raw: string): string {
+  return raw.replace(/^\uFEFF/, '');
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(stripBom(raw)) as T;
+}
+
+function validateCatalogParity(entry: RoomCatalogEntry, manifest: RoomManifest): void {
+  if (manifest.room_id !== entry.room_id) {
+    throw new Error(`Room manifest mismatch for ${entry.manifest}: room_id ${manifest.room_id} !== ${entry.room_id}`);
+  }
+
+  if (manifest.agent_id !== entry.agent_id) {
+    throw new Error(`Room manifest mismatch for ${entry.manifest}: agent_id ${manifest.agent_id} !== ${entry.agent_id}`);
+  }
+
+  if ((manifest.alter ?? '') !== (entry.alter ?? '')) {
+    throw new Error(`Room manifest mismatch for ${entry.manifest}: alter ${manifest.alter ?? ''} !== ${entry.alter ?? ''}`);
+  }
+
+  if (manifest.display_name !== entry.display_name) {
+    throw new Error(`Room manifest mismatch for ${entry.manifest}: display_name ${manifest.display_name} !== ${entry.display_name}`);
+  }
+}
+
+export function getRoomConfigDir(): string {
+  return DEFAULT_ROOM_CONFIG_DIR;
+}
+
+export async function loadRoomCatalog(roomConfigDir = DEFAULT_ROOM_CONFIG_DIR): Promise<RoomCatalog> {
+  return readJsonFile<RoomCatalog>(path.join(roomConfigDir, 'catalog.json'));
+}
+
+export async function loadRooms(roomConfigDir = DEFAULT_ROOM_CONFIG_DIR): Promise<RoomDefinition[]> {
+  const catalog = await loadRoomCatalog(roomConfigDir);
+  const rooms = await Promise.all(
+    catalog.rooms.map(async (entry) => {
+      const manifestPath = path.join(roomConfigDir, entry.manifest);
+      const manifest = await readJsonFile<RoomManifest>(manifestPath);
+      validateCatalogParity(entry, manifest);
+      return {
+        ...entry,
+        manifestFile: entry.manifest,
+        manifestPath,
+        manifest,
+      } satisfies RoomDefinition;
+    })
+  );
+
+  return rooms.sort((left, right) => left.display_name.localeCompare(right.display_name));
+}
+
+export async function loadRoom(roomId: string, roomConfigDir = DEFAULT_ROOM_CONFIG_DIR): Promise<RoomDefinition | null> {
+  const rooms = await loadRooms(roomConfigDir);
+  return rooms.find((room) => room.room_id === roomId) ?? null;
+}
+
+

--- a/pmoves/ui/lib/rooms.ts
+++ b/pmoves/ui/lib/rooms.ts
@@ -31,6 +31,7 @@ export interface RoomApp {
   action_namespace?: string;
   capabilities: string[];
   pinned?: boolean;
+  status?: 'active' | 'planned' | 'deprecated';
 }
 
 export interface RoomSkillBinding {


### PR DESCRIPTION
## Summary

Adds the first PMOVES room catalog contract and wires it into the UI as a loader-backed dashboard surface.

## What changed

- adds room manifest schemas
  - `pmoves/contracts/schemas/room/room.manifest.v1.schema.json`
  - `pmoves/contracts/schemas/room/skill.binding.v1.schema.json`
- adds seed room catalog + manifests
  - `pmoves/config/rooms/catalog.json`
  - `pmoves/config/rooms/4090-field.room.control.json`
  - `pmoves/config/rooms/5090-voice.room.studio.json`
  - `pmoves/config/rooms/z890-infra.room.fabric.json`
- adds room contract docs
  - `pmoves/docs/ROOM_MANIFEST_CONTRACT.md`
- adds manifest validator
  - `pmoves/scripts/validate_room_manifests.py`
- adds UI loader + test
  - `pmoves/ui/lib/rooms.ts`
  - `pmoves/ui/lib/__tests__/rooms.test.ts`
- adds authenticated room API
  - `pmoves/ui/app/api/rooms/route.ts`
- adds `Rooms` dashboard surface
  - `pmoves/ui/app/dashboard/rooms/page.tsx`
- adds dashboard nav entry
  - `pmoves/ui/components/DashboardNavigation.tsx`
- updates `.gitignore` so `pmoves/ui/lib/rooms.ts` and its test are not swallowed by the repo-wide `lib/` ignore rule

## Why

This moves rooms from doc-only concept to a typed, seedable, loader-backed contract that launcher and notebook surfaces can consume consistently.

## Verification

- `python pmoves/scripts/validate_room_manifests.py`
- `npx eslint lib/rooms.ts lib/__tests__/rooms.test.ts app/api/rooms/route.ts app/dashboard/rooms/page.tsx components/DashboardNavigation.tsx`
- `npx jest lib/__tests__/rooms.test.ts --runInBand`
- `npx tsc --noEmit`

## Notes

This PR intentionally stops at catalog + dashboard/API exposure.
Home/launcher entry routing is in the follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new room types (Field Control, Voice Studio, Infra Fabric) with pre-configured apps, personas, skill bindings, and notebook integrations.
  * Rooms dashboard, navigation entry, and API for browsing, stats, launching rooms, and inspecting manifest JSON.

* **Documentation**
  * Added Room Manifest contract docs and manifest/schema validation tooling.

* **Tests**
  * Added unit tests covering catalog loading and manifest hydration.

* **Chores**
  * Updated .gitignore to track specific UI/utility files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->