### PR TITLE
fix(chrome-ext): use /health not /v1/models for TensorZero health check

### DIFF
--- a/pmoves/chrome-extension/lib/constants.js
+++ b/pmoves/chrome-extension/lib/constants.js
@@ -29,7 +29,7 @@ export const DEFAULT_CONFIG = {
 };
 
 export const HEALTH_ENDPOINTS = {
-  tensorzero:      { path: '/v1/models',    method: 'GET' },
+  tensorzero:      { path: '/health',        method: 'GET' },
   gpuOrchestrator: { path: '/api/gpu/status', method: 'GET' },
   hirag:           { path: '/',              method: 'GET' },
   pmovesYt:        { path: '/healthz',       method: 'GET' },

--- a/pmoves/chrome-extension/options/options.js
+++ b/pmoves/chrome-extension/options/options.js
@@ -12,7 +12,7 @@ const FEATURES = [
 ];
 
 const HEALTH_PATHS = {
-  tensorzero:      '/v1/models',
+  tensorzero:      '/health',
   gpuOrchestrator: '/api/gpu/status',
   hirag:           '/',
   pmovesYt:        '/healthz',

--- a/pmoves/chrome-extension/test/mock-server.js
+++ b/pmoves/chrome-extension/test/mock-server.js
@@ -9,7 +9,7 @@ const services = [
     name: 'TensorZero',
     port: 3030,
     routes: {
-      'GET /v1/models': { models: [{ id: 'claude-sonnet-4-5' }, { id: 'gemma_embed_local' }] },
+      'GET /health': { status: 'ok' },
       'GET /healthz': 'ok',
       'POST /v1/chat/completions': (body) => ({
         choices: [{


### PR DESCRIPTION
## Summary
- Switch TensorZero health check endpoint from `/v1/models` to `/health` across all 3 chrome-extension files (constants, options, mock-server)
- `/v1/models` returns a model list, not a health status, and may not always be available — `/health` is the proper lightweight health probe
- Mock server updated to return `{ status: 'ok' }` instead of a model list for the health route

## Test plan
- [ ] `grep -r "v1/models" pmoves/chrome-extension/` returns no health-related hits
- [ ] Load extension options page, click "Test" on TensorZero row — should hit `/health` and show OK when TensorZero is running
- [ ] Run `node pmoves/chrome-extension/test/mock-server.js` and verify `GET http://localhost:3030/health` returns `{ "status": "ok" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated TensorZero service health check endpoint configuration to use the correct health status verification path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->