### PR TITLE
fix(cipher): rewrite cipher skills to MCP-first with local MEMORY.md fallback

### DIFF
--- a/.claude/commands/cipher/reasoning.md
+++ b/.claude/commands/cipher/reasoning.md
@@ -62,8 +62,10 @@ Arguments:
 #### Fallback: local auto-memory (if CIPHER_DOWN or MCP fails)
 
 Read the auto-memory files and search for reasoning-related entries using Grep:
-- Search for `reasoning`, `chain-of-thought`, `Q:`, `Result:` patterns
+- Search for `reasoning`, `reasoning_trace`, `chain-of-thought`, `Q:`, `Result:` patterns
 - Check topic files with `reasoning` in the filename
+- **Legacy note:** Historical entries may use category `reasoning_trace` instead of `reasoning`.
+  Search for both when retrieving patterns from older sessions.
 
 ---
 

--- a/.claude/commands/cipher/reasoning.md
+++ b/.claude/commands/cipher/reasoning.md
@@ -22,7 +22,7 @@ curl -sf --max-time 3 http://localhost:8096/health > /dev/null 2>&1 && echo "CIP
 
 Use the MCP tool `pmoves_cipher_store_reasoning`:
 
-```
+```yaml
 Tool: pmoves_cipher_store_reasoning
 Arguments:
   question: "$QUESTION"
@@ -52,7 +52,7 @@ Append the reasoning trace to your auto-memory file using the Write or Edit tool
 
 Use the MCP tool `pmoves_cipher_reasoning_patterns`:
 
-```
+```yaml
 Tool: pmoves_cipher_reasoning_patterns
 Arguments:
   query: "$PATTERN_QUERY"

--- a/.claude/commands/cipher/reasoning.md
+++ b/.claude/commands/cipher/reasoning.md
@@ -4,8 +4,8 @@ Store and retrieve reasoning traces and patterns in Cipher Memory.
 
 ## Instructions
 
-Manage reasoning traces in Cipher Memory. First check if the service is reachable.
-If it is NOT reachable, fall back to local auto-memory.
+Manage reasoning traces in Cipher Memory. Use MCP tools as the primary path.
+If Cipher is unreachable or MCP fails, fall back to local auto-memory.
 Do NOT let a connection failure interrupt your workflow.
 
 ### Step 1: Health check (silent, non-blocking)
@@ -14,45 +14,60 @@ Do NOT let a connection failure interrupt your workflow.
 curl -sf --max-time 3 http://localhost:8096/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
 ```
 
+---
+
 ### Store a reasoning trace
 
-#### If CIPHER_UP:
+#### Primary: MCP tool (if CIPHER_UP)
 
-```bash
-curl -s -X POST http://localhost:8096/api/memory \
-  -H "Content-Type: application/json" \
-  -d '{
-    "content": "$REASONING_CONTENT",
-    "category": "reasoning_trace",
-    "metadata": {
-      "task": "$TASK_DESCRIPTION",
-      "outcome": "$OUTCOME",
-      "confidence": 0.85
-    },
-    "source": "claude-code",
-    "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
-  }'
+Use the MCP tool `pmoves_cipher_store_reasoning`:
+
+```
+Tool: pmoves_cipher_store_reasoning
+Arguments:
+  question: "$QUESTION"
+  reasoning: "$CHAIN_OF_THOUGHT"
+  result: "$FINAL_ANSWER"
+  metadata: { "task": "$TASK", "confidence": 0.85 }
 ```
 
-#### If CIPHER_DOWN — Fallback:
+> **Known issue (2026-04-01):** MCP tools are currently blocked by the same gap as REST.
+> The MCP client (`pmoves-cipher-mcp/cipher_mcp/client.py`) calls `/api/memory` endpoints
+> which do not exist in `Pmoves-cipher` (no `/api/memory` routes registered in `server.ts`).
+> Until the cipher-api submodule implements these routes, MCP tools will return 404.
+> **Use the local fallback paths below.**
+
+#### Fallback: local auto-memory (if CIPHER_DOWN or MCP fails)
 
 Append the reasoning trace to your auto-memory file using the Write or Edit tool:
 - File: `~/.claude/projects/<project>/memory/MEMORY.md`
