### PR TITLE
fix(pr-monitor): correct repo auto-detect and default base branch

### DIFF
--- a/pmoves/mk/preflight.mk
+++ b/pmoves/mk/preflight.mk
@@ -229,10 +229,10 @@ topology-chit-gate-strict: ## Strict topology+CHIT gate (warnings fail)
 	$$runner tools/topology_chit_gate.py --strict $(ARGS)
 
 pr-monitor: ## Monitor PR merge readiness incl actionable/nitpick/out-of-diff review learnings
-	@$(PRECHECK_PY) tools/pr_monitor.py --base "$${PR_MONITOR_BASE:-PMOVES.AI-Edition-Hardened}" --json-out "docs/logs/pr_monitor_latest.json" --learnings-out "docs/logs/pr_monitor_learnings_latest.md" $(ARGS)
+	@$(PRECHECK_PY) tools/pr_monitor.py $${PR_MONITOR_REPO:+--repo "$$PR_MONITOR_REPO"} --base "$${PR_MONITOR_BASE:-main}" --json-out "docs/logs/pr_monitor_latest.json" --learnings-out "docs/logs/pr_monitor_learnings_latest.md" $(ARGS)
 
 pr-monitor-strict: ## Strict PR monitor (non-zero when blockers remain)
-	@$(PRECHECK_PY) tools/pr_monitor.py --base "$${PR_MONITOR_BASE:-PMOVES.AI-Edition-Hardened}" --strict --json-out "docs/logs/pr_monitor_latest.json" --learnings-out "docs/logs/pr_monitor_learnings_latest.md" $(ARGS)
+	@$(PRECHECK_PY) tools/pr_monitor.py $${PR_MONITOR_REPO:+--repo "$$PR_MONITOR_REPO"} --base "$${PR_MONITOR_BASE:-main}" --strict --json-out "docs/logs/pr_monitor_latest.json" --learnings-out "docs/logs/pr_monitor_learnings_latest.md" $(ARGS)
 
 pr-monitor-chit-packet: ## Encode PR monitor learnings into CHIT packet artifact
 	@$(MAKE) --no-print-directory pr-monitor

--- a/pmoves/tools/pr_monitor.py
+++ b/pmoves/tools/pr_monitor.py
@@ -103,7 +103,42 @@ def _run_json(cmd: list[str]) -> Any:
     return json.loads(payload)
 
 
