### PR TITLE
feat(agent-zero): add NVIDIA NIM to provider cascade

### DIFF
--- a/pmoves/config/provider_catalog.yaml
+++ b/pmoves/config/provider_catalog.yaml
@@ -561,3 +561,31 @@ providers:
             weight: 0.0
         strength_ref: null             # Needs seed entry
         vram_mb: 0
+
+  # ---------------------------------------------------------------------------
+  # NVIDIA NIM — Local Nemotron Super 49B on RTX 5090
+  # ---------------------------------------------------------------------------
+  # OpenAI-compatible endpoint served by the local `nvidia-nim` container.
+  # See pmoves/configs/tac_trees/nvidia-nims.tac.yaml for the integration plan
+  # and pmoves/config/model_nexus.yaml for the nexus-level provider record.
+  nvidia_nim:
+    env_var: NGC_API_KEY
+    key_pattern: ".*"
+    api_base: "http://nvidia-nim:8000/v1"
+    tz_type: openai
+    tier: llm
+    models:
+      nemotron_super_49b_nim:
+        model_name: "nvidia/llama-3.3-nemotron-super-49b-v1"
+        tz_model_key: nemotron_super_49b_nim
+        serves:
+          - function: agent_zero
+            variant_name: local_nvidia_nim
+            role: secondary
+            weight: 0.0
+          - function: deepresearch
+            variant_name: local_nvidia_nim
+            role: secondary
+            weight: 0.0
+        strength_ref: null             # Needs seed entry
+        vram_mb: 0                     # GPU-resident; tracked via gpu-orchestrator

--- a/pmoves/config/provider_catalog.yaml
+++ b/pmoves/config/provider_catalog.yaml
@@ -579,12 +579,12 @@ providers:
         model_name: "nvidia/llama-3.3-nemotron-super-49b-v1"
         tz_model_key: nemotron_super_49b_nim
         serves:
+          # Variant name must match the TZ config in pmoves/tensorzero/config/tensorzero.toml.
+          # PR #1211 defines [functions.agent_zero.variants.hosted_nim_nemotron].
+          # No deepresearch variant exists yet — add one to tensorzero.toml before
+          # extending `serves` to cover that function.
           - function: agent_zero
-            variant_name: local_nvidia_nim
-            role: secondary
-            weight: 0.0
-          - function: deepresearch
-            variant_name: local_nvidia_nim
+            variant_name: hosted_nim_nemotron
             role: secondary
             weight: 0.0
         strength_ref: null             # Needs seed entry


### PR DESCRIPTION
## Summary

- Register `nvidia_nim` in Agent Zero's `conf/model_providers.yaml` (appears in UI dropdown)
- Register `nvidia_nim` in PMOVES `pmoves/config/provider_catalog.yaml` (enables `provider_cascade.py` activation)
- Routes to local NIM container running Nemotron Super 49B at `http://nvidia-nim:8000/v1`
- Requires `NGC_API_KEY` env var

## Files

- `PMOVES-Agent-Zero/conf/model_providers.yaml` (submodule) — nvidia_nim under chat providers
- `pmoves/config/provider_catalog.yaml` — provider entry + nemotron_super_49b_nim model binding

## Dependencies

- **Needs PR #1211 (`feature/new-model-providers`) merged first** for the TensorZero `nemotron_super_49b_nim` model block to exist
- Works standalone for the Agent Zero UI dropdown registration

## Test plan

- [ ] YAML parses cleanly: `python3 -c "import yaml; yaml.safe_load(open('PMOVES-Agent-Zero/conf/model_providers.yaml'))"`
- [ ] `provider_cascade.py list` shows `nvidia_nim` after merge
- [ ] Agent Zero UI dropdown shows nvidia_nim option (manual verification)

## Follow-up notes

- LiteLLM auth convention uses `<PROVIDER>_API_KEY` — operators may need to alias `NGC_API_KEY` → `NVIDIA_NIM_API_KEY` if LiteLLM auth layer requires it. Flagging for future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA NIM provider integration, making the Nemotron 49B model available as an option for agents and research workflows.

* **Updates**
  * Refreshed provider configuration and updated submodule reference to incorporate the latest provider code and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->