### PR TITLE
fix(tests): consolidate NATS fixtures (3 runtime tests rewired)

### DIFF
--- a/pmoves/tests/conftest.py
+++ b/pmoves/tests/conftest.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import socket
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Callable, Dict
 
 import pytest
+import pytest_asyncio
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -141,8 +144,10 @@ def stub_external_modules() -> None:
         client_module = ModuleType("nats.aio.client")
 
         class _FakeNATS:
+            is_connected = True
+
             async def connect(self, *args, **kwargs):  # pragma: no cover - trivial
-                return None
+                return self
 
             async def publish(self, *args, **kwargs):  # pragma: no cover - trivial
                 return None
@@ -154,6 +159,56 @@ def stub_external_modules() -> None:
         _install_module("nats", nats_module)
         _install_module("nats.aio", aio_module)
         _install_module("nats.aio.client", client_module)
+
+
+@pytest.fixture(scope="session")
+def nats_url() -> str:
+    """Return the canonical authenticated NATS URL.
+
+    Prefers the NATS_URL environment variable (useful for CI overrides);
+    otherwise falls back to the production-authenticated default used
+    throughout PMOVES.AI (``nats://nats:pmoves@nats:4222``).
+    """
+    return os.environ.get("NATS_URL", "nats://nats:pmoves@nats:4222")
+
+
+@pytest.fixture(scope="session")
+def nats_available() -> bool:
+    """Return True when a NATS broker is reachable on localhost:4222."""
+    try:
+        with socket.create_connection(("127.0.0.1", 4222), timeout=1.0):
+            return True
+    except OSError:
+        return False
+
+
+@pytest_asyncio.fixture(scope="function")
+async def nats_client(nats_url: str, nats_available: bool):
+    """Yield an authenticated NATS client or skip when broker is unavailable.
+
+    The session-wide ``stub_external_modules`` fixture installs a lightweight
+    fake ``nats`` module so unit tests can import ``nats`` without the real
+    dependency. This fixture bypasses that stub and loads the real
+    ``nats-py`` package (installed in CI when a broker is running).
+    """
+    if not nats_available:
+        pytest.skip("NATS not reachable on localhost:4222")
+    import importlib
+
+    for mod_name in ("nats", "nats.aio", "nats.aio.client"):
+        sys.modules.pop(mod_name, None)
+    try:
+        nats_real = importlib.import_module("nats")
+    except ImportError:
+        pytest.skip("nats-py not installed")
+    nc = await nats_real.connect(nats_url)
+    try:
+        yield nc
+    finally:
+        try:
+            await nc.close()
+        except Exception:
+            pass
 
 
 @pytest.fixture(scope="session")

--- a/pmoves/tests/functional/test_a2ui_bridge_integration.py
+++ b/pmoves/tests/functional/test_a2ui_bridge_integration.py
@@ -78,52 +78,35 @@ async def test_a2ui_simulate_endpoint():
 
 
 @pytest.mark.asyncio
-async def test_nats_stream_exists():
-    """Test that the A2UI NATS stream is created."""
-    try:
-        import nats
-    except ImportError:
-        pytest.skip("nats-py not installed")
+async def test_nats_stream_exists(nats_client):
+    """Test that the A2UI NATS stream is created.
 
-    try:
-        nc = await nats.connect("nats://localhost:4222")
-        js = nc.jetstream()
+    Uses the session-scoped ``nats_client`` fixture (see
+    ``pmoves/tests/conftest.py``) which handles authentication and
+    skips cleanly when the broker is unavailable.
+    """
+    js = nats_client.jetstream()
 
-        # Verify A2UI stream exists
-        streams = await js.streams_info()
-        stream_names = [s.config.name for s in streams]
-        assert "A2UI" in stream_names
+    # Verify A2UI stream exists
+    streams = await js.streams_info()
+    stream_names = [s.config.name for s in streams]
+    assert "A2UI" in stream_names
 
-        # Verify stream configuration
-        a2ui_stream = await js.stream_info("A2UI")
-        assert a2ui_stream is not None
-
-        await nc.close()
-    except ConnectionRefusedError:
-        pytest.skip("NATS server not available at nats://localhost:4222")
+    # Verify stream configuration
+    a2ui_stream = await js.stream_info("A2UI")
+    assert a2ui_stream is not None
 
 
 @pytest.mark.asyncio
-async def test_nats_a2ui_subjects():
+async def test_nats_a2ui_subjects(nats_client):
     """Test that A2UI subjects are configured."""
-    try:
-        import nats
-    except ImportError:
-        pytest.skip("nats-py not installed")
+    js = nats_client.jetstream()
 
-    try:
-        nc = await nats.connect("nats://localhost:4222")
-        js = nc.jetstream()
+    stream_info = await js.stream_info("A2UI")
+    subjects = stream_info.config.subjects
 
-        stream_info = await js.stream_info("A2UI")
-        subjects = stream_info.config.subjects
-
-        # Verify expected subjects
-        assert "a2ui.render.v1" in subjects or any("a2ui.>" in s for s in subjects)
-
-        await nc.close()
-    except ConnectionRefusedError:
-        pytest.skip("NATS server not available")
+    # Verify expected subjects
+    assert "a2ui.render.v1" in subjects or any("a2ui.>" in s for s in subjects)
 
 
 @pytest.mark.asyncio

