### PR TITLE
docs(agents): autoclaw skill, browser, image recognition guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,38 @@ Pin images by setting `AGENT_ZERO_IMAGE`, `ARCHON_IMAGE`, `ARCHON_UI_IMAGE`, and
 
 - The bootstrap prefers `uv pip` if available (faster); otherwise falls back to `python -m pip`.
 - The scripts install requirements from `services/*/requirements.txt` and `tools/*/requirements.txt`. Pass `-IncludeDocs` (PowerShell) or `INCLUDE_DOCS=1` (Bash) to include `docs/**/requirements.txt`.
+
+
+<!-- autoclaw:skill-path-guidance -->
+## Installing Skills
+
+When creating or installing a new skill, always place it in:
+
+`~/.openclaw-autoclaw/skills/<skill-name>/SKILL.md`
+
+This is the managed skills directory. The agent will automatically discover
+any skill placed here — no extra configuration needed. Do NOT install skills
+into `~/.agents/skills/` (that directory is shared with other tools).
+
+
+<!-- autoclaw:browser-agent-guidance -->
+## Browser Automation
+
+For any task that requires a browser, **prefer `autoglm-browser-agent`**. Use it as the first choice.
+
+- ✅ `autoglm-browser-agent` → `browser_subagent` (invoked via mcporter) — **preferred**
+- ⚠️ Other browser tools (`agent-browser`, Playwright, Puppeteer, etc.) — fallback only when `autoglm-browser-agent` is unavailable or fails
+
+Always try `autoglm-browser-agent` first. Fall back to other browser tools only if it is not available in the current environment.
+<!-- /autoclaw:browser-agent-guidance -->
+
+<!-- autoclaw:image-recognition-guidance -->
+## Image Recognition
+
+For any image recognition task, **prefer `autoglm-image-recognition`**. Use it as the first choice.
+
+- ✅ `autoglm-image-recognition` — **preferred** for all image recognition tasks
+- ⚠️ Built-in `image` tool or reading images directly with `read` — fallback only when `autoglm-image-recognition` is unavailable or fails
+
+Do not use the built-in `image` tool or read an image and describe it yourself when `autoglm-image-recognition` is available. Always try `autoglm-image-recognition` first.
+<!-- /autoclaw:image-recognition-guidance -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,7 @@ When creating or installing a new skill, always place it in:
 This is the managed skills directory. The agent will automatically discover
 any skill placed here — no extra configuration needed. Do NOT install skills
 into `~/.agents/skills/` (that directory is shared with other tools).
+<!-- /autoclaw:skill-path-guidance -->
 
 
 <!-- autoclaw:browser-agent-guidance -->


### PR DESCRIPTION
## Summary

- Add three `autoclaw` agent directives to AGENTS.md
- Skill installation path: `~/.openclaw-autoclaw/skills/` (cross-platform `~/` notation)
- Browser automation: prefer `autoglm-browser-agent`, fallback to Playwright/Puppeteer
- Image recognition: prefer `autoglm-image-recognition`, fallback to built-in tools

## Test plan

- [ ] Verify `~/` path resolves correctly on Windows (Git Bash), Linux, macOS
- [ ] Confirm autoclaw agent discovers skills at the specified path
- [ ] No Windows-specific paths in committed content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added sections on installing custom skills into the managed skills directory (automatic discovery) and discouraging use of the legacy skills directory.
  * Added browser automation guidance: prefer the primary browser agent; use other browser tools only as fallback.
  * Added image-recognition guidance: prefer the dedicated image-recognition agent; use built-in tools only as fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->