### PR TITLE
fix(n8n): add error handling to approval poller and webhook processor

### DIFF
--- a/pmoves/n8n/flows/approval_poller.json
+++ b/pmoves/n8n/flows/approval_poller.json
@@ -54,13 +54,13 @@
               }
             ]
           },
-          "options": {},
-          "onError": "continueErrorOutput"
+          "options": {}
         },
         "id": "fetch_supabase",
         "name": "Fetch Pending Approvals",
         "type": "n8n-nodes-base.httpRequest",
         "typeVersion": 4.1,
+        "onError": "continueErrorOutput",
         "position": [
           -280,
           180
@@ -114,13 +114,13 @@
             "parameters": []
           },
           "body": "={{ JSON.stringify($json.envelope) }}",
-          "options": {},
-          "onError": "continueErrorOutput"
+          "options": {}
         },
         "id": "publish_event",
         "name": "Publish Approval Event",
         "type": "n8n-nodes-base.httpRequest",
         "typeVersion": 4.1,
+        "onError": "continueErrorOutput",
         "position": [
           520,
           180
@@ -156,13 +156,13 @@
             "parameters": []
           },
           "body": "={{ JSON.stringify($node[\"Prepare Publish Envelope\"].json[\"patch\"]) }}",
-          "options": {},
-          "onError": "continueErrorOutput"
+          "options": {}
         },
         "id": "mark_processed",
         "name": "Mark Publish Requested",
         "type": "n8n-nodes-base.httpRequest",
         "typeVersion": 4.1,
+        "onError": "continueErrorOutput",
         "position": [
           780,
           180

--- a/pmoves/n8n/flows/approval_poller.json
+++ b/pmoves/n8n/flows/approval_poller.json
@@ -54,7 +54,8 @@
               }
             ]
           },
-          "options": {}
+          "options": {},
+          "onError": "continueErrorOutput"
         },
         "id": "fetch_supabase",
         "name": "Fetch Pending Approvals",
@@ -113,7 +114,8 @@
             "parameters": []
           },
           "body": "={{ JSON.stringify($json.envelope) }}",
-          "options": {}
+          "options": {},
+          "onError": "continueErrorOutput"
         },
         "id": "publish_event",
         "name": "Publish Approval Event",
@@ -154,7 +156,8 @@
             "parameters": []
           },
           "body": "={{ JSON.stringify($node[\"Prepare Publish Envelope\"].json[\"patch\"]) }}",
-          "options": {}
+          "options": {},
+          "onError": "continueErrorOutput"
         },
         "id": "mark_processed",
         "name": "Mark Publish Requested",
@@ -185,6 +188,19 @@
           240,
           -20
         ]
+      },
+      {
+        "parameters": {
+          "functionCode": "const errorNode = $input.item.json.$error?.node?.name || 'unknown';\nconst errorMessage = $input.item.json.$error?.message || 'No error message';\nconst timestamp = new Date().toISOString();\nconsole.error(`[approval_poller] Error in ${errorNode}: ${errorMessage} at ${timestamp}`);\nreturn { json: { error: true, node: errorNode, message: errorMessage, timestamp } };"
+        },
+        "id": "error_handler",
+        "name": "Error Handler",
+        "type": "n8n-nodes-base.functionItem",
+        "typeVersion": 1,
+        "position": [
+          520,
+          400
+        ]
       }
     ],
     "connections": {
@@ -204,6 +220,13 @@
           [
             {
               "node": "Split Pending Approvals",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Error Handler",
               "type": "main",
               "index": 0
             }
@@ -247,6 +270,13 @@
               "type": "main",
               "index": 0
             }
+          ],
+          [
+            {
+              "node": "Error Handler",
+              "type": "main",
+              "index": 0
+            }
           ]
         ]
       },
