### PR TITLE
feat(registry): GPU models, Supabase seed, coder_claw profile, flare namespace

### DIFF
--- a/pmoves/config/gpu-models.yaml
+++ b/pmoves/config/gpu-models.yaml
@@ -219,6 +219,41 @@ models:
     quantization: "Q4_K_M"
     context_length: 131072
 
+  # NVIDIA Nemotron Super 49B (NIM container)
+  - id: "nemotron-super:49b"
+    provider: nvidia_nim
+    vram_mb: 30000
+    description: "NVIDIA Nemotron Super 49B - Requires NIM container, exclusive GPU access at 30GB"
+    priority_default: 9
+    quantization: "FP8"
+    context_length: 131072
+
+  # Qwen3-Coder-Next 80B MoE
+  - id: "qwen3-coder-next:80b"
+    provider: ollama
+    vram_mb: 7000
+    description: "Qwen3-Coder-Next 80B MoE - SWE-Bench SOTA, 3B active params. Apache 2.0"
+    priority_default: 9
+    quantization: "MoE-3B-active"
+    context_length: 262144
+
+  # Gemma 3n Family (Google edge-optimized multimodal)
+  - id: "gemma3n:e4b"
+    provider: ollama
+    vram_mb: 3500
+    description: "Google Gemma 3n E4B - Edge multimodal (text/image/video/audio), Per-Layer Embeddings"
+    priority_default: 5
+    quantization: "E4B"
+    context_length: 32768
+
+  - id: "gemma3n:e2b"
+    provider: ollama
+    vram_mb: 2000
+    description: "Google Gemma 3n E2B - Compact multimodal for Jetson edge deployment"
+    priority_default: 4
+    quantization: "E2B"
+    context_length: 32768
+
   # TTS Models (Ultimate TTS Studio)
   - id: "kokoro"
     provider: tts

--- a/pmoves/configs/agent-profiles/coder_claw.yaml
+++ b/pmoves/configs/agent-profiles/coder_claw.yaml
@@ -36,6 +36,7 @@ nats:
   publish:
     - mesh.gpu.status.v1
     - mesh.gpu.model.loaded.v1
+    - mesh.gpu.model.unloaded.v1  # model-registry depends on both load and unload events
     - mesh.gpu.command.result.v1
 
 exec_permissions:

--- a/pmoves/configs/agent-profiles/coder_claw.yaml
+++ b/pmoves/configs/agent-profiles/coder_claw.yaml
@@ -1,0 +1,59 @@
+# Coder Claw — Coding-Specialist GPU Claw
+# Hybrid: OpenClaw + TensorZero + NATS mesh participation
+#
+# Runs on 5090/4090 nodes for local coding inference using Qwen3-Coder-Next MoE.
+# SWE-Bench SOTA model with 80B total / 3B active params (Apache 2.0).
+# Communicates with fleet via NATS mesh.gpu.* subjects.
+
+name: coder_claw
+role: coding-specialist
+description: "Coding-focused agent backed by Qwen3-Coder-Next MoE model for code generation, review, and refactoring"
+
+node_affinity:
+  - 5090
+  - 4090
+hostname_pattern: "coder-claw-*"
+
+model:
+  provider: ollama
+  model: qwen3-coder-next:80b
+  endpoint: http://localhost:11434
+  fallback: tensorzero
+
+capabilities:
+  - code_generation
+  - code_review
+  - refactoring
+  - test_generation
+  - local_inference
+  - gpu_monitoring
+
+nats:
+  url: nats://nats:pmoves@nats:4222
+  subscribe:
+    - mesh.gpu.command.v1
+    - pinokio.agent.session.v1
+  publish:
+    - mesh.gpu.status.v1
+    - mesh.gpu.model.loaded.v1
+    - mesh.gpu.command.result.v1
+
+exec_permissions:
+  - nvidia-smi
+  - python3
+  - curl
+  - git
+  - make
+  - nats
+  - ollama
+
+health:
+  endpoint: null  # No HTTP endpoint — health via NATS heartbeat
+  heartbeat_subject: mesh.gpu.status.v1
+  heartbeat_interval_seconds: 10
+
+agent_zero:
+  subordinate: true
+  profile: coder_claw
+  inherit_context: true
+  report_to: agent_zero

--- a/pmoves/configs/agent-profiles/nemoclaw.yaml
+++ b/pmoves/configs/agent-profiles/nemoclaw.yaml
@@ -18,6 +18,12 @@ model:
   endpoint: http://localhost:11434
   fallback: null  # No fallback — local inference only
 
+multimodal_alternate:
+  provider: ollama
+  model: gemma3n:e2b
+  endpoint: http://localhost:11434
+  purpose: "Edge image/video/audio processing via Gemma 3n E2B multimodal"
+
 capabilities:
   - local_inference
   - gpu_monitoring

