### PR TITLE
fix(make): remove dead postgres/postgrest from DATA_SERVICES, add up-minio target

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -420,6 +420,8 @@ encapsulate the correct stop/restart/env-injection flow.
 | Tailscale ACL drift audit | `pmoves/docs/operations/FLEET_REMOTE_ACCESS_RUNBOOK.md` + `pmoves/configs/tailscale-acl-policy.json` | `/fleet:acl-audit` |
 | RustDesk enrollment / QR gen | `make -C pmoves fleet-enroll ROLE=... DEVICE=...` | `/fleet:enroll` |
 
+| MinIO restart (object storage) | `make -C pmoves up-minio` | `/minio:status` |
+
 **volume-reset SERVICE values:** `neo4j`, `tensorzero-clickhouse`, `meilisearch`, `qdrant`, `minio`, `supabase-db`, `nats`
 
 If a rebuild manifest arrives as raw `docker compose build ...`, translate it to the nearest Known Road whenever possible. Use the raw build only when there is no dedicated make target yet, and still return to the make-target bring-up path for the actual service start.

--- a/pmoves/Makefile
+++ b/pmoves/Makefile
@@ -835,6 +835,13 @@ up-data-tier: ## Start data tier (Qdrant, Neo4j, Meilisearch, MinIO)
 	@$(MAKE) --no-print-directory wait-data
 	@echo "✅ Data tier ready"
 
+.PHONY: up-minio
+up-minio: ## Start MinIO object storage (port 9000) + Presign
+	@echo "📦 Starting MinIO..."
+	@$(DC) up -d --force-recreate minio presign
+	@timeout 60 bash -c 'until curl -sf http://localhost:9000/minio/health/live; do sleep 2; done' || echo "⚠️ MinIO may still be starting"
+	@echo "✅ MinIO ready at http://localhost:9000 (console :9001)"
+
 .PHONY: up-bus
 up-bus: ## Start message bus (NATS)
 	@echo "📨 Starting message bus (NATS)..."
@@ -1542,13 +1549,9 @@ ifeq ($(EXTERNAL_MEILI),true)
 DATA_SERVICES += meilisearch
 endif
 
-ifeq ($(SUPA_PROVIDER),cli)
-		else
-ifeq ($(EXTERNAL_SUPABASE),true)
-		else
-DATA_SERVICES += postgres postgrest
-endif
-endif
+# NOTE: Supabase DB (postgres) and PostgREST are managed by the Supabase
+# stack (supabase-local profile or CLI), not by the main compose stack.
+# Do NOT add them to DATA_SERVICES — they have no matching compose service.
 
 # Canonical layer service sets for deterministic tiered bring-up/down.
 WORKER_SERVICES := hi-rag-gateway-v2 retrieval-eval render-webhook langextract extract-worker pdf-ingest transcribe-backend


### PR DESCRIPTION
## Summary
- **Remove dead `postgres postgrest` from `DATA_SERVICES`** — these services are managed by the Supabase stack (supabase-local profile or CLI) and have no matching compose service in the main stack, causing `make up-data-tier` to fail with "no such service" errors.
- **Add `up-minio` Known Road target** — canonical make target to restart MinIO object storage (port 9000) + Presign sidecar, with a 60s health-check gate.
- **Document `up-minio` in `.claude/CLAUDE.md`** Known Roads table so agents route MinIO restarts through the make target instead of raw docker compose commands.

## Test plan
- [ ] `make -C pmoves -n up-minio` succeeds (dry-run shows correct compose command)
- [ ] `make -C pmoves -n up-data-tier` no longer references `postgres` or `postgrest`
- [ ] Grep `DATA_SERVICES` in Makefile confirms no postgres/postgrest entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MinIO object storage startup command with automatic health check and service readiness verification.

* **Bug Fixes**
  * Corrected service configuration to properly manage Supabase database and API dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->