### PR TITLE
fix(infra): model-registry Dockerfile + bringup-layered Make override

### DIFF
--- a/pmoves/Makefile
+++ b/pmoves/Makefile
@@ -929,13 +929,13 @@ up-minimal: ## Start minimal stack (Supabase + Data + Bus only)
 
 .PHONY: bringup-layered
 bringup-layered: ## Deterministic local layered bring-up (minimal -> model-mgmt -> workers -> agents -> monitoring -> prod smoke)
-	@echo "🚀 Layered local bring-up (runtime=$${SUPABASE_RUNTIME:-cli})"
-	@SUPABASE_RUNTIME=$${SUPABASE_RUNTIME:-cli} $(MAKE) --no-print-directory up-minimal
-	@SUPABASE_RUNTIME=$${SUPABASE_RUNTIME:-cli} $(MAKE) --no-print-directory up-model-management
-	@SUPABASE_RUNTIME=$${SUPABASE_RUNTIME:-cli} $(MAKE) --no-print-directory up-workers
-	@SUPABASE_RUNTIME=$${SUPABASE_RUNTIME:-cli} $(MAKE) --no-print-directory up-agents
-	@SUPABASE_RUNTIME=$${SUPABASE_RUNTIME:-cli} $(MAKE) --no-print-directory up-monitoring
-	@SUPABASE_RUNTIME=$${SUPABASE_RUNTIME:-cli} $(MAKE) --no-print-directory smoke-prod
+	@echo "🚀 Layered local bring-up (runtime=$(SUPABASE_RUNTIME))"
+	@$(MAKE) --no-print-directory up-minimal
+	@$(MAKE) --no-print-directory up-model-management
+	@$(MAKE) --no-print-directory up-workers
+	@$(MAKE) --no-print-directory up-agents
+	@$(MAKE) --no-print-directory up-monitoring
+	@$(MAKE) --no-print-directory smoke-prod
 	@echo "✅ Layered local bring-up passed"
 
 .PHONY: up-model-management

--- a/pmoves/services/model-registry/Dockerfile
+++ b/pmoves/services/model-registry/Dockerfile
@@ -19,7 +19,7 @@ RUN groupadd -r pmoves --gid=65532 && \
     useradd -r -g pmoves --uid=65532 --home-dir=/app --shell=/sbin/nologin pmoves
 
 # Copy application with correct ownership
-COPY --chown=pmoves:pmoves main.py .
+COPY --chown=pmoves:pmoves *.py .
 
 # Switch to non-root user
 USER pmoves:pmoves


### PR DESCRIPTION
## Summary
- **model-registry Dockerfile:** Changed `COPY main.py` → `COPY *.py` to include `hf_client.py` — container was crash-looping with `ModuleNotFoundError` because the HuggingFace client module wasn't copied into the image
- **Makefile bringup-layered:** Removed redundant shell `${SUPABASE_RUNTIME:-cli}` override that was shadowing the Make-level `?= compose` default at line 30 — `$(MAKE)` already inherits Make variables

## Test plan
- [x] model-registry rebuilt and healthy (35th healthy container, verified via `docker ps`)
- [ ] `make -C pmoves -n bringup-layered` echoes `runtime=compose` (not `cli`)
- [ ] `make bringup-layered SUPABASE_RUNTIME=cli` override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and deployment infrastructure by streamlining environment variable handling in the build process.
  * Enhanced Docker image building to ensure all required application files are included during the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->