-- Add under a `## Reasoning Traces` section
+- Add under a topic file (e.g., `reasoning_<topic>.md`)
+- Include: question, reasoning chain, result, confidence
+
+---
 
 ### Retrieve reasoning patterns
 
-#### If CIPHER_UP:
+#### Primary: MCP tool (if CIPHER_UP)
 
-```bash
-curl -s "http://localhost:8096/api/memory/search?q=$PATTERN_QUERY&category=reasoning_trace&limit=5"
+Use the MCP tool `pmoves_cipher_reasoning_patterns`:
+
+```
+Tool: pmoves_cipher_reasoning_patterns
+Arguments:
+  query: "$PATTERN_QUERY"
+  limit: 5
 ```
 
-#### If CIPHER_DOWN — Fallback:
+#### Fallback: local auto-memory (if CIPHER_DOWN or MCP fails)
 
-Read the auto-memory file and search for reasoning-related entries.
+Read the auto-memory files and search for reasoning-related entries using Grep:
+- Search for `reasoning`, `chain-of-thought`, `Q:`, `Result:` patterns
+- Check topic files with `reasoning` in the filename
+
+---
 
 **Notes:**
-- Also available via MCP tools: `pmoves_cipher_store_reasoning`, `pmoves_cipher_reasoning_patterns`
-- Reasoning traces help agents learn from past decisions
-- Patterns are indexed for similarity search when Cipher is online
+- Reasoning traces help agents learn from past decisions across sessions
+- Patterns are indexed for similarity search when Cipher is fully online
+- Store with descriptive questions — future searches match on semantic similarity

--- a/.claude/commands/cipher/search.md
+++ b/.claude/commands/cipher/search.md
@@ -4,8 +4,8 @@ Search Cipher Memory for stored knowledge and reasoning traces.
 
 ## Instructions
 
-Search the Cipher Memory knowledge graph. First check if the service is reachable.
-If it is NOT reachable, search local auto-memory (MEMORY.md) instead.
+Search the Cipher Memory knowledge graph. Use the MCP tool as the primary path.
+If Cipher is unreachable or MCP fails, search local auto-memory instead.
 Do NOT let a connection failure interrupt your workflow.
 
 ### Step 1: Health check (silent, non-blocking)
@@ -14,27 +14,45 @@ Do NOT let a connection failure interrupt your workflow.
 curl -sf --max-time 3 http://localhost:8096/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
 ```
 
-### Step 2a: Search via Cipher Memory (only if CIPHER_UP)
+### Step 2a: Search via MCP tool (primary — if CIPHER_UP)
 
