### PR TITLE
fix(hirag): align default collection + propagate dimension mismatch errors

### DIFF
--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -1877,7 +1877,7 @@ services:
     - SSL_CERT_FILE=
     - SSL_CERT_DIR=
     - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
-    - QDRANT_COLLECTION=${QDRANT_COLLECTION:-pmoves_chunks}
+    - QDRANT_COLLECTION=${QDRANT_COLLECTION:-pmoves_chunks_qwen3}
     - SENTENCE_MODEL=${SENTENCE_MODEL:-all-MiniLM-L6-v2}
     - INDEXER_NAMESPACE=${INDEXER_NAMESPACE:-pmoves}
     - ALPHA=${ALPHA:-0.7}

--- a/pmoves/services/hi-rag-gateway-v2/app.py
+++ b/pmoves/services/hi-rag-gateway-v2/app.py
@@ -23,7 +23,7 @@ import nats
 import psycopg
 
 QDRANT_URL = os.environ.get("QDRANT_URL","http://qdrant:6333")
-COLL = os.environ.get("QDRANT_COLLECTION","pmoves_chunks")
+COLL = os.environ.get("QDRANT_COLLECTION","pmoves_chunks_qwen3")
 MODEL = os.environ.get("SENTENCE_MODEL","all-MiniLM-L6-v2")
 ALPHA = float(os.environ.get("ALPHA", "0.7"))
 
@@ -1499,8 +1499,10 @@ def hirag_query(req: QueryReq = Body(...), request: Request = None, _=Depends(re
         try:
             dim = len(vec)
             ensure_qdrant_collection(dim)
-        except Exception:
-            pass
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning("ensure_qdrant_collection non-fatal: %s", e)
         must = [FieldCondition(key="namespace", match=MatchValue(value=req.namespace))]
         hits = _qdrant_search(
             collection_name=COLL,
@@ -2394,8 +2396,10 @@ def hirag_upsert_batch(req: UpsertReq = Body(...), _=Depends(require_admin_tails
     if req.ensure_collection and vectors:
         try:
             ensure_qdrant_collection(len(vectors[0]))
-        except Exception:
-            pass
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning("ensure_qdrant_collection non-fatal: %s", e)
 
     points = []
     for it, vec in zip(items, vectors):


### PR DESCRIPTION
## Summary
- **Critical fix:** `app.py` default `QDRANT_COLLECTION` was `pmoves_chunks` (legacy 384d) — changed to `pmoves_chunks_qwen3` (2560d Qwen3-Embedding-4B)
- **GPU compose fix:** `docker-compose.yml:1880` was the only remaining `pmoves_chunks` default — now aligned with all other services
- **Error propagation:** Both `/hirag/query` and `/ingest` endpoints silently swallowed `HTTPException` (including 409 dimension mismatch) — now properly re-raised

## Root Cause
PR #1131 correctly updated docker-compose defaults but the Python-level fallback in `app.py:26` was missed. When the env var isn't explicitly passed (bare-metal runs, tests), Hi-RAG queries the wrong empty collection → 0 results.

The silent `except Exception: pass` blocks at lines 1499-1503 and 2394-2398 masked dimension mismatch errors that `ensure_qdrant_collection()` was correctly raising.

## Test plan
- [ ] `make -C pmoves hirag-smoke` passes
- [ ] Query returns >0 results: `curl -X POST http://localhost:8086/hirag/query -H "Content-Type: application/json" -d '{"query": "test", "top_k": 5}'`
- [ ] Dimension mismatch returns 409 instead of silent 0 results
- [ ] All 5 `QDRANT_COLLECTION` entries in docker-compose.yml are `pmoves_chunks_qwen3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default service configuration settings.

* **Bug Fixes**
  * Improved error handling during collection initialization to properly surface HTTP-level failures while logging and recovering from non-critical errors instead of silently suppressing all issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->