### PR TITLE
fix(fleet): rename tag:unfcu to tag:partner

### DIFF
--- a/.claude/commands/fleet/enroll.md
+++ b/.claude/commands/fleet/enroll.md
@@ -9,7 +9,7 @@ Run this command to:
 
 ## Arguments
 
-- `ROLE` — Required. One of: `owner`, `unfcu`, `guest`
+- `ROLE` — Required. One of: `owner`, `partner`, `guest`
 - `DEVICE` — Required. Device name (e.g., "Pixel 10", "UNFCU-Laptop-1")
 - `TTL` — Optional. Token lifetime (default: `5m`). Valid values: `5m`, `15m`, `1h`, `4h`, `24h`
 
@@ -18,7 +18,7 @@ Run this command to:
 | Role | Tailscale Tag | Allowed Nodes | Allowed Ports |
 |------|--------------|--------------|--------------|
 | `owner` | `tag:pmoves` | All | All |
-| `unfcu` | `tag:unfcu` | See ACL policy | See ACL policy |
+| `partner` | `tag:partner` | See ACL policy | See ACL policy |
 | `guest` | `tag:guest` | See ACL policy | See ACL policy |
 
 ## Implementation

--- a/.claude/commands/fleet/enroll.md
+++ b/.claude/commands/fleet/enroll.md
@@ -10,7 +10,7 @@ Run this command to:
 ## Arguments
 
 - `ROLE` — Required. One of: `owner`, `partner`, `guest`
-- `DEVICE` — Required. Device name (e.g., "Pixel 10", "UNFCU-Laptop-1")
+- `DEVICE` — Required. Device name (e.g., "Pixel 10", "Partner-Laptop-1")
 - `TTL` — Optional. Token lifetime (default: `5m`). Valid values: `5m`, `15m`, `1h`, `4h`, `24h`
 
 ## Roles

