### PR TITLE
feat(ci): extend Trivy + Cosign hardening gates to 10 additional submodules

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -108,8 +108,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-      with:
-        submodules: recursive
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -108,6 +108,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        submodules: recursive
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/integrations-ghcr.yml
+++ b/.github/workflows/integrations-ghcr.yml
@@ -46,6 +46,19 @@ on:
       - 'PMOVES.YT'
       - 'PMOVES-Jellyfin'
       - 'PMOVES-Supaserch'
+      # Priority 1: production services
+      - 'PMOVES-HiRAG'
+      - 'PMOVES-BoTZ'
+      - 'PMOVES-tensorzero'
+      - 'PMOVES-Neo4j'
+      - 'Pmoves-cipher'
+      # Priority 2: agent infrastructure
+      - 'PMOVES-E2B-Danger-Room'
+      - 'PMOVES-Pipecat'
+      - 'PMOVES-ClawZ'
+      # Priority 3: media/content
+      - 'PMOVES-transcribe-and-fetch'
+      - 'PMOVES-autoresearch'
       - '.github/workflows/integrations-ghcr.yml'
       - '.github/workflows/integrations-ghcr.matrix.json'
       - '.github/trivy/**'
@@ -65,6 +78,19 @@ on:
       - 'PMOVES.YT'
       - 'PMOVES-Jellyfin'
       - 'PMOVES-Supaserch'
+      # Priority 1: production services
+      - 'PMOVES-HiRAG'
+      - 'PMOVES-BoTZ'
+      - 'PMOVES-tensorzero'
+      - 'PMOVES-Neo4j'
+      - 'Pmoves-cipher'
+      # Priority 2: agent infrastructure
+      - 'PMOVES-E2B-Danger-Room'
+      - 'PMOVES-Pipecat'
+      - 'PMOVES-ClawZ'
+      # Priority 3: media/content
+      - 'PMOVES-transcribe-and-fetch'
+      - 'PMOVES-autoresearch'
       - '.github/workflows/integrations-ghcr.yml'
       - '.github/workflows/integrations-ghcr.matrix.json'
       - '.github/trivy/**'


### PR DESCRIPTION
## Summary
- Extend `integrations-ghcr.yml` path triggers from 6 to 16 submodules (Trivy scan + Cosign + SBOM on push/PR)
- Enable `submodules: recursive` in CodeQL workflow for Python/JS/TS analysis coverage
- Prioritized by production criticality: P1 (HiRAG, BoTZ, tensorzero, Neo4j, cipher), P2 (E2B, Pipecat, ClawZ), P3 (transcribe-and-fetch, autoresearch)

## Test plan
- [ ] Verify workflow YAML is valid (`gh workflow view integrations-ghcr`)
- [ ] Verify CodeQL checkout succeeds with recursive submodules
- [ ] Confirm path triggers fire on submodule gitlink changes in a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)