### PR TITLE
Route home launcher selection through room entry paths

### DIFF
--- a/pmoves/ui/__tests__/home-page.test.tsx
+++ b/pmoves/ui/__tests__/home-page.test.tsx
@@ -15,32 +15,41 @@ jest.mock('@/components/hub/SystemHubSection', () => ({
   SystemHubSection: () => <div data-testid="system-hub-section">Hub</div>,
 }));
 
+jest.mock('@/components/home/HomeRoomLauncher', () => ({
+  HomeRoomLauncher: () => <div data-testid="home-room-launcher">Room launcher</div>,
+}));
+
 describe('HomePage', () => {
-  it('renders the main heading', () => {
-    render(<HomePage />);
+  it('renders the main heading', async () => {
+    render(await HomePage());
     expect(screen.getByText('POWERFUL')).toBeInTheDocument();
     expect(screen.getByText('MOVES')).toBeInTheDocument();
   });
 
-  it('provides navigation to the ingestion dashboard', () => {
-    render(<HomePage />);
+  it('provides navigation to the launcher flow', async () => {
+    render(await HomePage());
     const link = screen.getByRole('link', { name: /launch console/i });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', expect.stringContaining('/login'));
   });
 
-  it('renders pipeline steps', () => {
-    render(<HomePage />);
+  it('renders pipeline steps', async () => {
+    render(await HomePage());
     expect(screen.getByText('Create')).toBeInTheDocument();
     expect(screen.getByText('Webhook')).toBeInTheDocument();
     expect(screen.getByText('Approve')).toBeInTheDocument();
     expect(screen.getByText('Publish')).toBeInTheDocument();
   });
 
-  it('renders agent personas', () => {
-    render(<HomePage />);
+  it('renders agent personas', async () => {
+    render(await HomePage());
     expect(screen.getByText('Archon')).toBeInTheDocument();
     expect(screen.getByText('Catalyst')).toBeInTheDocument();
     expect(screen.getByText('Ledger')).toBeInTheDocument();
+  });
+
+  it('renders the room launcher surface', async () => {
+    render(await HomePage());
+    expect(screen.getByTestId('home-room-launcher')).toBeInTheDocument();
   });
 });

--- a/pmoves/ui/app/(auth)/login/page.tsx
+++ b/pmoves/ui/app/(auth)/login/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import { featureFlags } from '@/config/featureFlags';
 import { getEnabledAuthProviders } from '@/config/supabaseProviders';
+import { loadRoom } from '@/lib/rooms';
 import { LoginForm } from './LoginForm';
 
 export const dynamic = 'force-dynamic';
@@ -19,6 +20,13 @@ const sanitizeNextParam = (value: string | string[] | undefined): string | undef
 const sanitizeErrorParam = (value: string | string[] | undefined): string | undefined => {
   if (Array.isArray(value)) return sanitizeErrorParam(value[0]);
   if (!value) return undefined;
+  return value;
+};
+
+const sanitizeRoomParam = (value: string | string[] | undefined): string | undefined => {
+  if (Array.isArray(value)) return sanitizeRoomParam(value[0]);
+  if (!value) return undefined;
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(value)) return undefined;
   return value;
 };
 
@@ -49,19 +57,21 @@ export default async function LoginPage({
       : (searchParams as LoginPageSearchParams | undefined);
 
   const nextParam = sanitizeNextParam(resolvedSearchParams?.next);
+  const roomParam = sanitizeRoomParam(resolvedSearchParams?.room_id);
   const initialError = sanitizeErrorParam(resolvedSearchParams?.error);
   const providers = featureFlags.oauth ? getEnabledAuthProviders() : [];
+  const selectedRoom = roomParam ? await loadRoom(roomParam) : null;
+  const resolvedNextPath = nextParam ?? selectedRoom?.manifest.shell.layout.default_route ?? '/dashboard/ingest';
 
   const bootJwt =
     process.env.NEXT_PUBLIC_SUPABASE_BOOT_USER_JWT || process.env.SUPABASE_BOOT_USER_JWT;
 
   if (bootJwt) {
-    redirect(nextParam ?? '/dashboard/ingest');
+    redirect(resolvedNextPath);
   }
 
   return (
     <main className="relative min-h-screen flex items-center justify-center bg-void text-ink-primary px-6 py-16 overflow-hidden">
-      {/* Background */}
       <div className="cymatic-grid" />
       <div className="absolute inset-0 pointer-events-none">
         <div className="absolute top-1/4 left-1/4 w-96 h-96 rounded-full bg-cata-cyan/10 blur-[120px]" />
@@ -70,7 +80,6 @@ export default async function LoginPage({
       <div className="noise-overlay" />
 
       <section className="relative z-10 flex w-full max-w-5xl flex-col lg:flex-row gap-12">
-        {/* Left side - branding */}
         <div className="flex-1 flex flex-col justify-center">
           <Link href="/" className="flex items-center gap-3 mb-12 group">
             <div className="w-10 h-10 bg-cata-cyan group-hover:bg-cata-forest transition-colors" />
@@ -87,7 +96,17 @@ export default async function LoginPage({
             Use your PMOVES Supabase credentials or a supported social provider to continue to the operator console.
           </p>
 
-          {/* Help section */}
+          {selectedRoom && (
+            <div className="mt-8 border border-cata-cyan/30 bg-void-elevated/80 p-4">
+              <div className="font-pixel text-[7px] uppercase tracking-[0.18em] text-cata-cyan">Room target</div>
+              <h2 className="mt-2 font-display text-xl font-bold text-ink-primary">{selectedRoom.display_name}</h2>
+              <p className="mt-2 text-sm text-ink-secondary">
+                {selectedRoom.summary ?? selectedRoom.manifest.description ?? 'Room manifest loaded from the PMOVES catalog.'}
+              </p>
+              <div className="mt-3 font-mono text-xs text-ink-muted">Entry route: {resolvedNextPath}</div>
+            </div>
+          )}
+
           <div className="mt-12 space-y-4">
             <h2 className="font-display font-semibold text-sm uppercase tracking-wider text-ink-muted">
               Having trouble?
@@ -109,13 +128,12 @@ export default async function LoginPage({
           </div>
         </div>
 
-        {/* Right side - form */}
         <div className="flex-1 flex items-center justify-center lg:justify-end">
           <LoginForm
             providers={providers}
             passwordEnabled={featureFlags.passwordAuth}
             callbackUrl={callbackUrl}
-            nextPath={nextParam}
+            nextPath={resolvedNextPath}
             initialError={initialError ?? null}
           />
         </div>

--- a/pmoves/ui/app/page.tsx
+++ b/pmoves/ui/app/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
+import { HomeRoomLauncher, type HomeRoomOption } from '@/components/home/HomeRoomLauncher';
 import { SystemHubSection } from '@/components/hub/SystemHubSection';
+import { loadRooms } from '@/lib/rooms';
 
 /* ═══════════════════════════════════════════════════════════════════════════
    POWERFULMOVES Landing Page — Megaman × Transformers
@@ -37,7 +39,7 @@ const personas: Persona[] = [
    Hero Section — Megaman × Transformers Style
    ───────────────────────────────────────────────────────────────────────────── */
 
-function HeroSection() {
+function HeroSection({ roomOptions }: { roomOptions: HomeRoomOption[] }) {
   return (
     <section className="relative min-h-screen overflow-hidden scanline">
       {/* Background layers */}
@@ -62,7 +64,7 @@ function HeroSection() {
             <Link href="https://github.com/POWERFULMOVES/PMOVES.AI" className="font-display text-xs uppercase tracking-wider text-ink-secondary hover:text-cata-cyan transition-colors">GitHub</Link>
           </div>
           <Link
-            href="/login?next=%2Fdashboard%2Fingest"
+            href="/login?next=%2Fdashboard%2Frooms"
             className="btn-primary"
           >
             Launch Console
@@ -113,8 +115,12 @@ function HeroSection() {
             </Link>
           </div>
 
+          <div className="opacity-0 animate-fade-in-up delay-500">
+            <HomeRoomLauncher rooms={roomOptions} />
+          </div>
+
           {/* Stats strip - mech style */}
-          <div className="mt-16 flex flex-wrap gap-8 lg:gap-16 opacity-0 animate-fade-in-up delay-500">
+          <div className="mt-16 flex flex-wrap gap-8 lg:gap-16 opacity-0 animate-fade-in-up delay-[600ms]">
             <div className="card-mech p-4 min-w-[120px]">
               <div className="font-display text-3xl font-bold text-cata-cyan">60+</div>
               <div className="font-pixel text-[6px] text-ink-muted uppercase mt-2">Microservices</div>
@@ -359,11 +365,39 @@ function Footer() {
    Main Page
    ───────────────────────────────────────────────────────────────────────────── */
 
-export default function HomePage() {
+async function loadHomeRoomOptions(): Promise<HomeRoomOption[]> {
+  try {
+    const rooms = await loadRooms();
+    return rooms.map((room) => ({
+      roomId: room.room_id,
+      displayName: room.display_name,
+      agentId: room.agent_id,
+      alter: room.alter,
+      summary: room.summary ?? room.manifest.description,
+      defaultRoute: room.manifest.shell.layout.default_route,
+      accentColor: room.manifest.shell.theme.accent_color,
+      glyph: room.manifest.persona?.glyph,
+      pinnedApps: room.manifest.apps
+        .filter((app) => app.pinned)
+        .slice(0, 3)
+        .map((app) => ({
+          appId: app.app_id,
+          route: app.route,
+        })),
+    }));
+  } catch (error) {
+    console.error('Failed to load home room options', error);
+    return [];
+  }
+}
+
+export default async function HomePage() {
+  const roomOptions = await loadHomeRoomOptions();
+
   return (
     <main id="main-content" tabIndex={-1} className="bg-void text-ink-primary">
       <div className="noise-overlay" />
-      <HeroSection />
+      <HeroSection roomOptions={roomOptions} />
       <SystemHubSection />
       <PipelineSection />
       <PersonasSection />

--- a/pmoves/ui/components/home/HomeRoomLauncher.test.tsx
+++ b/pmoves/ui/components/home/HomeRoomLauncher.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HomeRoomLauncher, type HomeRoomOption } from './HomeRoomLauncher';
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+const ROOMS: HomeRoomOption[] = [
+  {
+    roomId: '4090-field.room.control',
+    displayName: '4090 Field Control Room',
+    agentId: '4090-claude',
+    alter: '4090-field',
+    summary: 'Scout/control room for review and handoff.',
+    defaultRoute: '/dashboard/notebook/runtime',
+    accentColor: '#065F46',
+    glyph: '◎',
+    pinnedApps: [{ appId: 'notebook-workbench', route: '/notebook-workbench' }],
+  },
+  {
+    roomId: '5090-voice.room.studio',
+    displayName: '5090 Voice Studio',
+    agentId: '5090-claude',
+    alter: '5090-voice',
+    summary: 'Voice-first room for media and audition workflows.',
+    defaultRoute: '/dashboard/services',
+    accentColor: '#B45309',
+    glyph: '◉',
+    pinnedApps: [{ appId: 'voice-lab', route: '/dashboard/services' }],
+  },
+];
+
+describe('HomeRoomLauncher', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('launches the first room by default', () => {
+    render(<HomeRoomLauncher rooms={ROOMS} />);
+
+    const launchLink = screen.getByRole('link', { name: /launch 4090 field control room/i });
+    expect(launchLink).toHaveAttribute('href', '/login?room_id=4090-field.room.control');
+    expect(screen.getByText('/dashboard/notebook/runtime')).toBeInTheDocument();
+  });
+
+  it('updates the launch target and persists the selected room', async () => {
+    const user = userEvent.setup();
+    render(<HomeRoomLauncher rooms={ROOMS} />);
+
+    await user.click(screen.getByRole('button', { name: /5090 voice studio/i }));
+
+    expect(screen.getByRole('link', { name: /launch 5090 voice studio/i })).toHaveAttribute(
+      'href',
+      '/login?room_id=5090-voice.room.studio'
+    );
+    expect(window.localStorage.getItem('pmoves.home.selectedRoom')).toBe('5090-voice.room.studio');
+  });
+});

--- a/pmoves/ui/components/home/HomeRoomLauncher.tsx
+++ b/pmoves/ui/components/home/HomeRoomLauncher.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+
+export type HomeRoomOption = {
+  roomId: string;
+  displayName: string;
+  agentId: string;
+  alter?: string;
+  summary?: string;
+  defaultRoute: string;
+  accentColor?: string;
+  glyph?: string;
+  pinnedApps: Array<{
+    appId: string;
+    route: string;
+  }>;
+};
+
+type HomeRoomLauncherProps = {
+  rooms: HomeRoomOption[];
+};
+
+const STORAGE_KEY = 'pmoves.home.selectedRoom';
+
+function getLoginHref(roomId: string): string {
+  return `/login?room_id=${encodeURIComponent(roomId)}`;
+}
+
+export function HomeRoomLauncher({ rooms }: HomeRoomLauncherProps) {
+  const [selectedRoomId, setSelectedRoomId] = useState(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const storedRoomId = window.localStorage.getItem(STORAGE_KEY);
+        if (storedRoomId && rooms.some((room) => room.roomId === storedRoomId)) {
+          return storedRoomId;
+        }
+      } catch {
+        // Ignore storage failures and fall back to the first room.
+      }
+    }
+
+    return rooms[0]?.roomId ?? '';
+  });
+
+  const selectedRoom = useMemo(
+    () => rooms.find((room) => room.roomId === selectedRoomId) ?? rooms[0] ?? null,
+    [rooms, selectedRoomId]
+  );
+
+  useEffect(() => {
+    if (!selectedRoom) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, selectedRoom.roomId);
+    } catch {
+      // Ignore storage failures and keep the in-memory selection.
+    }
+  }, [selectedRoom]);
+
+  if (!selectedRoom) {
+    return (
+      <div className="mt-10 max-w-3xl border border-border-subtle bg-void-elevated/80 p-5">
+        <div className="font-pixel text-[8px] uppercase tracking-[0.2em] text-ink-muted">[ Room Launch ]</div>
+        <p className="mt-3 text-sm text-ink-secondary">
+          Room manifests are not available yet. Open the catalog once the room seeds are present.
+        </p>
+        <Link href="/dashboard/rooms" className="btn-ghost mt-4 inline-flex">
+          Open room catalog
+        </Link>
+      </div>
+    );
+  }
+
+  const accent = selectedRoom.accentColor ?? '#22C55E';
+
+  return (
+    <section className="mt-10 max-w-4xl border border-cata-cyan/20 bg-void-elevated/80 p-5 backdrop-blur-sm sm:p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="font-pixel text-[8px] uppercase tracking-[0.2em] text-cata-cyan">[ Room Launch ]</div>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-ink-secondary">
+            Choose the room shell you want to enter. The selected room is carried through login and resolves to its declared entry route.
+          </p>
+        </div>
+        <Link href="/dashboard/rooms" className="btn-ghost text-xs">
+          Room Catalog
+        </Link>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {rooms.map((room) => {
+          const active = room.roomId === selectedRoom.roomId;
+          const roomAccent = room.accentColor ?? '#22C55E';
+          return (
+            <button
+              key={room.roomId}
+              type="button"
+              aria-pressed={active}
+              onClick={() => setSelectedRoomId(room.roomId)}
+              className="border px-3 py-2 text-left font-mono text-xs uppercase tracking-wider transition-all"
+              style={{
+                borderColor: active ? roomAccent : 'rgba(148, 163, 184, 0.25)',
+                backgroundColor: active ? `${roomAccent}20` : 'rgba(15, 23, 42, 0.65)',
+                color: active ? roomAccent : 'rgb(203 213 225)',
+              }}
+            >
+              {room.displayName}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px]">
+        <div className="border border-border-subtle bg-void/80 p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="font-pixel text-[7px] uppercase tracking-[0.18em]" style={{ color: accent }}>
+                {selectedRoom.agentId}
+                {selectedRoom.alter ? ` / ${selectedRoom.alter}` : ''}
+              </div>
+              <h3 className="mt-2 font-display text-2xl font-bold text-ink-primary">{selectedRoom.displayName}</h3>
+            </div>
+            <div
+              className="flex h-11 w-11 items-center justify-center border text-lg font-display font-bold"
+              style={{ borderColor: accent, backgroundColor: `${accent}12`, color: accent }}
+              aria-hidden="true"
+            >
+              {selectedRoom.glyph ?? selectedRoom.displayName.charAt(0).toUpperCase()}
+            </div>
+          </div>
+
+          <p className="mt-3 text-sm leading-relaxed text-ink-secondary">
+            {selectedRoom.summary ?? 'Room manifest loaded from the PMOVES catalog.'}
+          </p>
+
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <div>
+              <div className="font-pixel text-[6px] uppercase tracking-[0.18em] text-ink-muted">Entry route</div>
+              <div className="mt-2 font-mono text-xs text-ink-primary">{selectedRoom.defaultRoute}</div>
+            </div>
+            <div>
+              <div className="font-pixel text-[6px] uppercase tracking-[0.18em] text-ink-muted">Pinned apps</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {selectedRoom.pinnedApps.length > 0 ? (
+                  selectedRoom.pinnedApps.map((app) => (
+                    <Link
+                      key={app.appId}
+                      href={app.route}
+                      className="border border-border-subtle bg-void-soft px-2 py-1 font-mono text-2xs uppercase tracking-wider text-ink-secondary transition-colors hover:border-ink-primary hover:text-ink-primary"
+                    >
+                      {app.appId}
+                    </Link>
+                  ))
+                ) : (
+                  <span className="font-mono text-2xs uppercase tracking-wider text-ink-muted">No pinned apps</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <Link
+            href={getLoginHref(selectedRoom.roomId)}
+            className="btn-primary text-center"
+            aria-label={`Launch ${selectedRoom.displayName}`}
+          >
+            Launch {selectedRoom.displayName}
+          </Link>
+          <Link href={selectedRoom.defaultRoute} className="btn-secondary text-center">
+            Preview Entry Route
+          </Link>
+          <div className="border border-border-subtle bg-void/70 p-3 text-xs text-ink-secondary">
+            Selection is stored locally on this browser so the same room stays primed on return visits.
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary

Adds room selection to the landing surface and carries the chosen oom_id through login so auth resolves to the room's declared entry route.

## What changed

- adds home room launcher component
  - pmoves/ui/components/home/HomeRoomLauncher.tsx
  - pmoves/ui/components/home/HomeRoomLauncher.test.tsx
- updates landing page to load room options from the room catalog and render the launcher
  - pmoves/ui/app/page.tsx
- updates login flow to accept oom_id, load the matching room manifest, and resolve 
extPath from the room default route when 
ext is not explicitly provided
  - pmoves/ui/app/(auth)/login/page.tsx
- updates landing page tests to cover the new launcher surface
  - pmoves/ui/__tests__/home-page.test.tsx

## Behavior

- landing page shows selectable seeded rooms
- selected room is persisted locally in browser storage
- Launch <Room> links to /login?room_id=<room>
- login page shows the selected room target
- if boot JWT is present, redirect goes directly to the resolved room route
- if 
ext is explicitly supplied, it still wins over the room default route

## Why

This turns rooms into actual entry surfaces instead of a passive catalog page. The launcher now uses the same room manifest contract that the dashboard/API already exposes.

## Verification

- 
px eslint app/page.tsx 'app/(auth)/login/page.tsx' components/home/HomeRoomLauncher.tsx components/home/HomeRoomLauncher.test.tsx __tests__/home-page.test.tsx
- 
px jest __tests__/home-page.test.tsx components/home/HomeRoomLauncher.test.tsx lib/__tests__/rooms.test.ts --runInBand
- 
px tsc --noEmit

## Depends on

- #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added room launcher to the home page displaying available rooms with descriptions and pinned apps
  * Users can select and launch rooms with persistent selection across sessions
  * Login page displays selected room information and configures navigation to room-specific entry routes

* **Tests**
  * Added test coverage for room launcher and home page functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->