-```bash
-curl -s "http://localhost:8096/api/memory/search?q=$QUERY&limit=10" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-results = d if isinstance(d, list) else d.get('results', [])
-for i, r in enumerate(results):
-    print(f'{i+1}. [{r.get(\"category\",\"?\")}] {r.get(\"content\",\"?\")[:120]}...')
-    print(f'   source={r.get(\"source\",\"?\")} ts={r.get(\"timestamp\",\"?\")}')
-"
+Use the MCP tool `pmoves_cipher_search`:
+
+```
+Tool: pmoves_cipher_search
+Arguments:
+  query: "$QUERY"
+  category: "$CATEGORY"       # optional filter
+  tags: ["$TAG1"]             # optional filter
+  limit: 10                   # optional, default 10
 ```
 
-### Step 2b: Fallback — search local auto-memory (if CIPHER_DOWN)
+**Category filters** (must match `tools.py` enum):
+`code_pattern`, `decision`, `context`, `submodule`, `architecture`, `reasoning`
 
-If the health check shows `CIPHER_DOWN`, do NOT attempt the curl call.
-Instead, read and search the auto-memory file using the Read tool:
-- File: `~/.claude/projects/<project>/memory/MEMORY.md`
-- Search for the user's query terms within the file content
+> **Known issue (2026-04-01):** MCP tools are currently blocked by the same gap as REST.
+> The MCP client (`pmoves-cipher-mcp/cipher_mcp/client.py`) calls `GET /api/memory/search`
+> which does not exist in `Pmoves-cipher` (no `/api/memory` routes registered in `server.ts`).
+> Until the cipher-api submodule implements these routes, MCP tools will return 404.
+> **Use the fallback below.**
 
-**Notes:**
-- Also available via MCP tool: `pmoves_cipher_search` (requires MCP server running)
-- Supports semantic search over Neo4j graph when online
-- Results include category, source, and timestamp metadata
+### Step 2b: Fallback — search local auto-memory (if CIPHER_DOWN or MCP fails)
+
+If the health check shows `CIPHER_DOWN`, or MCP returns a 404/connection error,
+do NOT retry. Instead, search the auto-memory file using the Read and Grep tools:
+- Index file: `~/.claude/projects/<project>/memory/MEMORY.md`
+- Read the index, then follow links to topic files matching the query
+- Use Grep to search across all `*.md` files in the memory directory
+
+### Marco/Polo pattern
+
+Search with a different phrasing than how the memory was stored.
+Cipher's embedding model bridges intent across phrasings.
+
+```
+# If stored as: "Agent orientation: claims register shows lanes A, B, C active"
+# Search with: "what lanes are currently claimed"
+```
+
+When searching locally (fallback), use multiple keyword variations since
+local search is keyword-based, not semantic.

--- a/.claude/commands/cipher/store.md
+++ b/.claude/commands/cipher/store.md
@@ -18,7 +18,7 @@ curl -sf --max-time 3 http://localhost:8096/health > /dev/null 2>&1 && echo "CIP
 
 Use the MCP tool `pmoves_cipher_store`:
 
-```
+```yaml
 Tool: pmoves_cipher_store
 Arguments:
   content: "$CONTENT"
@@ -34,9 +34,6 @@ Arguments:
 - `submodule` — Submodule knowledge and configuration
 - `architecture` — System patterns and design
 - `reasoning` — Chain-of-thought reasoning traces
-- `agent_plan` — Agent execution plans and strategy outlines
-- `agent_checkpoint` — Mid-task progress snapshots for resilience
-- `agent_completion` — Task completion records and outcomes
 
 > **Known issue (2026-04-01):** MCP tools are currently blocked by the same gap as REST.
 > The MCP client (`pmoves-cipher-mcp/cipher_mcp/client.py`) calls `POST /api/memory`
@@ -59,7 +56,7 @@ This ensures the memory is persisted even when Cipher services are offline.
 Store with intent-shaped phrasing. When you later search, rephrase the query.
 Cipher's embedding model bridges the gap between how you stored and how you search.
 
-```
+```text
 # Marco (store)
 /cipher:store Agent orientation: claims register shows lanes A, B, C active
 

--- a/.claude/commands/cipher/store.md
+++ b/.claude/commands/cipher/store.md
@@ -4,41 +4,62 @@ Store a memory entry in Cipher Memory (Neo4j-backed knowledge graph).
 
 ## Instructions
 
-Store a memory entry. First check if Cipher Memory is reachable.
-If it is NOT reachable, fall back to local auto-memory (write to MEMORY.md instead).
+Store a memory entry. Use the MCP tool as the primary path.
+If Cipher is unreachable or MCP fails, fall back to local auto-memory.
 Do NOT let a connection failure interrupt your workflow.
 
 ### Step 1: Health check (silent, non-blocking)
-
-Run this check. If it fails, skip to the **Fallback** section below.
 
 ```bash
 curl -sf --max-time 3 http://localhost:8096/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
 ```
 
-### Step 2a: Store via Cipher Memory (only if CIPHER_UP)
+### Step 2a: Store via MCP tool (primary — if CIPHER_UP)
 
-```bash
-curl -s -X POST http://localhost:8096/api/memory \
-  -H "Content-Type: application/json" \
-  -d '{
-    "content": "$CONTENT",
-    "category": "$CATEGORY",
-    "source": "claude-code",
-    "timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'"
-  }'
+Use the MCP tool `pmoves_cipher_store`:
+
+```
+Tool: pmoves_cipher_store
+Arguments:
+  content: "$CONTENT"
+  category: "$CATEGORY"
+  tags: ["$TAG1", "$TAG2"]
+  metadata: { "source": "claude-code", "session": "$SESSION_ID" }
 ```
 