@@ -255,6 +285,13 @@
           [
             {
               "node": "Split Pending Approvals",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Error Handler",
               "type": "main",
               "index": 0
             }

--- a/pmoves/n8n/flows/github_webhook_processor.json
+++ b/pmoves/n8n/flows/github_webhook_processor.json
@@ -98,6 +98,7 @@
         "name": "Prepare Discord Notification",
         "type": "n8n-nodes-base.functionItem",
         "typeVersion": 1,
+        "onError": "continueErrorOutput",
         "position": [
           1540,
           120
@@ -111,13 +112,13 @@
           "sendBody": true,
           "specifyBody": "json",
           "jsonBody": "={{ $json.payload }}",
-          "options": {},
-          "onError": "continueErrorOutput"
+          "options": {}
         },
         "id": "send_discord",
         "name": "Send Discord Notification",
         "type": "n8n-nodes-base.httpRequest",
         "typeVersion": 4.1,
+        "onError": "continueErrorOutput",
         "position": [
           1760,
           120
@@ -246,6 +247,13 @@
           [
             {
               "node": "Send Discord Notification",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Error Handler",
               "type": "main",
               "index": 0
             }

--- a/pmoves/n8n/flows/github_webhook_processor.json
+++ b/pmoves/n8n/flows/github_webhook_processor.json
@@ -92,7 +92,7 @@
       },
       {
         "parameters": {
-          "functionCode": "const payload = $json.nats_payload;\nconst status = payload.payload?.status || 'unknown';\nconst conclusion = payload.payload?.conclusion || 'pending';\nconst repo = payload.payload?.repository || 'unknown';\nconst workflow = payload.payload?.workflow || 'unknown';\nconst runner = payload.payload?.runner || 'unknown';\n\nlet emoji = '⏳';\nif (status === 'in_progress') emoji = '🔄';\nelse if (status === 'completed') {\n  emoji = conclusion === 'success' ? '✅' : conclusion === 'failure' ? '❌' : '⚠️';\n}\n\nconst embed = {\n  title: `${emoji} GitHub Job ${status}`,\n  description: `**${workflow}** in ${repo}`,\n  color: conclusion === 'success' ? 0x00FF00 : conclusion === 'failure' ? 0xFF0000 : 0xFFFF00,\n  fields: [\n    {\n      name: 'Repository',\n      value: repo,\n      inline: true\n    },\n    {\n      name: 'Runner',\n      value: runner,\n      inline: true\n    },\n    {\n      name: 'Status',\n      value: status,\n      inline: true\n    },\n    {\n      name: 'Conclusion',\n      value: conclusion || 'pending',\n      inline: true\n    },\n    {\n      name: 'Job ID',\n      value: payload.payload?.job_id || 'unknown',\n      inline: false\n    },\n    {\n      name: 'Actor',\n      value: payload.payload?.actor || 'unknown',\n      inline: true\n    },\n    {\n      name: 'Timestamp',\n      value: payload.ts || new Date().toISOString(),\n      inline: false\n    }\n  ]\n};\n\nreturn {\n  json: {\n    webhookUrl: $env.DISCORD_WEBHOOK_URL || 'https://discord.com/api/webhooks/placeholder',\n    payload: {\n      username: 'PMOVES GitHub Runner Monitor',\n      embeds: [embed]\n    }\n  }\n};"
+          "functionCode": "const payload = $json.nats_payload;\nconst status = payload.payload?.status || 'unknown';\nconst conclusion = payload.payload?.conclusion || 'pending';\nconst repo = payload.payload?.repository || 'unknown';\nconst workflow = payload.payload?.workflow || 'unknown';\nconst runner = payload.payload?.runner || 'unknown';\n\nconst discordUrl = $env.DISCORD_WEBHOOK_URL;\nif (!discordUrl) {\n  throw new Error('DISCORD_WEBHOOK_URL not configured in n8n environment');\n}\n\nlet emoji = '⏳';\nif (status === 'in_progress') emoji = '🔄';\nelse if (status === 'completed') {\n  emoji = conclusion === 'success' ? '✅' : conclusion === 'failure' ? '❌' : '⚠️';\n}\n\nconst embed = {\n  title: `${emoji} GitHub Job ${status}`,\n  description: `**${workflow}** in ${repo}`,\n  color: conclusion === 'success' ? 0x00FF00 : conclusion === 'failure' ? 0xFF0000 : 0xFFFF00,\n  fields: [\n    {\n      name: 'Repository',\n      value: repo,\n      inline: true\n    },\n    {\n      name: 'Runner',\n      value: runner,\n      inline: true\n    },\n    {\n      name: 'Status',\n      value: status,\n      inline: true\n    },\n    {\n      name: 'Conclusion',\n      value: conclusion || 'pending',\n      inline: true\n    },\n    {\n      name: 'Job ID',\n      value: payload.payload?.job_id || 'unknown',\n      inline: false\n    },\n    {\n      name: 'Actor',\n      value: payload.payload?.actor || 'unknown',\n      inline: true\n    },\n    {\n      name: 'Timestamp',\n      value: payload.ts || new Date().toISOString(),\n      inline: false\n    }\n  ]\n};\n\nreturn {\n  json: {\n    webhookUrl: discordUrl,\n    payload: {\n      username: 'PMOVES GitHub Runner Monitor',\n      embeds: [embed]\n    }\n  }\n};"
         },
         "id": "prepare_notification",
         "name": "Prepare Discord Notification",
@@ -111,7 +111,8 @@
           "sendBody": true,
           "specifyBody": "json",
           "jsonBody": "={{ $json.payload }}",
-          "options": {}
+          "options": {},
+          "onError": "continueErrorOutput"
         },
         "id": "send_discord",
         "name": "Send Discord Notification",
@@ -161,6 +162,19 @@
         "position": [
           1320,
           380
+        ]
+      },
+      {
+        "parameters": {
+          "functionCode": "const errorNode = $input.item.json.$error?.node?.name || 'unknown';\nconst errorMessage = $input.item.json.$error?.message || 'No error message';\nconst timestamp = new Date().toISOString();\nconsole.error(`[github_webhook] Error in ${errorNode}: ${errorMessage} at ${timestamp}`);\nreturn { json: { error: true, node: errorNode, message: errorMessage, timestamp } };"
+        },
+        "id": "error_handler",
+        "name": "Error Handler",
+        "type": "n8n-nodes-base.functionItem",
+        "typeVersion": 1,
+        "position": [
+          1760,
+          340
         ]
       }
     ],