--- a/pmoves/configs/flare-model-namespace.yaml
+++ b/pmoves/configs/flare-model-namespace.yaml
@@ -59,3 +59,36 @@ mappings:
     lane: "local"
     nodes: [z890, 5090]
     purpose: "embeddings"
+
+  # --- NVIDIA NIM ---
+  nemotron-super:
+    flare_name: "pmoves/nemotron-super-49b"
+    provider: "nvidia_nim"
+    model_id: "nvidia/llama-3_3-nemotron-super-49b-v1"
+    lane: "local"
+    nodes: [5090]
+    vllm_compatible: false
+
+  # --- Coding ---
+  qwen-coder-next:
+    flare_name: "pmoves/qwen-3-coder-next-80b"
+    provider: "ollama"
+    model_id: "qwen3-coder-next:80b"
+    lane: "local"
+    nodes: [5090, 4090]
+    vllm_compatible: true
+
+  # --- Edge Multimodal ---
+  gemma-3n-e4b:
+    flare_name: "pmoves/gemma-3n-e4b"
+    provider: "ollama"
+    model_id: "gemma3n:e4b"
+    lane: "local"
+    nodes: [5090, 4090]
+
+  gemma-3n-e2b:
+    flare_name: "pmoves/gemma-3n-e2b"
+    provider: "ollama"
+    model_id: "gemma3n:e2b"
+    lane: "edge"
+    nodes: [jetson]

--- a/pmoves/supabase/initdb/12_model_registry_seed.sql
+++ b/pmoves/supabase/initdb/12_model_registry_seed.sql
@@ -237,15 +237,18 @@ ON CONFLICT (name) DO UPDATE SET
   updated_at = NOW();
 
 -- NVIDIA NIM (local NIM container runtime)
+-- Name matches the canonical key used in pmoves/config/model_nexus.yaml,
+-- pmoves/configs/agent-profiles/nemotron_claw.yaml, and
+-- pmoves/configs/flare-model-namespace.yaml.
 INSERT INTO pmoves_core.model_providers (name, type, api_base, api_key_env_var, description, active, metadata)
 VALUES (
-  'nvidia_nim_local',
+  'nvidia_nim',
   'openai_compatible',
-  'http://localhost:8000/v1',
-  NULL,
+  'http://nvidia-nim:8000/v1',
+  'NGC_API_KEY',
   'NVIDIA NIM local container runtime for Nemotron models',
   true,
-  '{"network": "internal", "location": "local", "runtime": "nim"}'::jsonb
+  '{"network": "pmoves_api", "location": "local", "runtime": "nim"}'::jsonb
 )
 ON CONFLICT (name) DO UPDATE SET
   type = EXCLUDED.type,
@@ -637,7 +640,7 @@ DO $$
 DECLARE
   v_nim_local_id UUID;
 BEGIN
-  SELECT id INTO v_nim_local_id FROM pmoves_core.model_providers WHERE name = 'nvidia_nim_local';
+  SELECT id INTO v_nim_local_id FROM pmoves_core.model_providers WHERE name = 'nvidia_nim';
 
   -- Nemotron Super 49B - Agentic NIM model requiring exclusive GPU
   INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)

--- a/pmoves/supabase/initdb/12_model_registry_seed.sql
+++ b/pmoves/supabase/initdb/12_model_registry_seed.sql
@@ -236,6 +236,26 @@ ON CONFLICT (name) DO UPDATE SET
   metadata = EXCLUDED.metadata,
   updated_at = NOW();
 
+-- NVIDIA NIM (local NIM container runtime)
+INSERT INTO pmoves_core.model_providers (name, type, api_base, api_key_env_var, description, active, metadata)
+VALUES (
+  'nvidia_nim_local',
+  'openai_compatible',
+  'http://localhost:8000/v1',
+  NULL,
+  'NVIDIA NIM local container runtime for Nemotron models',
+  true,
+  '{"network": "internal", "location": "local", "runtime": "nim"}'::jsonb
+)
+ON CONFLICT (name) DO UPDATE SET
+  type = EXCLUDED.type,
+  api_base = EXCLUDED.api_base,
+  api_key_env_var = EXCLUDED.api_key_env_var,
+  description = EXCLUDED.description,
+  active = EXCLUDED.active,
+  metadata = EXCLUDED.metadata,
+  updated_at = NOW();
+
 -- =============================================================================
 -- Local Chat Models (Ollama)
 -- =============================================================================
@@ -534,6 +554,102 @@ BEGIN
     2500,
     128000,
     'Phi3 Mini 3.8B - Edge deployment with 128k context',
