### PR TITLE
fix(hooks): CHIT bypass for with-env.sh + Git state cleanup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -260,6 +260,44 @@ make -C pmoves auth-alignment     # Cross-tier credential consistency check
 - `pmoves/tools/brand_defaults.py` - Applies seeded branded defaults (auto-generates Neo4j, strengthens Meilisearch/Invidious keys)
 - `pmoves/tools/push-gh-secrets.sh` - Syncs env values to GitHub Actions secrets (filtered by CHIT manifest)
 - `pmoves/bootstrap/registry.json` - Declarative service variable definitions
+- `pmoves/scripts/with-env.sh` - **Canonical env loader.** Use this instead of `. env.shared`
+  in any Make target, script, or CI step that needs env.shared values. Raw `. env.shared`
+  sourcing fails because env.shared is in Docker env_file format (KEY=value, no `export`),
+  not bash. `with-env.sh` parses the file safely and exports the values. See PR #1046 for
+  the root-cause analysis and full remediation history.
+
+**Operator command paths:**
+```bash
+# Run any command with env.shared loaded into the environment
+bash pmoves/scripts/with-env.sh <command>
+
+# Example: run a pytest with all service env vars available
+bash pmoves/scripts/with-env.sh pytest pmoves/tests/test_nats_subjects.py
+
+# In Makefile recipes, invoke via:
+@bash scripts/with-env.sh make -C pmoves smoke
+```
+
+**Git state cleanup workflows** (operator commands for triaging dirty worktrees):
+```bash
+# Check if a worktree is mid-merge/cherry-pick/rebase
+git -C <worktree-path> status --short
+git -C <worktree-path> rev-parse -q --verify MERGE_HEAD  # exits 0 if in merge state
+git -C <worktree-path> rev-parse -q --verify CHERRY_PICK_HEAD
+git -C <worktree-path> rev-parse -q --verify REBASE_HEAD
+
+# Authoritative sitrep for all worktrees (use this, not per-worktree spot checks)
+make -C pmoves worktree-sitrep           # snapshot
+make -C pmoves worktree-sitrep-strict    # gate (non-zero exit on any dirty/conflicted worktree)
+
+# Stale state files that can remain after an interrupted merge/rebase:
+#   .git/MERGE_HEAD, .git/MERGE_MSG, .git/AUTO_MERGE, .git/rebase-merge/, .git/rebase-apply/
+# These are cleaned by `git merge --abort` or `git rebase --abort` respectively.
+```
+
+See `pmoves/docs/AGENTS/CODEX_CIPHER_MEMORY_IMPLEMENTATION_MAP.md` for the full worktree
+cleanup strategy and `pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md` (search `with-env.sh`) for
+the historical context on why this script exists.
 
 **See:** `.claude/context/credentials-workflow.md` for complete bootstrap sequence and
 `pmoves/docs/operations/SEEDED_BRANDED_DEFAULTS.md` for full credential catalog.

--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -871,6 +871,8 @@ chitBypassPatterns:
   - 'make\s+.*secrets-sync'
   - 'make\s+.*secrets-runtime-hydrate'
   - 'make\s+.*ci-runners'
+  # with-env.sh is the env loader for all make targets
+  - 'with-env\.sh'
   # Tailscale key management
   - 'make\s+.*tailscale-save-key'
   - 'make\s+.*tailscale-join'

--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -890,6 +890,12 @@ chitBypassPatterns:
   - '\bhostinger-kvm-setup\b'
   - '\bmigrate-vps\b'
   - '\bdeploy-vps-cluster\b'
+  # Git state cleanup — remove stale rebase/merge crash artifacts from .git/
+  # VS Code crashes leave empty rebase-merge/rebase-apply dirs that block git rebase.
+  # rm -rf and force flags still blocked by bashToolPatterns (runs before bypass).
+  - '(rmdir|rm)\s+.*\.git[/\\](rebase-merge|rebase-apply)'
+  - 'rm\s+.*\.git[/\\](AUTO_MERGE|MERGE_HEAD|MERGE_MSG)'
+  - 'rm\s+.*\.git[/\\]\.MERGE_MSG\.swp'
 
 # File paths that CHIT operations may create/write — bypass zero-access.
 # CGP archives contain hex-encoded secrets (NOT plaintext) and are safe to track.


### PR DESCRIPTION
## Summary
- Add `with-env.sh` to chitBypassPatterns — env loader for all make targets was blocked
- Add Git state cleanup patterns — `rmdir/rm` on stale `.git/rebase-merge`, `AUTO_MERGE`, `MERGE_HEAD`, `MERGE_MSG` crash artifacts
- Destructive flags remain blocked by bashToolPatterns first-layer check

## Context
Follows PR #1189 (merged). These 2 patterns were identified during rebase when VS Code crash artifacts blocked `git rebase` and the `with-env.sh` pattern was missing from main's version of #1189.

## Test plan
- [x] `rmdir .git/rebase-merge` no longer blocked by damage-control hook
- [x] `rm .git/AUTO_MERGE` no longer blocked
- [x] YAML validates cleanly
- [x] Destructive recursive delete on .git/ still blocked (bashToolPatterns first layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened trusted operation patterns to allow additional deployment and maintenance workflows, including extended cleanup patterns for stale Git rebase/merge artifacts.
* **Documentation**
  * Added guidance for a canonical env loader, clarified env.shared format and how to run commands with it, and included a worktree cleanup/runbook with commands and gating recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->