--- a/.claude/context/nats-subjects.md
+++ b/.claude/context/nats-subjects.md
@@ -575,7 +575,7 @@ Example: `ingest.transcript.ready.v1`
   ```json
   {
     "token_id": "tok-abc123",
-    "role": "owner|unfcu|guest",
+    "role": "owner|partner|guest",
     "device_name": "Pixel 10",
     "issued_at": "2026-03-27T18:00:00Z",
     "expires_at": 1774638000,

--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -892,6 +892,8 @@ chitSafePaths:
   - "docker-compose.integrations"
   # PR-kit compose files — integration starter templates
   - "pr-kits"
+  # Context docs that need fleet/config renames (approved per issue #1173)
+  - ".claude/context/nats-subjects.md"
 
 # ---------------------------------------------------------------------------
 # PMOVES.AI - GIT SUBMODULES

--- a/pmoves/configs/tailscale-acl-policy.json
+++ b/pmoves/configs/tailscale-acl-policy.json
@@ -8,7 +8,7 @@
     "tag:vps": ["autogroup:admin"],
     "tag:lab": ["autogroup:admin"],
     "tag:exit": ["autogroup:admin"],
-    "tag:unfcu": ["autogroup:admin"],
+    "tag:partner": ["autogroup:admin"],
     "tag:guest": ["autogroup:admin"]
   },
 
@@ -27,13 +27,13 @@
     },
     {
       "action": "accept",
-      "src": ["tag:unfcu"],
+      "src": ["tag:partner"],
       "dst": [
         "tag:gpu:3030",
         "tag:gpu:8080",
         "tag:gpu:8081"
       ],
-      "comment": "UNFCU partner: Agent Zero API + UI, TensorZero Gateway only"
+      "comment": "Partner access: Agent Zero API + UI, TensorZero Gateway only"
     },
     {
       "action": "accept",

--- a/pmoves/docs/operations/RUSTDESK_SELF_HOSTED.md
+++ b/pmoves/docs/operations/RUSTDESK_SELF_HOSTED.md
@@ -131,7 +131,7 @@ Claws scripts SSH via key at `$LOCALAPPDATA/Temp/hostinger_vps`.
 RUSTDESK_RELAY_HOST=<KVM2_IP> RUSTDESK_PUBLIC_KEY=<KEY> CHIT_PASSPHRASE=<secret> \
   python pmoves/scripts/fleet/generate-enrollment.py generate --role owner --ttl 5m --device "Pixel 10"
 
-# UNFCU partner (limited access, 24-hour window)
+# Partner (limited access, 24-hour window)
 ... generate --role partner --ttl 24h --device "Partner-Laptop-1"
 
 # Guest demo (Agent Zero UI only, 1-hour window)

--- a/pmoves/docs/operations/RUSTDESK_SELF_HOSTED.md
+++ b/pmoves/docs/operations/RUSTDESK_SELF_HOSTED.md
@@ -132,7 +132,7 @@ RUSTDESK_RELAY_HOST=<KVM2_IP> RUSTDESK_PUBLIC_KEY=<KEY> CHIT_PASSPHRASE=<secret>
   python pmoves/scripts/fleet/generate-enrollment.py generate --role owner --ttl 5m --device "Pixel 10"
 
 # UNFCU partner (limited access, 24-hour window)
-... generate --role unfcu --ttl 24h --device "UNFCU-Laptop-1"
+... generate --role partner --ttl 24h --device "Partner-Laptop-1"
 
 # Guest demo (Agent Zero UI only, 1-hour window)
 ... generate --role guest --ttl 1h
@@ -143,7 +143,7 @@ RUSTDESK_RELAY_HOST=<KVM2_IP> RUSTDESK_PUBLIC_KEY=<KEY> CHIT_PASSPHRASE=<secret>
 | Role | Tailscale Tag | Allowed Nodes | Allowed Ports |
 |------|--------------|--------------|--------------|
 | `owner` | `tag:pmoves` | All | All |
-| `unfcu` | `tag:unfcu` | 5090, Z890 | 3030, 8080, 8081 |
+| `partner` | `tag:partner` | 5090, Z890 | 3030, 8080, 8081 |
 | `guest` | `tag:guest` | Z890 | 8081 |
 
 ### Security Layers

--- a/pmoves/mk/infra.mk
+++ b/pmoves/mk/infra.mk
@@ -147,7 +147,7 @@ fleet-enroll: ## Generate CHIT-signed enrollment token: make fleet-enroll ROLE=o
 	@if [ -z "$(ROLE)" ] || [ -z "$(DEVICE)" ]; then \
 		echo "ERROR: ROLE and DEVICE are required."; \
 		echo "Usage:  make fleet-enroll ROLE=owner DEVICE=\"Pixel 10\""; \
-		echo "Roles:  owner, unfcu, guest"; \
+		echo "Roles:  owner, partner, guest"; \
 		exit 1; \
 	fi
 	@echo "=== Generating Enrollment Token ==="

--- a/pmoves/scripts/fleet/generate-enrollment.py
+++ b/pmoves/scripts/fleet/generate-enrollment.py
@@ -7,7 +7,7 @@ Enrollment tokens are CHIT-signed (HMAC-SHA256) and expire after TTL.
 
 Usage:
     python generate-enrollment.py --role owner --ttl 5m --device "Pixel 10"
-    python generate-enrollment.py --role unfcu --ttl 24h --device "UNFCU-Laptop-1"
+    python generate-enrollment.py --role partner --ttl 24h --device "Partner-Laptop-1"
     python generate-enrollment.py --role guest --ttl 1h
     python generate-enrollment.py --verify <token-json-file>
     python generate-enrollment.py --list  # show all unexpired tokens
@@ -43,9 +43,9 @@ ROLES = {
         "tailscale_tags": ["tag:pmoves"],
         "allowed_nodes": "*",
     },
-    "unfcu": {
-        "description": "UNFCU partner access — GPU nodes, agent + inference ports only",
-        "tailscale_tags": ["tag:unfcu"],
+    "partner": {
+        "description": "Partner access — GPU nodes, agent + inference ports only",
+        "tailscale_tags": ["tag:partner"],
         "allowed_nodes": ["pmoves-5090", "pmoves-z890"],
         "allowed_ports": [3030, 8080, 8081],
     },


### PR DESCRIPTION
## Summary
- Renames `tag:unfcu` → `tag:partner` across 6 config/doc/script files plus damage-control bypass
- Prevents premature client-name exposure in ACL policy, enrollment scripts, and documentation
- The generic "partner" role works for any external collaborator

Pre-existing bug found during PR #1181 review. Filed as a separate issue to keep the security-hardening PR focused.

## Files Changed
| File | Change |
|------|--------|
| `pmoves/configs/tailscale-acl-policy.json` | `tag:unfcu` → `tag:partner`, comment updated |
| `pmoves/scripts/fleet/generate-enrollment.py` | Role key, description, tag renamed |
| `.claude/commands/fleet/enroll.md` | Role list and table updated |
| `pmoves/docs/operations/RUSTDESK_SELF_HOSTED.md` | Example and role table updated |
| `pmoves/mk/infra.mk` | Help text roles list updated |
| `.claude/context/nats-subjects.md` | Payload example enum updated |
| `.claude/hooks/damage-control/patterns.yaml` | chitSafePaths entry for nats-subjects.md |

## Post-merge action
Apply updated ACL at https://login.tailscale.com/admin/acls. Check if any live devices have `tag:unfcu` assigned and update those.

Fixes #1173

## Test plan
- [ ] `grep -r "unfcu"` across changed files returns zero matches
- [ ] `python pmoves/scripts/fleet/generate-enrollment.py --help` still parses
- [ ] Updated ACL applied to Tailscale admin console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated enrollment guidance, payload examples, and help text to use the new role name "partner" (examples and role table updated accordingly).

* **Chores**
  * Updated access control mappings and enrollment tooling to reference the "partner" role and corresponding access tag.
  * Added a documentation path to the safety allowlist for management tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->