### PR TITLE
fix(mcp): cipher stdio bridge + SDK compat

### DIFF
--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,8 +1,12 @@
 {
   "mcpServers": {
     "pmoves-cipher": {
-      "type": "sse",
-      "url": "http://localhost:8096/sse"
+      "command": "uv",
+      "args": ["--directory", "./pmoves-cipher-mcp", "run", "python", "-m", "cipher_mcp.server"],
+      "env": {
+        "CIPHER_URL": "http://localhost:8096",
+        "NATS_URL": "nats://nats:pmoves@nats:4222"
+      }
     },
     "docker": {
       "command": "docker",

--- a/pmoves-cipher-mcp/cipher_mcp/server.py
+++ b/pmoves-cipher-mcp/cipher_mcp/server.py
@@ -77,6 +77,7 @@ async def main():
                 server_version="0.1.0",
                 capabilities=app.get_capabilities(
                     notification_options=NotificationOptions(),
+                    experimental_capabilities={},
                 ),
             ),
         )


### PR DESCRIPTION
## Summary
- Switch cipher MCP from broken SSE transport to stdio bridge (`pmoves-cipher-mcp/`)
- Fix MCP SDK `experimental_capabilities` arg in `server.py`

## Why
SSE had 3 failures: wrong endpoint path, Docker Desktop port binding bug, Bearer auth blocking. The stdio bridge is the documented architecture per `pmoves-cipher-mcp/README.md`.

## Files
- `.claude/mcp.json` — SSE → stdio config
- `pmoves-cipher-mcp/cipher_mcp/server.py` — SDK compat fix

## Test plan
- [ ] `echo '...' | uv ... run python -m cipher_mcp.server` → initializes with 4 tools
- [ ] New Claude Code session → cipher MCP tools appear
- [ ] Docker Desktop restart → `curl localhost:8096/health` → healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cipher server deployment to use environment-based configuration for improved flexibility.
  * Added explicit capabilities initialization for the cipher server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->