@@ -239,6 +253,24 @@
         ]
       },
       "Send Discord Notification": {
+        "main": [
+          [
+            {
+              "node": "Respond Success",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Error Handler",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Error Handler": {
         "main": [
           [
             {


### PR DESCRIPTION
## Summary
- **approval_poller.json**: Add `onError: continueErrorOutput` to 3 httpRequest nodes (`fetch_supabase`, `publish_event`, `mark_processed`) + Error Handler node that logs and dead-ends (no retry loop)
- **github_webhook_processor.json**: Replace dead placeholder Discord webhook URL with validation guard that throws if `DISCORD_WEBHOOK_URL` not configured; add `onError: continueErrorOutput` to `send_discord` + Error Handler that routes to `Respond Success` (webhook still returns 200)

Pre-existing bugs found during PR #1181 review. Filed as separate issues to keep the security-hardening PR focused.

Fixes #1186
Fixes #1187
Fixes #1188

## Test plan
- [ ] Both JSON files parse without errors
- [ ] `approval_poller.json`: all 3 httpRequest nodes have `onError`, `error_handler` node exists
- [ ] `github_webhook_processor.json`: `send_discord` has `onError`, `error_handler` node exists, no `placeholder` URL in `prepare_notification` code
- [ ] Error outputs wire to error handler (connection index 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflows now continue on upstream errors and capture structured error details with timestamps instead of stopping.
  * Error flows route to a centralized handler that records and returns consistent error information.

* **Improvements**
  * Discord notification flow now requires an explicit webhook configuration to avoid silent misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->