+    true
+  )
+  ON CONFLICT (provider_id, model_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    capabilities = EXCLUDED.capabilities,
+    vram_mb = EXCLUDED.vram_mb,
+    context_length = EXCLUDED.context_length,
+    description = EXCLUDED.description,
+    updated_at = NOW();
+
+  -- Qwen3-Coder-Next 80B MoE - SWE-Bench SOTA coding model
+  INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
+  VALUES (
+    v_ollama_local_id,
+    'qwen3_coder_next_80b_local',
+    'qwen3-coder-next:80b',
+    'chat',
+    '["chat", "code_generation", "code_review", "function_calling", "json_mode"]'::jsonb,
+    7000,
+    262144,
+    'Qwen3-Coder-Next 80B MoE - 3B active params, SWE-Bench SOTA. Apache 2.0',
+    true
+  )
+  ON CONFLICT (provider_id, model_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    capabilities = EXCLUDED.capabilities,
+    vram_mb = EXCLUDED.vram_mb,
+    context_length = EXCLUDED.context_length,
+    description = EXCLUDED.description,
+    updated_at = NOW();
+
+  -- Gemma 3n E4B - Edge-optimized multimodal
+  INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
+  VALUES (
+    v_ollama_local_id,
+    'gemma_3n_e4b_local',
+    'gemma3n:e4b',
+    'chat',
+    '["chat", "vision", "video", "audio", "multimodal"]'::jsonb,
+    3500,
+    32768,
+    'Google Gemma 3n E4B - Edge multimodal with Per-Layer Embeddings',
+    true
+  )
+  ON CONFLICT (provider_id, model_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    capabilities = EXCLUDED.capabilities,
+    vram_mb = EXCLUDED.vram_mb,
+    context_length = EXCLUDED.context_length,
+    description = EXCLUDED.description,
+    updated_at = NOW();
+
+  -- Gemma 3n E2B - Compact edge multimodal (Jetson)
+  INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
+  VALUES (
+    v_ollama_edge_id,
+    'gemma_3n_e2b_edge',
+    'gemma3n:e2b',
+    'chat',
+    '["chat", "vision", "video", "audio", "multimodal"]'::jsonb,
+    2000,
+    32768,
+    'Google Gemma 3n E2B - Compact multimodal for Jetson edge deployment',
+    true
+  )
+  ON CONFLICT (provider_id, model_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    capabilities = EXCLUDED.capabilities,
+    vram_mb = EXCLUDED.vram_mb,
+    context_length = EXCLUDED.context_length,
+    description = EXCLUDED.description,
+    updated_at = NOW();
+
+END $$;
+
+-- =============================================================================
+-- NVIDIA NIM Local Models
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_nim_local_id UUID;
+BEGIN
+  SELECT id INTO v_nim_local_id FROM pmoves_core.model_providers WHERE name = 'nvidia_nim_local';
+
+  -- Nemotron Super 49B - Agentic NIM model requiring exclusive GPU
+  INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
+  VALUES (
+    v_nim_local_id,
+    'nemotron_super_49b_local',
+    'nvidia/llama-3_3-nemotron-super-49b-v1',
+    'chat',
+    '["chat", "function_calling", "json_mode", "tool_use", "agentic_reasoning"]'::jsonb,
+    30000,
+    131072,
+    'NVIDIA Nemotron Super 49B - FP8, requires NIM container with exclusive GPU access',
     true
   )
   ON CONFLICT (provider_id, model_id) DO UPDATE SET


### PR DESCRIPTION
## Summary

- 4 new GPU model entries in `gpu-models.yaml` with VRAM budgets and node affinity
- `nvidia_nim_local` provider + 4 model entries in Supabase registry seed (idempotent ON CONFLICT)
- New `coder_claw` agent profile: Qwen3-Coder-Next coding specialist (5090/4090, Agent Zero subordinate)
- `nemoclaw` updated with `multimodal_alternate` pointing to Gemma 3n for edge inference
- 4 new flare model namespace mappings

## Files

- `pmoves/config/gpu-models.yaml` — 4 model entries
- `pmoves/supabase/initdb/12_model_registry_seed.sql` — provider + 4 models
- `pmoves/configs/agent-profiles/coder_claw.yaml` — new profile
- `pmoves/configs/agent-profiles/nemoclaw.yaml` — multimodal alternate
- `pmoves/configs/flare-model-namespace.yaml` — 4 flare mappings

## Test plan

- [ ] SQL seed is idempotent (re-run safe via ON CONFLICT)
- [ ] `coder_claw.yaml` schema matches existing profiles (nemoclaw, etc.)
- [ ] Flare namespace entries don't conflict with existing mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)