+def _parse_origin_remote() -> str | None:
+    """Parse owner/repo from the origin remote URL.
+
+    Prefers origin over whatever `gh repo view` auto-detects, because checkouts
+    with both origin (fork) and upstream (parent) remotes can confuse gh's
+    auto-detection and return the upstream instead of the fork being worked on.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            text=True, capture_output=True, check=False, encoding="utf-8",
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    url = proc.stdout.strip()
+    if not url:
+        return None
+    # Handle both SSH (git@github.com:owner/repo.git) and HTTPS (https://github.com/owner/repo.git)
+    for prefix in ("git@github.com:", "https://github.com/", "ssh://git@github.com/"):
+        if url.startswith(prefix):
+            url = url[len(prefix):]
+            break
+    if url.endswith(".git"):
+        url = url[:-4]
+    if "/" in url and url.count("/") == 1:
+        return url
+    return None
+
+
 def _repo_name(default_repo: str) -> str:
+    # Prefer origin remote over gh auto-detection (which may return upstream).
+    origin = _parse_origin_remote()
+    if origin:
+        return origin
     try:
         data = _run_json(["gh", "repo", "view", "--json", "nameWithOwner"])
     except RuntimeError:
@@ -591,7 +626,7 @@ def main(argv: list[str] | None = None) -> int:
         default="",
         help="owner/repo override (default: auto-detect from current checkout, fallback POWERFULMOVES/PMOVES.AI)",
     )
-    parser.add_argument("--base", default="PMOVES.AI-Edition-Hardened", help="base branch filter (default: PMOVES.AI-Edition-Hardened)")
+    parser.add_argument("--base", default="main", help="base branch filter (default: main; use PMOVES.AI-Edition-Hardened for submodule tiers)")
     parser.add_argument("--state", default="open", choices=["open", "closed", "merged", "all"], help="PR state filter")
     parser.add_argument("--pr", dest="prs", action="append", type=int, default=[], help="monitor specific PR number (repeatable)")
     parser.add_argument("--json-out", type=Path, default=None, help="write full monitor payload as JSON")


### PR DESCRIPTION
## Summary

Stream D of Session 10 parallel orchestration — fixes the \`make -C pmoves pr-monitor\` command so it surfaces real PRs from POWERFULMOVES/PMOVES.AI on \`main\` instead of producing the confusing \"No PRs found for repo=openclaw/openclaw state=open base=PMOVES.AI-Edition-Hardened\" message.

### Root causes

1. **Wrong repo auto-detection.** On checkouts that have both \`origin\` (the POWERFULMOVES fork being worked on) and \`upstream\` (openclaw/openclaw), \`gh repo view --json nameWithOwner\` returns the upstream instead of the origin. \`pmoves/tools/pr_monitor.py::_repo_name\` used that output directly.

2. **Wrong base branch default.** The tool's \`--base\` default was \`PMOVES.AI-Edition-Hardened\`, which is the submodule tier-llm base branch, not the top-level PMOVES.AI main branch. Top-level PRs target \`main\`, so default monitoring returned zero results.

3. **PR_MONITOR_REPO env var was not forwarded** by the Makefile target even though the tool supported \`--repo\` explicitly.

### Fix

- \`pmoves/tools/pr_monitor.py\`: \`_repo_name()\` now parses \`git config --get remote.origin.url\` first (handles SSH and HTTPS), falls back to \`gh repo view\`, then to the explicit default \`POWERFULMOVES/PMOVES.AI\`. Changed \`--base\` default from \`PMOVES.AI-Edition-Hardened\` to \`main\` (with a docstring note that submodule tier monitoring can override).
- \`pmoves/mk/preflight.mk\`: \`pr-monitor\` and \`pr-monitor-strict\` targets now forward \`PR_MONITOR_REPO\` as \`--repo\` when set, and default \`PR_MONITOR_BASE\` to \`main\`.

### Verification

Before:
\`\`\`
$ make -C pmoves pr-monitor
No PRs found for repo=openclaw/openclaw state=open base=PMOVES.AI-Edition-Hardened
\`\`\`

After:
\`\`\`
$ make -C pmoves pr-monitor
| PR | Mergeable | Checks (P/F/Q) | Review (A/N/OOD) | Blockers | Title |
| #1179 | MERGEABLE/BLOCKED | 8/1/0 | 4/3/8 | merge_state=BLOCKED, ... |
| #1189 | MERGEABLE/BLOCKED | 18/0/0 | 3/1/6 | ... |
| #1193 | MERGEABLE/BLOCKED | 6/0/0 | 2/0/2 | ... |
(7 PRs total)
\`\`\`

Env override also works: \`make -C pmoves pr-monitor PR_MONITOR_REPO=POWERFULMOVES/PMOVES.AI\`

## Test plan
- [x] Verify \`make -C pmoves pr-monitor\` shows all open PRs
- [x] Verify \`PR_MONITOR_REPO=foo/bar\` env override is respected
- [x] Verify \`PR_MONITOR_BASE=PMOVES.AI-Edition-Hardened\` env override still works for submodule tier monitoring
- [ ] CI runs pytest suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PR monitor tool now automatically detects repository ownership and project identifiers from git configuration, with fallback detection methods for enhanced flexibility.

* **Changes**
  * Default base branch updated to `main` instead of the previously configured hardened version.
  * Build system now conditionally passes repository parameters based on environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->