--- a/pmoves/tests/functional/test_tokenism_simulator.py
+++ b/pmoves/tests/functional/test_tokenism_simulator.py
@@ -237,22 +237,18 @@ class TestTokenismSimulatorIntegrations:
         """Get the base URL for the tokenism-simulator service."""
         return os.getenv('TOKENISM_URL', 'http://localhost:8100')
 
-    @pytest.fixture
-    def nats_url(self) -> str:
-        """Get the NATS URL."""
-        return os.getenv('NATS_URL', 'nats://localhost:4222')
+    @pytest.mark.asyncio
+    async def test_nats_connection(self, nats_client):
+        """Test that NATS is accessible (for publishing simulation results).
 
-    def test_nats_connection(self, nats_url: str):
-        """Test that NATS is accessible (for publishing simulation results)."""
-        try:
-            import nats
-            nc = nats.connect(nats_url, timeout=5)
-            assert nc.is_connected
-            nc.close()
-        except ImportError:
-            pytest.skip("nats library not available")
-        except Exception as e:
-            pytest.skip(f"NATS not available: {e}")
+        Uses the session-scoped ``nats_client`` fixture from
+        ``pmoves/tests/conftest.py`` which enforces the canonical
+        authenticated URL and skips cleanly when the broker is
+        unreachable. Previously this test called the synchronous
+        ``nats.connect()`` as a classmethod, which is not part of the
+        nats-py API and always raised.
+        """
+        assert nats_client.is_connected
 
     def test_tensorzero_connection(self):
         """Test that TensorZero gateway is accessible (for LLM analysis)."""


### PR DESCRIPTION
## Summary

Consolidates NATS test fixtures into a session-scoped `conftest.py` so runtime tests stop hardcoding unauthenticated URLs and stop invoking `nats.connect()` as a non-existent classmethod.

Three new fixtures added to `pmoves/tests/conftest.py`:

- `nats_url` — session-scoped, defaults to canonical `nats://nats:pmoves@nats:4222`, honours `NATS_URL` override
- `nats_available` — cheap socket probe on `127.0.0.1:4222` for clean skip when broker is down
- `nats_client` — async fixture that bypasses the autouse `_FakeNATS` stub (pops `nats*` from `sys.modules` before `importlib.import_module`), connects with real `nats-py`, and tears down on exit

Three tests rewired to use the fixture:

- `tests/functional/test_a2ui_bridge_integration.py::test_nats_stream_exists`
- `tests/functional/test_a2ui_bridge_integration.py::test_nats_a2ui_subjects`
- `tests/functional/test_tokenism_simulator.py::TestTokenismSimulatorIntegrations::test_nats_connection` (converted sync->async; local `nats_url` fixture with unauthenticated default removed)

`_FakeNATS.connect()` widened to return `self` with `is_connected=True` so unit tests that accidentally import the stub don't crash on silent `AttributeError`.

## Scope note

Task brief mentioned ~8-9 failing NATS tests. Investigation showed **only 3 actually open a NATS connection at runtime**. The rest (`smoke/test_nats_configuration.py`, `smoke/test_nats_authentication.py`, `test_clawz_field.py`, `a2ui/test_bridge.py`, etc.) are static env/doc grep checks that already skip or never open sockets — left alone per task constraints.

## Files changed

- `pmoves/tests/conftest.py` (+53 lines)
- `pmoves/tests/functional/test_a2ui_bridge_integration.py` (-25 lines net — fixture-managed skips replaced try/except wrappers)
- `pmoves/tests/functional/test_tokenism_simulator.py` (-11 lines net)

## Not touched (per task constraints)

- NATS service code, `docker-compose.yml`, tier env files
- `tests/smoke/test_port_conflicts.py`
- `tests/smoke/test_service_contracts.py`
- `tests/hardening/test_docker_hardening.py`
- Any encoding test or non-Python file

## Testing

### Collection
```
cd pmoves && python -m pytest \
  tests/functional/test_a2ui_bridge_integration.py \
  tests/functional/test_tokenism_simulator.py \
  --collect-only -q
```
Result: **19 tests collected cleanly**, `test_nats_connection` now a `<Coroutine>`.

### Target tests (broker not running locally -> expect skipped, not failed)
```
cd pmoves && python -m pytest \
  tests/functional/test_a2ui_bridge_integration.py::test_nats_stream_exists \
  tests/functional/test_a2ui_bridge_integration.py::test_nats_a2ui_subjects \
  "tests/functional/test_tokenism_simulator.py::TestTokenismSimulatorIntegrations::test_nats_connection" \
  -v
```
Result: **3 skipped, 0 failed** (reason: "NATS not reachable on localhost:4222").

### Regression check (smoke/a2ui)
- `tests/smoke -k nats` — same 7 pre-existing `env.shared`-dependent failures (unrelated, file is runtime-generated and gitignored)
- `tests/a2ui` — same pre-existing `ModuleNotFoundError: No module named 'bridge'` collection error (unrelated)

Both pre-existing failures confirmed out of scope and not introduced by this change.

## Test plan

- [ ] CI runs with NATS broker available — 3 rewired tests should execute and assert against real JetStream stream config
- [ ] CI runs without NATS broker — 3 rewired tests skip cleanly (no fails)
- [ ] Other NATS-adjacent unit tests that import the `_FakeNATS` stub still pass (widened `connect()` return)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced NATS integration test infrastructure with environment-aware fixtures and automatic availability detection.
  * Improved test reliability with graceful skipping when the message broker is unreachable.
  * Refactored functional tests to use shared NATS client fixtures for consistent connection handling and reduced code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->