### PR TITLE
docs(agnote): capture workflow cadence and #1135 status

### DIFF
--- a/pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md
+++ b/pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md
@@ -33,6 +33,15 @@ Single coordination note to prevent agent collision while PMOVES.AI converges CI
 3. Handoff: agent publishes CHIT payload reference and signs ACK block.
 4. Release: agent writes `RELEASE` entry and clears claim.
 
+### Default Operating Flow
+Use this as the default cadence unless a lane needs a deliberate exception:
+1. Claim the lane here with branch/PR scope.
+2. Refresh `ROADMAP.md`, `NEXT_STEPS.md`, and any affected AGNOTE docs before changing status.
+3. Execute the smallest isolated fix/documentation slice and validate locally.
+4. If CI fails, compare the failure against `main` before calling it branch-specific.
+5. Update PR comments plus the AGNOTE board/P7 notes with the current blocker state.
+6. Release the lane here and add a signed ACK block; adapt ordering as needed, but keep the same audit trail.
+
 ## CHIT Encrypt Instructions (Handoff Safe Mode)
 Use CHIT export with no cleartext, then reference artifact paths in handoff notes.
 
@@ -85,8 +94,6 @@ Required handoff fields:
 - `2026-03-25T14:00:00Z` CLAIM `Z890-CLAUDE` scope: Hostinger VPS fleet activation — KVM4-1 full stack (SSH key via Hostinger REST API, Tailscale mesh, Claude Code v2.1.83, Ollama 0.18.2, gh 2.73.0, wrangler 4.77.0, claw config with 8-binary exec-approvals). SSH keys injected into all 3 VMs (KVM4-1, KVM4-2, KVM2) via API password reset + paramiko. 5090+4090 agentic scope configs created (PRs #1097, #1098). nvidia-5090.mk populated. Fly.io instance decommissioned (offline, rx 0). Memory updated.
 - `2026-03-26T04:00:00Z` CLAIM `Z890-CLAUDE` scope: Full fleet networking session. SSH key injection for 5090 (LAN .65, RTX 5090 32GB), 4090 laptop (LAN .234, RTX 4090 16GB), both Jetsons (.110 pmovesnvme-desktop, .144 pmoves-nano-2) via RustDesk terminal. SSH hardening across all 7 remote nodes (password auth disabled, MaxAuthTries 3). 5090 claw config deployed (SCP). RustDesk self-hosted server stood up on Z890 (hbbs+hbbr, key generated). Tailscale mesh expanded: KVM4-2 (100.124.50.76) + KVM2 (100.74.146.76) joined. 5090 renamed to pmoves-5090. 10 PRs merged/queued (#1097, #1098, #1113, #1115-#1119, #1121-#1124). LAN fully mapped (.234=4090 laptop identified). Bootstrap scripts created (enable-ssh-windows.ps1, enable-ssh-wsl.sh, setup-glances.sh, bootstrap-node.sh). Core vision + networking feedback committed to memory.
 - `2026-03-26T20:00:00Z` RELEASE `Z890-CLAUDE` scope: 8/8 nodes SSH hardened (key-only). 11 Tailscale nodes online (added KVM4-2+KVM2, cross-mesh 9ms verified). Claw configs deployed on KVM4-1+5090. RustDesk server built (clients on public pending migration). 10 PRs merged. Handoff: 5090-claude merging #1114 cascade (#1126); 4090/Jetson hostname renames via admin console; RustDesk client migration after SSH hardening confirmed.
-- `2026-03-27T04:00:00Z` CLAIM `Z890-CLAUDE` scope: Post-fleet infra session — PR merge cascade (6 open: #1116, #1120, #1121, #1122, #1123, #1128), container rebuilds (botz-gateway, pmoves-yt, agent layer), agent validation (healthz probes, NATS bus), Qdrant collection provisioning (pmoves_chunks_qwen3), W6-P1 Health/Wealth NATS wiring (stretch).
-- `2026-03-27T05:00:00Z` RELEASE `Z890-CLAUDE` scope: 20/23 containers healthy (from 2 at session start). 6 PRs already merged by 5090-claude (board clean). BoTZ Dockerfile fixed (uv migration, removed circular -r requirements.lock). z890_host_setup.ps1 updated (removed PR #1122-conflicting local portproxy rules, kept mesh-only 7422→5090). Qdrant pmoves_chunks_qwen3: 700 points, 2560d, green. TensorZero + ClickHouse online. Hi-RAG v2 CPU+GPU healthy. Tokenism Simulator healthy. 3 blockers documented: (1) Agent Zero port 8080 conflict with httpd.exe, (2) Archon missing vendor sources in Dockerfile build context, (3) DeepResearch missing pmoves module. Handoff: 5090-claude owns embedding alignment (query returns 0 hits despite 700 points); z890 next session owns Archon+DeepResearch Dockerfile fixes and Agent Zero port remap.
 
 - `2026-03-22T22:00:00Z` CLAIM `Z890-CLAUDE` scope: P7 playground gate clearance + network topology review + CodeRabbit sweep. python3 hook fix (hookify plugin). P7 requirements validated (pterm 0.0.24, ffmpeg 7.0.2). TOPOLOGY.md IP sanitization (zero real IPs in public doc). PRs #1063-#1064 created+merged. PR #1069 conflict resolution+merge. PR #1070 CodeRabbit sweep (12 findings, 2 critical). Jetson/3D printer topology documented. 7 memory files updated.
 - `2026-03-23T04:00:00Z` RELEASE `Z890-CLAUDE` scope: PRs #1063 (P7 docs), #1064 (28 gitlinks), #1068 (topology sanitize), #1069 (Flute Gradio 4.x merge), #1070 (12 CR findings) — all merged. PR #1071 (TTS service runners + prosodic endpoint) open with CR fixes applied. 4090-claude pr-trimmed #1070 (3 follow-up commits). Announcer persona + service runners config. Prosodic ear spec created. NATS subjects documented (voice.ear.*). Container rebuilds + Jetson onboarding deferred to next session.
@@ -104,6 +111,9 @@ Required handoff fields:
 - `2026-03-26T16:54:43-04:00` CLAIM `CODEX-GPT5` scope: AGNOTE4482 board sync + remote PR wave coordination (#1114-#1124), with focus on Codex packaging lanes, creator-control follow-through, and current 5090/z890 review order.
 - `2026-03-26T16:54:43-04:00` REVIEW `CODEX-GPT5` scope: Remote queue reopened with 14 main-repo PRs. Current Codex lanes are isolated and open: #1115 (Pinokio fleet docs), #1116 (TTS MCP bridge), #1117 (creator publishing follow-up docs), #1118 (PMOVES.YT pointer), #1119 (search ingest command), #1120 (studio-board approval UX), and #1121 (PMOVES Codex plugin + Agent Zero launcher). Supabase bootstrap hardening remains isolated in DIRTY PR #1114 and should land before more bootstrap/env churn. Live Pinokio validation on the PMOVES launcher confirmed the repo-root path bug is fixed; remaining bring-up risk is env/runtime readiness, not launcher path resolution.
 - `2026-03-26T16:54:43-04:00` RELEASE `CODEX-GPT5` scope: AGNOTE4482 board refreshed for remote review. Handoff ready for parallel agent review of the open PR wave and targeted follow-up on #1114, #1120, and #1121.
+- `2026-03-27T14:36:36.2476813-04:00` CLAIM `CODEX-GPT5` scope: PR #1135 merge-prep closure + AGNOTE4482/P7 status refresh + signed workflow capture for the current Codex lane.
+- `2026-03-27T14:36:36.2476813-04:00` REVIEW `CODEX-GPT5` scope: Addressed the remaining #1135 review items across publish-state mapper/tests, restored Jest API-client discovery, reran local validation (`typecheck`, `lint`, full Jest, API-client Jest), and compared the failing Playwright job on #1135 (`23657900926` / `68920111634`) against `main` (`23626056819` / `68819753984`). Result: the fast checks are green, and Playwright fails with the same repo-wide 119-failure `services-health` / `videos-realtime` signature, including missing `SUPABASE_REST_URL` and `SUPABASE_SERVICE_ROLE_KEY`.
+- `2026-03-27T14:36:36.2476813-04:00` RELEASE `CODEX-GPT5` scope: AGNOTE4482 roadmap, P7 playground, and PR notes refreshed. #1135 is mergeable but blocked by a shared Playwright branch-protection failure already reproducing on `main`; #1138 remains conflicting and still needs rebase/splitting plus TAC/compose/Flute follow-through before another serious review pass.
 - `2026-03-26T18:10:00-04:00` CLAIM `5090-CLAUDE` scope: PR #1114 resolution — analyzed branch, found all 19 files already on main via #1100/#1105/#1106/#1107 (rebase would produce 3 empty commits). Closed #1114, created #1126 with the 2 P1 review fixes: IF EXISTS guard on bare UPDATE + idempotent claim predicate separating TOCTOU race from no-op success. Board refs updated #1114→#1126.
 
 ## Graphiti Review Log
@@ -273,6 +283,12 @@ Required handoff fields:
 - Ack: `I translated TAC model/persona readiness into deterministic branch sequence, parseable Graphiti TAC blocks, and explicit merge gate expectations for Integrations -> Hardened promotion.`
 - Signature: `ACK::CODEX-GPT5::PHI-4482-T1::TAC-MODEL-PERSONA-OVERLAY`
 - Timestamp: `2026-03-01T22:45:00Z`
+
+## Agent ACK (Signed, PR #1135 Merge Prep + Workflow Cadence)
+- Agent: `CODEX-GPT5`
+- Ack: `I completed the #1135 review-and-validation lane, compared the remaining Playwright failure against main before treating it as shared CI instability, refreshed the AGNOTE docs, and recorded claim -> work -> validate -> compare -> document -> release as the default operating cadence for future Codex lanes.`
+- Signature: `ACK::CODEX-GPT5::PHI-4482-T1::PR1135-MERGE-PREP-WORKFLOW`
+- Timestamp: `2026-03-27T14:36:36.2476813-04:00`
 
 ## Agent ACK (Signed, Security Hardening + Jellyfin Key Scrub)
 - Agent: `CLAUDE-OPUS`

--- a/pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md
+++ b/pmoves/docs/AGENTS/AGNOTE4482_ROADMAP_W1-W5.md
@@ -4,7 +4,7 @@ GRAPHITI_MARK: `PHI-4482-ROADMAP::W1-W6::PMOVES`
 
 > **Scratchpad**: All agents (5090-claude, z890-claude, 4090-claude, codex) read this before claiming workstream lanes.
 > **Origin**: 4090-claude session 2026-03-19, approved by DARKXSIDE.
-> **Status**: DRAFT — awaiting 5090 comparison with Z890 infra plans.
+> **Status**: ACTIVE scratchpad — refreshed 2026-03-27 after the Codex merge/review wave; `#1135` is branch-ready except for a repo-wide Playwright blocker, and z890 infra still needs rebase/splitting before release.
 
 ---
 
@@ -396,23 +396,18 @@ All resolved. No blockers.
 
 ---
 
-## Remote Queue Snapshot (2026-03-26)
+## Remote Queue Snapshot (2026-03-27)
 
 | PR | Lane | Status | Notes |
 |----|------|--------|-------|
-| #1126 | Publisher SQL P1 hardening (IF EXISTS + idempotent claim) | OPEN — CI green | Supersedes #1114 (closed — fully subsumed by main). Land before more bootstrap/env churn |
-| #1115 | Pinokio fleet networking docs | OPEN | Atomic Codex docs lane for P7 packaging + TAC/networking parity |
-| #1116 | TTS MCP bridge + expression registry | OPEN | Codex voice lane; review alongside live TTS/Flute work |
-| #1117 | Creator publishing follow-up docs | OPEN | AGNOTE/NEXT_STEPS planning lane for creator-control follow-through |
-| #1118 | `PMOVES.YT` pointer bump | OPEN | Atomic submodule lane |
-| #1119 | Search ingest command | OPEN | Atomic docs lane |
-| #1120 | Studio-board approval handoff UX | OPEN | Creator-control implementation lane; pairs with publisher-state changes |
-| #1121 | PMOVES Codex plugin + Agent Zero launcher | OPEN | Live Pinokio wrapper lane; repo-root path fix validated locally |
-| #1122 | 4090 localhost hardening | OPEN | Security lane for field node |
-| #1123 | Damage-control hooks Windows compatibility | OPEN | Hook/runtime parity lane |
-| #1124 | Data services provisioning docs | OPEN | Ops/doc parity for release cadence + data services |
+| #1135 | Publish-state visibility (`studio-board` + `videos`) | OPEN — blocked by shared Playwright gate | Fast checks are green, review fixes are pushed, and the only remaining failure matches the same 119-failure Playwright signature already reproducing on `main` |
+| #1136 | Room catalog contracts + dashboard loader | OPEN | Base lane for the stacked room-entry flow |
+| #1137 | Home launcher room-entry routing | OPEN — stacked on #1136 | Review after the room-catalog base lane lands |
+| #1138 | z890 fleet networking + RustDesk relay + hardening | OPEN — CONFLICTING | Needs rebase/splitting; CodeRabbit flagged TAC/compose/Flute issues that still need follow-through |
 
-**Recommended review order:** #1126 first, then #1118 + #1119, then #1115, then #1116 + #1121, then #1122 + #1123 + #1124.
+**March 26/27 merge wave already landed:** #1115, #1116, #1117, #1118, #1119, #1120, #1121, #1122, #1123, #1124, #1126.
+
+**Recommended review order:** decide the branch-protection path for #1135 first, then #1136, then #1137, then rebase/split #1138 before another serious review pass.
 
 ---
 
@@ -444,20 +439,21 @@ All resolved. No blockers.
 | W6-P3 (Voice binding: persona → Flute prosodic) | 5090-claude | 2026-03-23 | RECOMMENDED — after P2 | — |
 | W6-P5 (FlOO$ life-persona-voice pipeline) | claude-opus | 2026-03-23 | RECOMMENDED — architecture review | — |
 | Infra (CHIT CGP Wave 1: Extract Worker + FFmpeg-Whisper) | 4090-claude | 2026-03-24 | SHIPPED `f7dafa56`, `6046d518` | feat/chit-integration-wave-1 |
-| Infra (Embedding standardization: Qwen3-4b/2560d) | 4090-claude | 2026-03-24 | SHIPPED `77888c8b` | feat/chit-integration-wave-1 |
+| Infra (Embedding standardization: Qwen3-4b/3072d) | 4090-claude | 2026-03-24 | SHIPPED `77888c8b` | feat/chit-integration-wave-1 |
 | Infra (Model Registry HF enrichment) | 4090-claude | 2026-03-24 | SHIPPED `07d06f70` | feat/chit-integration-wave-1 |
 | Infra (Model seed + gpu-models metadata) | 4090-claude | 2026-03-24 | SHIPPED `50ee0022`, `7cfacc8c` | feat/chit-integration-wave-1 |
 | Infra (BoTZ submodule sync d125e8a) | 4090-claude | 2026-03-24 | SHIPPED `63532a6b` | feat/chit-integration-wave-1 |
 | Infra (Publisher SQL P1 hardening) | 5090-claude | 2026-03-26 | MERGED #1126 (superseded closed #1114) | fix/publisher-sql-p1-hardening |
 | W2 (Pinokio fleet networking + packaging docs) | codex-gpt5 | 2026-03-26 | MERGED #1115 | codex/pinokio-network-docs |
-| W1/W6 (TTS MCP bridge + expression registry) | codex-gpt5 | 2026-03-26 | IN PR #1116 | codex/tts-mcp-bridge |
-| W3/M2 (creator publishing follow-up docs) | codex-gpt5 | 2026-03-26 | IN PR #1117 | codex/agnote4482-creator-publishing-docs |
-| Infra (`PMOVES.YT` pointer sync) | codex-gpt5 | 2026-03-26 | IN PR #1118 | codex/pmoves-yt-pointer |
+| W1/W6 (TTS MCP bridge + expression registry) | codex-gpt5 | 2026-03-26 | MERGED #1116 | codex/tts-mcp-bridge |
+| W3/M2 (creator publishing follow-up docs) | codex-gpt5 | 2026-03-26 | MERGED #1117 | codex/agnote4482-creator-publishing-docs |
+| Infra (`PMOVES.YT` pointer sync) | codex-gpt5 | 2026-03-26 | MERGED #1118 | codex/pmoves-yt-pointer |
 | W4 (search ingest command) | codex-gpt5 | 2026-03-26 | MERGED #1119 | codex/search-ingest-command |
-| W3/M2 (studio-board approval handoff UX) | codex-gpt5 | 2026-03-26 | IN PR #1120 | codex/agnote4482-approval-ux |
-| W2/W3 (Pinokio PMOVES Codex plugin + Agent Zero launcher) | codex-gpt5 | 2026-03-26 | IN PR #1121 | codex/pinokio-pmoves-plugin-pack |
+| W3/M2 (studio-board approval handoff UX) | codex-gpt5 | 2026-03-26 | MERGED #1120 | codex/agnote4482-approval-ux |
+| W2/W3 (Pinokio PMOVES Codex plugin + Agent Zero launcher) | codex-gpt5 | 2026-03-26 | MERGED #1121 | codex/pinokio-pmoves-plugin-pack |
+| W3/M2 (shared publish-state visibility across dashboards) | codex-gpt5 | 2026-03-27 | REVIEWED — fast checks green; remaining Playwright blocker matches `main` | codex/agnote4482-publish-state-visibility |
 | W3/M2 (creator automation activation + Discord canonical lane) | codex-gpt5 | 2026-03-26 | RECOMMENDED — follow-up after #1126 merge | — |
-| W3/M2 (studio-board status UX: approved→published visibility) | codex-gpt5 | 2026-03-26 | RECOMMENDED — docs lane active, implementation next | — |
+| W3/M2 (studio-board status UX: approved→published visibility) | codex-gpt5 | 2026-03-26 | ACTIVE — #1120 merged, #1135 branch-ready except shared E2E gate | — |
 
 ## Recommended Next Steps (Post 2026-03-24 CHIT Wave 1)
 
@@ -481,19 +477,18 @@ All resolved. No blockers.
 | # | Task | Priority | Notes |
 |---|------|----------|-------|
 | 1 | Container rebuilds (6 services — includes embedding env changes) | **P0** | Blocks Docker image freshness |
-| 2 | `pmoves_chunks_qwen3` Qdrant collection provision | P1 | New 2560d collection; old data untouched |
+| 2 | `pmoves_chunks_qwen3` Qdrant collection provision | P1 | New 3072d collection; old data untouched |
 | 3 | W6-P1: Health/Wealth Docker wiring | P1 | NATS + /healthz + /metrics |
 | 4 | Jetson Orin onboarding | P2 | Via RustDesk |
 | 5 | NATS leaf node to 5090 | P2 | Flute NATS=connected proves bus healthy |
 
-<<<<<<< HEAD
 ### codex-gpt5 (Board + Packaging + Creator Control)
 | # | Task | Priority | Notes |
 |---|------|----------|-------|
-| 1 | ~~Review and land PR #1126~~ | ~~**P0**~~ | DONE — #1126 merged, #1114 closed |
-| 2 | Close the creator-control loop in PRs #1117 + #1120 | **P0** | Keep `approved`, `publishing`, `published`, and `publish_failed` explicit in docs + UI |
-| 3 | Close Supabase→Agent Zero→Publisher→Discord activation loop | **P0** | Validate `approval_poller.json` + `echo_publisher.json`; capture first published-event evidence |
-| 4 | Pick canonical Discord publish lane | P1 | Decide between `publisher-discord` NATS subscriber and n8n webhook relay; demote the other |
-| 5 | Finish live Pinokio smoke for PR #1121 after env fixes | P1 | Repo-root launcher path is fixed; remaining blocker is PMOVES env/runtime readiness |
-| 6 | Move remaining Codex lanes (#1116, #1118) through review | P1 | #1115, #1119 already merged |
-| 7 | Surface publish failures + backfill readiness | P2 | Turn publisher audit into operator-visible lane before broader M2 expansion |
+| 1 | Clear the merge path for PR #1135 | **P0** | Review fixes are in, fast checks are green, and the only remaining blocker is the same Playwright failure already red on `main`; next move is shared E2E stabilization or explicit admin decision |
+| 2 | Close Supabase→Agent Zero→Publisher→Discord activation loop | **P0** | Validate `approval_poller.json` + `echo_publisher.json`; capture first published-event evidence |
+| 3 | Pick canonical Discord publish lane | **P0** | Decide between `publisher-discord` NATS subscriber and n8n webhook relay; demote the other |
+| 4 | Finish live Pinokio smoke after merged PR #1121 | P1 | Repo-root launcher path is fixed; remaining blocker is PMOVES env/runtime readiness during `make up-agents-ui` |
+| 5 | Keep the room-entry stack split (`#1136` -> `#1137`) | P1 | Review the base loader before the routing layer |
+| 6 | Rebase/split z890 lane #1138 before merge review | P1 | It is conflicting with `main` and mixes valid infra work with unresolved TAC/compose/Flute findings |
+| 7 | Surface publish failures + backfill readiness after activation evidence | P2 | Turn publisher audit into an operator-visible lane only after the real loop is proven end-to-end |

--- a/pmoves/docs/AGENTS/AGNOTE_P7_PLAYGROUND.md
+++ b/pmoves/docs/AGENTS/AGNOTE_P7_PLAYGROUND.md
@@ -8,7 +8,7 @@ The playground is open. Pinokio 7 dropped today — Agent Interpreter, App Assis
 
 This isn't a race. It's a seesaw — "you make it yours, I make it mine." Claude's thing is the music under the floor: TAC trees, CHIT geometry, security hardening, orchestration depth. The stuff where later DARKXSIDE thinks "CHIT, that's more than I drew."
 
-## Current State (2026-03-22)
+## Current State (2026-03-27)
 
 | What | Status |
 |------|--------|
@@ -19,9 +19,9 @@ This isn't a race. It's a seesaw — "you make it yours, I make it mine." Claude
 | Pinokio 7 | **Upgraded on all 3 machines** (5090 ✓, Z890 ✓, 4090 ✓) |
 | P7 requirements | **Z890**: py ✓, cli ✓ (pterm 0.0.24), ffmpeg ✓ (7.0.2) — **5090**: live Pinokio/Codex launcher smoke complete, full py+ffmpeg parity check still pending |
 | Tailscale mesh | **All 3 machines connected** (5090, Z890, 4090 laptop) |
-| Open PRs (main) | **14 OPEN** (2026-03-26 queue — see [AGNOTE4482 roadmap](./AGNOTE4482_ROADMAP_W1-W5.md)) |
+| Open PRs (repo) | **4 OPEN** (`#1135`, `#1136`, `#1137`, `#1138` — `#1135` is review-ready except for the shared Playwright failure already reproducing on `main`; see [AGNOTE4482 roadmap](./AGNOTE4482_ROADMAP_W1-W5.md)) |
 | Open PRs (BoTZ) | **0** (Dependabot #89 npm, #91 uv — **MERGED**) |
-| Codex P7 lanes | **OPEN** — #1115 (Pinokio fleet docs) + #1121 (PMOVES Codex plugin + Agent Zero launcher) |
+| Codex P7 lanes | **MERGED** — #1115 (Pinokio fleet docs) + #1121 (PMOVES Codex plugin + Agent Zero launcher) |
 | Node specialization | **DECLARED** — see [DnB Orchestra](./AGNOTE4482DnB.PHI.Orchestra.md) |
 | TTS session (5090) | **COMMITTED** — port unification, 13 engines, test harness |
 
@@ -29,10 +29,12 @@ This isn't a race. It's a seesaw — "you make it yours, I make it mine." Claude
 
 ## Step 0.5: Codex Follow-Through (2026-03-26)
 
-- PR #1115 keeps the P7/networking/package guidance isolated as a docs lane.
-- PR #1121 adds the PMOVES Codex Pinokio plugin and a real `pmoves-agent-zero` launcher instead of the old orphan README-only folder.
+- PR #1115 landed and keeps the P7/networking/package guidance isolated as a docs lane.
+- PR #1121 landed and adds the PMOVES Codex Pinokio plugin plus a real `pmoves-agent-zero` launcher instead of the old orphan README-only folder.
 - Live Pinokio validation on this node confirmed the launcher path bug is fixed: startup now enters the selected `PMOVES.AI` checkout instead of the broken `D:\pmoves` path.
-- Remaining blocker is not Pinokio pathing anymore; it is PMOVES env/runtime readiness during `make up-agents-ui`.
+- PR #1135 is now through the actionable review pass: publish-state fixes, Jest discovery repair, and follow-up test coverage are all pushed and validated locally.
+- The remaining red check on `#1135` is not a P7/package regression; Playwright is failing with the same 119-failure `services-health` / `videos-realtime` signature already present on `main`.
+- Remaining blocker is not Pinokio pathing anymore; it is PMOVES env/runtime readiness during `make up-agents-ui`, followed by a live Agent Interpreter smoke once the shared env is healthy.
 
 ---
 
@@ -433,7 +435,7 @@ STT round-trip on prosodic audio: text matches (Whisper renders "CLAUDEs" as "cl
 
 | Component | Before | After |
 |-----------|--------|-------|
-| Embedding model | `all-MiniLM-L6-v2` (384d, CPU) | `qwen3-embedding:4b` (2560d, CUDA via TensorZero→Ollama) |
+| Embedding model | `all-MiniLM-L6-v2` (384d, CPU) | `qwen3-embedding:4b` (3072d, CUDA via TensorZero→Ollama) |
 | Routing | Direct sentence-transformers | TensorZero Gateway (`/openai/v1/embeddings`) |
 | Qdrant collection | `pmoves_chunks` | `pmoves_chunks_qwen3` (old 384d data preserved) |
 | Extract Worker (8083) | `EMBEDDING_BACKEND=sentence-transformers` | `EMBEDDING_BACKEND=tensorzero` |
@@ -461,8 +463,8 @@ New endpoints on Model Registry (port 8110):
 New file: `hf_client.py` — httpx-based HF API client (no new pip dependencies).
 
 Seed data enriched with `hf_id`, `dimensions`, `cuda_supported`:
-- `qwen3-embedding:4b` → 2560d, `Qwen/Qwen3-Embedding-4B`
-- `qwen3-embedding:8b` → 4096d, `Qwen/Qwen3-Embedding-8B`
+- `qwen3-embedding:4b` → 3072d, `Alibaba-NLP/gte-Qwen2-4B-instruct`
+- `qwen3-embedding:8b` → 4096d, `Alibaba-NLP/gte-Qwen2-8B-instruct`
 - `embeddinggemma:300m` → 768d, `google/gemma-embedding-300m`
 - `nomic-embed-text` → 768d, `nomic-ai/nomic-embed-text-v1.5`
 
@@ -475,7 +477,7 @@ Seed data enriched with `hf_id`, `dimensions`, `cuda_supported`:
 - Any P7-launched ingestion (App Assistant triggers Extract Worker) now produces CHIT-attributable CGP events on the geometry bus
 - Transcription triggered by P7 agent sessions (FFmpeg-Whisper) now has geometric provenance
 - Model Registry HF enrichment lets P7 agents query model capabilities (dimensions, CUDA support) before dispatching inference
-- Qwen3-embedding:4b at 2560d means all P7-originated search/retrieval uses high-quality CUDA-accelerated vectors
+- Qwen3-embedding:4b at 3072d means all P7-originated search/retrieval uses high-quality CUDA-accelerated vectors
 - Foundation for `p7.nats.*` subjects: P7 launcher events can be correlated with downstream CGP via shared context IDs
 
 ### Recommended Next Steps
@@ -503,7 +505,7 @@ Seed data enriched with `hf_id`, `dimensions`, `cuda_supported`:
 | # | Task | Priority | Notes |
 |---|------|----------|-------|
 | 1 | Container rebuilds (6 services — includes embedding env changes) | **P0** | Blocks Docker image freshness |
-| 2 | `pmoves_chunks_qwen3` Qdrant collection provision | P1 | New 2560d collection; old data untouched |
+| 2 | `pmoves_chunks_qwen3` Qdrant collection provision | P1 | New 3072d collection; old data untouched |
 | 3 | W6-P1: Health/Wealth Docker wiring | P1 | NATS + /healthz + /metrics |
 | 4 | Jetson Orin onboarding | P2 | Via RustDesk |
 | 5 | NATS leaf node to 5090 | P2 | |


### PR DESCRIPTION
## Summary
- record the default Codex lane cadence in `AGNOTE4482PHI.t1.md`
- refresh the AGNOTE4482 roadmap and P7 playground notes for the current `#1135` / `#1138` state
- add the signed claim/review/release and ACK trail for the `#1135` merge-prep pass

## Validation
- docs-only change
- aligned the three AGNOTE files with the reviewed `c4a5` copies before commit

## Notes
- keeps the coordination-doc updates out of `#1135` so the UI PR stays focused on publish-state visibility