### PR TITLE
feat(fleet): add RustDesk enrollment and audit watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
 # PMOVES.AI gitignore
 
 # =============================================================================
+# Infrastructure Secrets (relay keys, QR configs, audits — NEVER COMMIT)
+# =============================================================================
+rustdesk-*-qr.png
+**/rustdesk-*-qr.png
+pmoves/docs/security/FLEET_AUDIT_*.md
+pmoves/scripts/fleet/.enrollment-ledger.jsonl
+
+# =============================================================================
 # Environment & Secrets (NEVER COMMIT)
 # =============================================================================
 .env

--- a/pmoves/configs/tailscale-acl-policy.json
+++ b/pmoves/configs/tailscale-acl-policy.json
@@ -7,7 +7,9 @@
     "tag:gpu": ["autogroup:admin"],
     "tag:vps": ["autogroup:admin"],
     "tag:lab": ["autogroup:admin"],
-    "tag:exit": ["autogroup:admin"]
+    "tag:exit": ["autogroup:admin"],
+    "tag:unfcu": ["autogroup:admin"],
+    "tag:guest": ["autogroup:admin"]
   },
 
   "acls": [
@@ -22,6 +24,22 @@
       "src": ["tag:lab"],
       "dst": ["tag:gpu:*"],
       "comment": "Lab nodes can reach GPU nodes for inference"
+    },
+    {
+      "action": "accept",
+      "src": ["tag:unfcu"],
+      "dst": [
+        "tag:gpu:3030",
+        "tag:gpu:8080",
+        "tag:gpu:8081"
+      ],
+      "comment": "UNFCU partner: Agent Zero API + UI, TensorZero Gateway only"
+    },
+    {
+      "action": "accept",
+      "src": ["tag:guest"],
+      "dst": ["tag:gpu:8081"],
+      "comment": "Guest demo: Agent Zero UI only"
     },
     {
       "action": "accept",

--- a/pmoves/docs/operations/RUSTDESK_SELF_HOSTED.md
+++ b/pmoves/docs/operations/RUSTDESK_SELF_HOSTED.md
@@ -1,0 +1,224 @@
+# RustDesk Self-Hosted Relay — KVM2
+
+> Remote desktop access for the PMOVES fleet via self-hosted RustDesk server.
+>
+> Last updated: 2026-03-27
+
+---
+
+## Server Architecture
+
+**Host:** KVM2 (<KVM2_IP>) — Hostinger VPS, 4C/8GB, Ubuntu
+**Transport:** Bare-metal systemd services (not Docker)
+
+| Service | Unit | Port(s) | Purpose |
+|---------|------|---------|---------|
+| hbbs | `hbbs.service` | 21115, 21116, 21118 | Rendezvous (ID registration + NAT traversal + WebSocket) |
+| hbbr | `hbbr.service` | 21117, 21119 | Relay (encrypted traffic forwarding + QUIC) |
+
+**Key:** `<RUSTDESK_KEY>`
+
+### hbbs Configuration
+
+The hbbs service MUST include the `-r` relay flag pointing to the server's own public IP:
+
+```
+ExecStart=/opt/rustdesk-server/hbbs -r <KVM2_IP>
+```
+
+Without `-r`, clients behind NAT will fail to relay through the server.
+
+### Firewall (UFW)
+
+```
+22/tcp    SSH (key-only)
+21115/tcp hbbs
+21116/tcp hbbs
+21117/tcp hbbr
+21118/tcp hbbs (WebSocket)
+21119/tcp hbbr (QUIC)
+```
+
+All other ports are denied by default.
+
+---
+
+## Fleet Registration Status
+
+| Node | Config Method | Registered | Verified |
+|------|--------------|------------|----------|
+| Z890 | RustDesk GUI | Yes | Bidirectional with 5090+4090 |
+| 5090 | RustDesk GUI | Yes | Bidirectional |
+| 4090 Laptop | RustDesk GUI | Yes | Bidirectional |
+| Jetson #1 | `restart-jetson-rustdesk.sh` | Yes | Via relay (stabilizing) |
+| Jetson #2 | `restart-jetson-rustdesk.sh` | Yes | Via relay (stabilizing) |
+| Phone (Pixel) | QR code pending | No | — |
+| Tablet (S8 Ultra) | QR code pending | No | — |
+
+---
+
+## Client Configuration
+
+### Windows / macOS / Linux Desktop
+
+1. Open RustDesk → Settings → Network
+2. Set **ID Server:** `<KVM2_IP>`
+3. Set **Key:** `<RUSTDESK_KEY>`
+4. Leave Relay Server blank (server auto-relays via `-r` flag)
+
+### Jetson (Linux, systemd service)
+
+RustDesk runs as a systemd service under root on Jetsons. Config must be written to BOTH:
+- `/root/.config/rustdesk/RustDesk2.toml` (root service reads this)
+- `/home/pmovesnvme/.config/rustdesk/RustDesk2.toml` (user session)
+
+Use `restart-jetson-rustdesk.sh` to deploy config to both paths:
+
+```bash
+bash pmoves/scripts/claws/restart-jetson-rustdesk.sh
+```
+
+This script:
+1. Writes `RustDesk2.toml` with KVM2 as rendezvous + relay server
+2. Copies to both root and user config paths
+3. Injects the `pmoves-claw` SSH key into root's authorized_keys
+4. Restarts the RustDesk service
+5. Verifies KVM2 registration via `update_pk` in server logs
+
+### Android / iOS (Mobile)
+
+1. Open RustDesk app → Settings (gear icon) → ID/Relay Server
+2. Tap **Import Server Config** (QR icon)
+3. Scan the QR code (generated locally, NOT committed to repo — gitignored)
+
+To regenerate the QR locally:
+```bash
+python -c "
+import qrcode, json
+config = json.dumps({'host':'<KVM2_IP>','key':'<RUSTDESK_KEY>','api':'','relay':'<KVM2_IP>'}, separators=(',',':'))
+qrcode.make(config).save('pmoves/docs/operations/rustdesk-kvm2-qr.png')
+"
+```
+
+**Manual fallback** (if QR not available):
+- Open RustDesk → Settings → ID/Relay Server
+- Set **ID Server**, **Relay Server**, and **Key** from the values in KVM2 server config
+
+---
+
+## Scripts
+
+| Script | Location | Purpose |
+|--------|----------|---------|
+| `fix-kvm2-rustdesk-relay.sh` | `pmoves/scripts/claws/` | Add `-r` relay flag to KVM2 hbbs and restart |
+| `restart-jetson-rustdesk.sh` | `pmoves/scripts/claws/` | Full Jetson config deploy (root+user, SSH key, verify) |
+| `generate-enrollment.py` | `pmoves/scripts/fleet/` | Time-limited, role-based enrollment QR + token generation |
+| `fleet-audit-watcher.sh` | `pmoves/scripts/fleet/` | KVM2 journal watcher → NATS event publisher |
+| `fleet-audit-watcher.service` | `pmoves/scripts/fleet/` | systemd unit file for the watcher |
+
+Claws scripts SSH via key at `$LOCALAPPDATA/Temp/hostinger_vps`.
+
+---
+
+## Enrollment System
+
+### Generating Enrollment Tokens
+
+```bash
+# Owner device (full access, 5-minute window)
+RUSTDESK_RELAY_HOST=<KVM2_IP> RUSTDESK_PUBLIC_KEY=<KEY> CHIT_PASSPHRASE=<secret> \
+  python pmoves/scripts/fleet/generate-enrollment.py generate --role owner --ttl 5m --device "Pixel 10"
+
+# UNFCU partner (limited access, 24-hour window)
+... generate --role unfcu --ttl 24h --device "UNFCU-Laptop-1"
+
+# Guest demo (Agent Zero UI only, 1-hour window)
+... generate --role guest --ttl 1h
+```
+
+### Roles
+
+| Role | Tailscale Tag | Allowed Nodes | Allowed Ports |
+|------|--------------|--------------|--------------|
+| `owner` | `tag:pmoves` | All | All |
+| `unfcu` | `tag:unfcu` | 5090, Z890 | 3030, 8080, 8081 |
+| `guest` | `tag:guest` | Z890 | 8081 |
+
+### Security Layers
+
+```
+Layer 1: Tailscale ACL (network) — tag-based port access control
+Layer 2: RustDesk key (transport) — only fleet members connect
+Layer 3: Per-client password (session) — device-to-device auth
+Layer 4: Audit trail (NATS) — all events logged
+```
+
+- Enrollment tokens are CHIT-signed (HMAC-SHA256) with TTL expiry
+- Expired tokens fail validation even if HMAC is correct (fail-closed)
+- Tokens are logged to local ledger (`fleet/.enrollment-ledger.jsonl`, gitignored)
+
+### Verifying Tokens
+
+```bash
+CHIT_PASSPHRASE=<secret> python pmoves/scripts/fleet/generate-enrollment.py verify '<token-json>'
+```
+
+### NATS Subjects
+
+| Subject | Publisher | Purpose |
+|---------|-----------|---------|
+| `fleet.device.registered.v1` | fleet-audit-watcher | New RustDesk client registered |
+| `fleet.device.approved.v1` | admin | Device approved |
+| `fleet.device.blocked.v1` | admin | Device blocked |
+| `fleet.enrollment.created.v1` | generate-enrollment.py | Token generated |
+| `fleet.audit.connection.v1` | fleet-audit-watcher | Connection/disconnection events |
+| `fleet.audit.heartbeat.v1` | fleet-audit-watcher | Watcher liveness (every 5m) |
+
+### Installing the Audit Watcher on KVM2
+
+```bash
+scp pmoves/scripts/fleet/fleet-audit-watcher.sh root@<KVM2_IP>:/opt/pmoves/
+scp pmoves/scripts/fleet/fleet-audit-watcher.service root@<KVM2_IP>:/etc/systemd/system/
+ssh root@<KVM2_IP> "chmod +x /opt/pmoves/fleet-audit-watcher.sh && \
+  systemctl daemon-reload && systemctl enable --now fleet-audit-watcher"
+```
+
+Requires: `nats` CLI installed on KVM2 for NATS publishing.
+
+---
+
+## Troubleshooting
+
+### Connection drops / intermittent
+
+1. Verify relay flag is set: `ssh root@<KVM2_IP> "grep ExecStart /etc/systemd/system/hbbs.service"`
+   - Must show `-r <KVM2_IP>`
+2. Check server logs: `ssh root@<KVM2_IP> "journalctl -u hbbs -n 20 --no-pager"`
+3. On Jetson: verify root config has correct server: `sudo cat /root/.config/rustdesk/RustDesk2.toml`
+
+### Client not registering
+
+1. Check `update_pk` entries in hbbs logs (indicates client registration)
+2. Verify UFW allows ports 21115-21119
+3. Ensure client key matches server key exactly
+
+### Relay vs Direct
+
+- **Direct:** Both peers on same LAN with no NAT → fastest, no relay
+- **Relay:** At least one peer behind NAT → routed through KVM2 hbbr
+- Relay mode is expected for Jetsons and mobile devices
+
+---
+
+## Architecture Decision
+
+**Why self-hosted?**
+- Full control over relay infrastructure
+- No dependency on public RustDesk servers
+- Key pinning prevents unauthorized connections
+- Consistent with PMOVES principle: self-host everything, trust nothing external
+
+**Why bare-metal (not Docker)?**
+- KVM2 is a lightweight exit node — Docker overhead not justified
+- systemd services are simpler to manage on a VPS
+- Direct network access without Docker bridge complexity

--- a/pmoves/scripts/fleet/fleet-audit-watcher.service
+++ b/pmoves/scripts/fleet/fleet-audit-watcher.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=PMOVES Fleet Audit Watcher
+Documentation=https://github.com/POWERFULMOVES/PMOVES.AI
+After=network.target hbbs.service hbbr.service
+Wants=hbbs.service hbbr.service
+
+[Service]
+Type=simple
+ExecStart=/opt/pmoves/fleet-audit-watcher.sh
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=fleet-audit-watcher
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/var/log/pmoves
+
+# Environment
+Environment=NATS_URL=nats://nats:pmoves@nats:4222
+
+[Install]
+WantedBy=multi-user.target

--- a/pmoves/scripts/fleet/fleet-audit-watcher.sh
+++ b/pmoves/scripts/fleet/fleet-audit-watcher.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# =============================================================================
+# PMOVES Fleet Audit Watcher
+#
+# Runs on KVM2 as a systemd service. Tails hbbs/hbbr journals for connection
+# events and publishes them to NATS for fleet-wide observability.
+#
+# Install:
+#   scp fleet-audit-watcher.sh root@<KVM2>:/opt/pmoves/
+#   scp fleet-audit-watcher.service root@<KVM2>:/etc/systemd/system/
+#   ssh root@<KVM2> "systemctl daemon-reload && systemctl enable --now fleet-audit-watcher"
+#
+# NATS subjects published:
+#   fleet.device.registered.v1   — new client registered (update_pk)
+#   fleet.audit.connection.v1    — relay connection event
+#   fleet.audit.heartbeat.v1     — watcher alive (every 5 minutes)
+#
+# Dependencies: nats CLI (https://github.com/nats-io/natscli)
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+NATS_URL="${NATS_URL:-nats://nats:pmoves@nats:4222}"
+LOG_DIR="/var/log/pmoves"
+LOG_FILE="${LOG_DIR}/fleet-audit.jsonl"
+HEARTBEAT_INTERVAL=300  # 5 minutes
+
+mkdir -p "${LOG_DIR}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ts() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+publish() {
+    local subject="$1"
+    local payload="$2"
+
+    # Append to local log
+    echo "${payload}" >> "${LOG_FILE}"
+
+    # Publish to NATS (fire-and-forget, don't block on failure)
+    if command -v nats &>/dev/null; then
+        echo "${payload}" | nats pub "${subject}" --server "${NATS_URL}" 2>/dev/null || true
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Heartbeat (background)
+# ---------------------------------------------------------------------------
+
+heartbeat_loop() {
+    while true; do
+        local payload
+        payload=$(cat <<EOF
+{"event":"heartbeat","ts":"$(ts)","service":"fleet-audit-watcher","node":"kvm2"}
+EOF
+        )
+        publish "fleet.audit.heartbeat.v1" "${payload}"
+        sleep "${HEARTBEAT_INTERVAL}"
+    done
+}
+
+heartbeat_loop &
+HEARTBEAT_PID=$!
+trap "kill ${HEARTBEAT_PID} 2>/dev/null" EXIT
+
+# ---------------------------------------------------------------------------
+# Watch hbbs journal for registration + connection events
+# ---------------------------------------------------------------------------
+
+echo "[$(ts)] Fleet audit watcher started on KVM2"
+echo "[$(ts)] NATS: ${NATS_URL}"
+echo "[$(ts)] Log: ${LOG_FILE}"
+
+journalctl -u hbbs -u hbbr -f --no-pager --output=short-iso 2>/dev/null | while IFS= read -r line; do
+
+    # New client registration (update_pk)
+    if echo "${line}" | grep -q "update_pk"; then
+        # Extract client ID from log line (format varies, best-effort)
+        client_id=$(echo "${line}" | grep -oP 'update_pk \K[^ ]+' || echo "unknown")
+        payload=$(cat <<EOF
+{"event":"device.registered","ts":"$(ts)","client_id":"${client_id}","raw":"${line}"}
+EOF
+        )
+        echo "[$(ts)] NEW REGISTRATION: ${client_id}"
+        publish "fleet.device.registered.v1" "${payload}"
+    fi
+
+    # Relay connection events
+    if echo "${line}" | grep -qE "(relay connection|new relay)"; then
+        payload=$(cat <<EOF
+{"event":"relay.connection","ts":"$(ts)","raw":"${line}"}
+EOF
+        )
+        publish "fleet.audit.connection.v1" "${payload}"
+    fi
+
+    # Connection closed / disconnected
+    if echo "${line}" | grep -qiE "(closed|disconnect|timeout)"; then
+        payload=$(cat <<EOF
+{"event":"connection.closed","ts":"$(ts)","raw":"${line}"}
+EOF
+        )
+        publish "fleet.audit.connection.v1" "${payload}"
+    fi
+
+done

--- a/pmoves/scripts/fleet/generate-enrollment.py
+++ b/pmoves/scripts/fleet/generate-enrollment.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+PMOVES Fleet Enrollment Generator
+
+Generates time-limited, role-based enrollment payloads for RustDesk + Tailscale.
+Enrollment tokens are CHIT-signed (HMAC-SHA256) and expire after TTL.
+
+Usage:
+    python generate-enrollment.py --role owner --ttl 5m --device "Pixel 10"
+    python generate-enrollment.py --role unfcu --ttl 24h --device "UNFCU-Laptop-1"
+    python generate-enrollment.py --role guest --ttl 1h
+    python generate-enrollment.py --verify <token-json-file>
+    python generate-enrollment.py --list  # show all unexpired tokens
+
+Outputs:
+    - QR code PNG (stdout path)
+    - Enrollment JSON (stdout)
+    - CLI paste command for manual config
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+ROLES = {
+    "owner": {
+        "description": "Full fleet access — all nodes, all ports",
+        "tailscale_tags": ["tag:pmoves"],
+        "allowed_nodes": "*",
+    },
+    "unfcu": {
+        "description": "UNFCU partner access — GPU nodes, agent + inference ports only",
+        "tailscale_tags": ["tag:unfcu"],
+        "allowed_nodes": ["pmoves-5090", "pmoves-z890"],
+        "allowed_ports": [3030, 8080, 8081],
+    },
+    "guest": {
+        "description": "Guest demo access — single demo node only",
+        "tailscale_tags": ["tag:guest"],
+        "allowed_nodes": ["pmoves-z890"],
+        "allowed_ports": [8081],
+    },
+}
+
+TTL_MAP = {
+    "5m": 5 * 60,
+    "15m": 15 * 60,
+    "1h": 3600,
+    "4h": 4 * 3600,
+    "24h": 24 * 3600,
+}
+
+# RustDesk server config (placeholders — real values injected at runtime)
+RUSTDESK_HOST_ENV = "RUSTDESK_RELAY_HOST"
+RUSTDESK_KEY_ENV = "RUSTDESK_PUBLIC_KEY"
+
+# CHIT signing
+CHIT_PASSPHRASE_ENV = "CHIT_PASSPHRASE"
+
+# Output directory for QR codes (gitignored)
+QR_OUTPUT_DIR = Path(__file__).parent.parent.parent / "docs" / "operations"
+
+# Token ledger (gitignored, local only)
+LEDGER_PATH = Path(__file__).parent / ".enrollment-ledger.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# HMAC signing (inline, no dependency on pmoves.chit at script level)
+# ---------------------------------------------------------------------------
+
+def _canon(obj: dict[str, Any]) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sign_enrollment(payload: dict[str, Any], passphrase: str) -> dict[str, Any]:
+    """Sign an enrollment payload with HMAC-SHA256."""
+    doc = json.loads(json.dumps(payload))
+    kid = hashlib.sha256(passphrase.encode()).hexdigest()[:16]
+    doc_nosig = json.loads(json.dumps(doc))
+    doc_nosig.pop("sig", None)
+    mac = hmac.new(
+        passphrase.encode("utf-8"), _canon(doc_nosig), hashlib.sha256
+    ).digest()
+    doc["sig"] = {
+        "alg": "HMAC-SHA256",
+        "kid": kid,
+        "hmac": base64.b64encode(mac).decode("ascii"),
+    }
+    return doc
+
+
+def verify_enrollment(payload: dict[str, Any], passphrase: str) -> tuple[bool, str]:
+    """Verify enrollment token signature and TTL. Returns (valid, reason)."""
+    if "sig" not in payload:
+        return False, "missing signature"
+
+    # Check expiry first (fail-closed)
+    expires_at = payload.get("expires_at", 0)
+    if time.time() > expires_at:
+        return False, f"expired at {datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat()}"
+
+    sig = payload["sig"]
+    mac_b64 = sig.get("hmac", "")
+    doc_nosig = json.loads(json.dumps(payload))
+    doc_nosig.pop("sig", None)
+    mac2 = hmac.new(
+        passphrase.encode("utf-8"), _canon(doc_nosig), hashlib.sha256
+    ).digest()
+    try:
+        mac1 = base64.b64decode(mac_b64)
+    except Exception:
+        return False, "invalid HMAC encoding"
+
+    if not hmac.compare_digest(mac1, mac2):
+        return False, "HMAC mismatch — token tampered or wrong passphrase"
+
+    return True, "valid"
+
+
+# ---------------------------------------------------------------------------
+# QR Generation
+# ---------------------------------------------------------------------------
+
+def generate_qr(data: str, output_path: Path) -> Path:
+    """Generate a QR code PNG. Requires `qrcode` and `pillow`."""
+    try:
+        import qrcode
+    except ImportError:
+        print("ERROR: qrcode package not installed. Run: uv pip install qrcode pillow", file=sys.stderr)
+        sys.exit(1)
+
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=10,
+        border=4,
+    )
+    qr.add_data(data)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    img.save(str(output_path))
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# Ledger (local audit trail for generated tokens)
+# ---------------------------------------------------------------------------
+
+def append_ledger(entry: dict[str, Any]) -> None:
+    """Append enrollment event to local ledger (gitignored)."""
+    with open(LEDGER_PATH, "a") as f:
+        f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+
+def list_active_tokens() -> list[dict[str, Any]]:
+    """List all unexpired enrollment tokens from ledger."""
+    if not LEDGER_PATH.exists():
+        return []
+    now = time.time()
+    active = []
+    for line in LEDGER_PATH.read_text().splitlines():
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        if entry.get("expires_at", 0) > now:
+            active.append(entry)
+    return active
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def generate(args: argparse.Namespace) -> None:
+    role = args.role
+    if role not in ROLES:
+        print(f"ERROR: Unknown role '{role}'. Choose from: {', '.join(ROLES)}", file=sys.stderr)
+        sys.exit(1)
+
+    ttl_seconds = TTL_MAP.get(args.ttl)
+    if ttl_seconds is None:
+        print(f"ERROR: Unknown TTL '{args.ttl}'. Choose from: {', '.join(TTL_MAP)}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load secrets from environment
+    rustdesk_host = os.environ.get(RUSTDESK_HOST_ENV)
+    rustdesk_key = os.environ.get(RUSTDESK_KEY_ENV)
+    passphrase = os.environ.get(CHIT_PASSPHRASE_ENV)
+
+    if not rustdesk_host or not rustdesk_key:
+        print(
+            f"ERROR: Set {RUSTDESK_HOST_ENV} and {RUSTDESK_KEY_ENV} environment variables.\n"
+            f"These contain the RustDesk server IP and public key.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    role_config = ROLES[role]
+    now = time.time()
+    expires_at = now + ttl_seconds
+
+    # Build enrollment payload
+    enrollment = {
+        "version": "fleet.enrollment.v1",
+        "token_id": secrets.token_urlsafe(16),
+        "role": role,
+        "device_name": args.device or f"enrollment-{role}-{int(now)}",
+        "issued_at": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
+        "expires_at": expires_at,
+        "ttl_seconds": ttl_seconds,
+        "issuer": "z890-claude",
+        "rustdesk": {
+            "host": rustdesk_host,
+            "key": rustdesk_key,
+            "api": "",
+            "relay": rustdesk_host,
+        },
+        "access": {
+            "tailscale_tags": role_config["tailscale_tags"],
+            "allowed_nodes": role_config["allowed_nodes"],
+            "allowed_ports": role_config.get("allowed_ports", "*"),
+        },
+    }
+
+    # Sign with CHIT HMAC if passphrase available
+    if passphrase:
+        enrollment = sign_enrollment(enrollment, passphrase)
+        print(f"Token signed with CHIT HMAC (kid: {enrollment['sig']['kid']})", file=sys.stderr)
+    else:
+        print("WARNING: CHIT_PASSPHRASE not set — token issued UNSIGNED.", file=sys.stderr)
+        print("Set CHIT_PASSPHRASE for production enrollment.", file=sys.stderr)
+
+    # Generate RustDesk-only QR (for mobile app import)
+    rustdesk_qr_data = json.dumps(enrollment["rustdesk"], separators=(",", ":"))
+
+    # Generate QR code
+    device_slug = (args.device or role).lower().replace(" ", "-")
+    qr_filename = f"rustdesk-{device_slug}-qr.png"
+    qr_path = QR_OUTPUT_DIR / qr_filename
+    generate_qr(rustdesk_qr_data, qr_path)
+
+    # Log to ledger
+    ledger_entry = {
+        "token_id": enrollment["token_id"],
+        "role": role,
+        "device_name": enrollment["device_name"],
+        "issued_at": enrollment["issued_at"],
+        "expires_at": expires_at,
+        "signed": "sig" in enrollment,
+    }
+    append_ledger(ledger_entry)
+
+    # Output
+    expires_str = datetime.fromtimestamp(expires_at, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    print(f"\n{'=' * 60}")
+    print(f"  PMOVES Fleet Enrollment — {role.upper()}")
+    print(f"{'=' * 60}")
+    print(f"  Role:        {role} — {role_config['description']}")
+    print(f"  Device:      {enrollment['device_name']}")
+    print(f"  Token ID:    {enrollment['token_id']}")
+    print(f"  Expires:     {expires_str} ({args.ttl})")
+    print(f"  Signed:      {'YES (CHIT HMAC)' if 'sig' in enrollment else 'NO (unsigned)'}")
+    print(f"  QR Code:     {qr_path}")
+    print(f"{'=' * 60}")
+    print(f"\n  RustDesk manual config:")
+    print(f"    ID Server:    {rustdesk_host}")
+    print(f"    Relay Server: {rustdesk_host}")
+    print(f"    Key:          {rustdesk_key}")
+    print(f"\n  RustDesk paste (for mobile Settings > Import):")
+    print(f"    {rustdesk_qr_data}")
+    if role_config["tailscale_tags"]:
+        print(f"\n  Tailscale tags to assign: {', '.join(role_config['tailscale_tags'])}")
+    if role_config.get("allowed_ports") and role_config["allowed_ports"] != "*":
+        print(f"  Allowed ports: {role_config['allowed_ports']}")
+    print(f"\n  Full enrollment token (save for verification):")
+    print(f"  {json.dumps(enrollment, separators=(',', ':'))}")
+    print()
+
+
+def verify(args: argparse.Namespace) -> None:
+    passphrase = os.environ.get(CHIT_PASSPHRASE_ENV)
+    if not passphrase:
+        print("ERROR: Set CHIT_PASSPHRASE to verify tokens.", file=sys.stderr)
+        sys.exit(1)
+
+    token_path = Path(args.verify)
+    if token_path.exists():
+        payload = json.loads(token_path.read_text())
+    else:
+        # Try parsing as inline JSON
+        try:
+            payload = json.loads(args.verify)
+        except json.JSONDecodeError:
+            print(f"ERROR: Cannot parse '{args.verify}' as JSON file or inline JSON.", file=sys.stderr)
+            sys.exit(1)
+
+    valid, reason = verify_enrollment(payload, passphrase)
+    if valid:
+        print(f"VALID — role={payload['role']}, device={payload.get('device_name', '?')}, "
+              f"expires={datetime.fromtimestamp(payload['expires_at'], tz=timezone.utc).isoformat()}")
+    else:
+        print(f"INVALID — {reason}")
+        sys.exit(1)
+
+
+def list_tokens(_args: argparse.Namespace) -> None:
+    active = list_active_tokens()
+    if not active:
+        print("No active enrollment tokens.")
+        return
+    print(f"{'Token ID':<24s} {'Role':<8s} {'Device':<20s} {'Expires':<24s} {'Signed'}")
+    print("-" * 90)
+    for t in active:
+        exp = datetime.fromtimestamp(t["expires_at"], tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+        print(f"{t['token_id']:<24s} {t['role']:<8s} {t['device_name']:<20s} {exp:<24s} {'YES' if t['signed'] else 'NO'}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="PMOVES Fleet Enrollment Generator",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # generate
+    gen = sub.add_parser("generate", aliases=["gen"], help="Generate enrollment token + QR")
+    gen.add_argument("--role", required=True, choices=ROLES.keys(), help="Access role")
+    gen.add_argument("--ttl", default="5m", choices=TTL_MAP.keys(), help="Token TTL (default: 5m)")
+    gen.add_argument("--device", help="Device display name")
+
+    # verify
+    ver = sub.add_parser("verify", help="Verify an enrollment token")
+    ver.add_argument("token", metavar="TOKEN", help="Token JSON file or inline JSON string")
+
+    # list
+    sub.add_parser("list", help="List active (unexpired) enrollment tokens")
+
+    args = parser.parse_args()
+
+    if args.command in ("generate", "gen"):
+        generate(args)
+    elif args.command == "verify":
+        args.verify = args.token
+        verify(args)
+    elif args.command == "list":
+        list_tokens(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CHIT-signed RustDesk enrollment token generation for owner, unfcu, and guest roles
- add the KVM2 fleet audit watcher and systemd unit for hbbs/hbbr -> NATS observability
- document the enrollment flow, role matrix, watcher install path, and Tailscale ACL enforcement

## Validation
- `python pmoves/scripts/fleet/generate-enrollment.py --help`
- `python pmoves/scripts/fleet/generate-enrollment.py list`
- `bash -n pmoves/scripts/fleet/fleet-audit-watcher.sh` (returned 0; emitted a local WSL mount warning in this Windows environment)

## Notes
- remote/admin follow-through still required: install the watcher on KVM2, install the `nats` CLI there, clean stale Tailscale nodes, and tighten VPS `PermitRootLogin` on the three Hostinger nodes
- split from the conflicting z890 lane so the enrollment work can move independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-hosted RustDesk relay deployment and operations guide with client configuration steps for desktop and mobile platforms.
  * Implemented fleet enrollment and auditing system with time-limited role-based enrollment tokens and Tailscale tag mapping.
  * Extended network access control policies to support guest and unfcu tags with port-based routing.

* **Documentation**
  * Added comprehensive operational guide covering self-hosted setup, client configuration, Jetson deployment, and troubleshooting.

* **Chores**
  * Updated configuration ignore rules and network policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->