-### Step 2b: Fallback — store in local auto-memory (if CIPHER_DOWN)
+**Categories** (must match `tools.py` enum):
+- `code_pattern` — Reusable code patterns and conventions
+- `decision` — Architectural decisions and rationale
+- `context` — Project-specific context
+- `submodule` — Submodule knowledge and configuration
+- `architecture` — System patterns and design
+- `reasoning` — Chain-of-thought reasoning traces
 
-If the health check shows `CIPHER_DOWN`, do NOT attempt the curl POST.
-Instead, append the memory to your auto-memory file using the Write or Edit tool:
-- File: `~/.claude/projects/<project>/memory/MEMORY.md`
+> **Known issue (2026-04-01):** MCP tools are currently blocked by the same gap as REST.
+> The MCP client (`pmoves-cipher-mcp/cipher_mcp/client.py`) calls `POST /api/memory`
+> which does not exist in `Pmoves-cipher` (no `/api/memory` routes registered in `server.ts`).
+> Until the cipher-api submodule implements these routes, MCP tools will return 404.
+> **Use the fallback below.**
+
+### Step 2b: Fallback — store in local auto-memory (if CIPHER_DOWN or MCP fails)
+
+If the health check shows `CIPHER_DOWN`, or MCP returns a 404/connection error,
+do NOT retry. Instead, write the memory to your auto-memory file using the Write or Edit tool:
+- File: `~/.claude/projects/<project>/memory/MEMORY.md` (index) + a topic file
 - Add the content under an appropriate section heading
+- Follow the memory file frontmatter format (name, description, type)
 
-This ensures the memory is persisted even when Docker services are offline.
+This ensures the memory is persisted even when Cipher services are offline.
 
-**Notes:**
-- Cipher Memory also available via MCP tool: `pmoves_cipher_store` (requires MCP server running)
-- Categories: `agent_plan`, `agent_checkpoint`, `agent_completion`, `pattern`, `learning`
-- Content is indexed in Neo4j for graph traversal queries when Cipher is online
+### Marco/Polo pattern
+
+Store with intent-shaped phrasing. When you later search, rephrase the query.
+Cipher's embedding model bridges the gap between how you stored and how you search.
+
+```
+# Marco (store)
+/cipher:store Agent orientation: claims register shows lanes A, B, C active
+
+# Polo (search later with different phrasing)
+/cipher:search what lanes are currently claimed
+```

--- a/.claude/commands/cipher/store.md
+++ b/.claude/commands/cipher/store.md
@@ -34,6 +34,9 @@ Arguments:
 - `submodule` — Submodule knowledge and configuration
 - `architecture` — System patterns and design
 - `reasoning` — Chain-of-thought reasoning traces
+- `agent_plan` — Agent execution plans and strategy outlines
+- `agent_checkpoint` — Mid-task progress snapshots for resilience
+- `agent_completion` — Task completion records and outcomes
 
 > **Known issue (2026-04-01):** MCP tools are currently blocked by the same gap as REST.
 > The MCP client (`pmoves-cipher-mcp/cipher_mcp/client.py`) calls `POST /api/memory`


### PR DESCRIPTION
## Summary
- Rewrote 3 cipher skill files (store, search, reasoning) from broken REST API curl to MCP-first
- Documented 3-layer gap: skills (FIXED) → MCP client (BLOCKED) → cipher-api (ROOT CAUSE)
- Aligned categories to `tools.py` enum: `code_pattern`, `decision`, `context`, `submodule`, `architecture`, `reasoning`
- Added Marco/Polo pattern documentation for intent-shaped storage/retrieval
- Added known-issue callout with exact file paths to all 3 skills
- Local MEMORY.md fallback as working path until `/api/memory` routes implemented

## Test plan
- [ ] Verify zero `curl.*api/memory` references in cipher skill files
- [ ] Verify MCP tool names match `pmoves-cipher-mcp/cipher_mcp/tools.py`
- [ ] Verify categories match `tools.py` enum at line 251
- [ ] Verify known-issue callout appears inline after MCP tool block in all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Made MCP tools the primary method for storing and retrieving reasoning patterns and general memory.
  * Updated storage formats and required categories for saved memories to improve consistency.
  * Improved offline/failed-service fallback: local auto-memory now writes indexed topic files and uses expanded keyword-based retrieval across them.
  * Added guidance on query phrasing and a known-issue note directing users to local fallback when MCP calls fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->