### PR TITLE
chore(infra): update NIM TAC tree + add smoke-new-models target

### DIFF
--- a/pmoves/Makefile
+++ b/pmoves/Makefile
@@ -1461,7 +1461,7 @@ up-legacy-both: ## Ensure v1 hi-rag gateway CPU+GPU are up
 	@$(DC) --profile gpu --profile legacy up -d hi-rag-gateway-gpu >/dev/null 2>&1 || true
 	@echo "✔ hi-rag-gateway v1: CPU(:8089) + GPU(:8090 if GPUs present)."
 
-.PHONY: up down clean smoke smoke-prod smoke-gpu smoke-qwen-rerank llama-throughput-smoke manifest-audit
+.PHONY: up down clean smoke smoke-prod smoke-gpu smoke-qwen-rerank smoke-new-models llama-throughput-smoke manifest-audit
 .PHONY: up down clean up-workers up-yt channel-monitor-up channel-monitor-smoke up-media up-jellyfin up-nats ps supabase-up supabase-stop supabase-clean supa-extract-remote env-setup env-check up-jellyfin-ai-nvenc down-jellyfin-ai-nvenc up-rustdesk down-rustdesk
 .PHONY: up down clean up-cloudflare down-cloudflare logs-cloudflare cloudflare-url restart-cloudflare up-workers up-yt up-media up-jellyfin up-nats ps supabase-up supabase-stop supabase-clean supa-extract-remote env-setup env-check manifest-audit
 .PHONY: discord-ping discord-ping-ps demo-content-published health-publisher-discord up-agents health-agent-zero health-jellyfin-bridge seed-approval seed-approval-ps m2-preflight evidence-stamp evidence-stamp-ps evidence-log evidence-log-ps m2-seed-demo n8n-webhook-demo
@@ -1586,6 +1586,32 @@ llama-throughput-smoke: ## Quick llama throughput validation (single request tes
 smoke-qwen-rerank: ## Enforce Qwen reranker selection on v2-gpu then run strict GPU smoke
 	@$(PYTHON) tools/smoke_gpu.py --require-qwen --stats-only $(ARGS) || python tools/smoke_gpu.py --require-qwen --stats-only $(ARGS) || py -3 tools/smoke_gpu.py --require-qwen --stats-only $(ARGS)
 	@GPU_SMOKE_STRICT=true $(MAKE) --no-print-directory smoke-gpu
+
+smoke-new-models: ## Smoke test new model providers (NIM, Qwen3-Coder-Next, Gemma 3n)
+	@echo "=== New Model Providers Smoke Test ==="
+	@echo "1) NVIDIA NIM health:"
+	@curl -sf http://localhost:$${NIM_HOST_PORT:-8000}/v1/health/ready >/dev/null 2>&1 \
+	  && echo "   NIM: ready" \
+	  || echo "   NIM: not available (skipped)"
+	@echo "2) TensorZero model catalog:"
+	@tz_json=$$(curl -sf http://localhost:3030/v1/models 2>/dev/null); \
+	if [ -z "$$tz_json" ]; then \
+	  echo "   TensorZero: unreachable"; \
+	else \
+	  for m in nemotron_super_49b_nim coding_qwen3_coder_next_80b_local gemma_3n_e4b_local; do \
+	    if echo "$$tz_json" | grep -q "\"$$m\""; then \
+	      echo "   $$m: present"; \
+	    else \
+	      echo "   $$m: MISSING"; \
+	    fi; \
+	  done; \
+	fi
+	@echo "3) Agent Zero provider catalog:"
+	@if [ -f ../PMOVES-Agent-Zero/conf/model_providers.yaml ] && grep -q nvidia_nim ../PMOVES-Agent-Zero/conf/model_providers.yaml; then \
+	  echo "   Agent Zero: nvidia_nim registered"; \
+	else \
+	  echo "   Agent Zero: nvidia_nim NOT registered"; \
+	fi
 
 manifest-audit: ## Report CHIT manifest projection (allow-missing for audit visibility)
 	@$(PYTHON) tools/secrets_sync.py report --manifest pmoves/chit/secrets_manifest.yaml --allow-missing || python tools/secrets_sync.py report --manifest pmoves/chit/secrets_manifest.yaml --allow-missing || py -3 tools/secrets_sync.py report --manifest pmoves/chit/secrets_manifest.yaml --allow-missing

--- a/pmoves/Makefile
+++ b/pmoves/Makefile
@@ -1594,12 +1594,13 @@ smoke-new-models: ## Smoke test new model providers (NIM, Qwen3-Coder-Next, Gemm
 	  && echo "   NIM: ready" \
 	  || echo "   NIM: not available (skipped)"
 	@echo "2) TensorZero model catalog:"
-	@tz_json=$$(curl -sf http://localhost:3030/v1/models 2>/dev/null); \
+	@tz_port=$${TENSORZERO_HOST_PORT:-3030}; \
+	tz_json=$$(curl -sf "http://localhost:$$tz_port/v1/models" 2>/dev/null); \
 	if [ -z "$$tz_json" ]; then \
-	  echo "   TensorZero: unreachable"; \
+	  echo "   TensorZero: unreachable (port $$tz_port)"; \
 	else \
 	  for m in nemotron_super_49b_nim coding_qwen3_coder_next_80b_local gemma_3n_e4b_local; do \
-	    if echo "$$tz_json" | grep -q "\"$$m\""; then \
+	    if echo "$$tz_json" | grep -Fq "\"$$m\""; then \
 	      echo "   $$m: present"; \
 	    else \
 	      echo "   $$m: MISSING"; \

--- a/pmoves/configs/tac_trees/nvidia-nims.tac.yaml
+++ b/pmoves/configs/tac_trees/nvidia-nims.tac.yaml
@@ -82,15 +82,15 @@ root:
           action:
             type: grep
             target: "pmoves/tensorzero/config/tensorzero.toml"
-            pattern: "models.nim_"
-            expect: "NIM model with routing to nvidia-nim provider"
+            pattern: "models.nemotron_super_49b_nim"
+            expect: "nemotron_super_49b_nim model block with routing to nvidia-nim provider"
         - id: nims.tensorzero.agent-zero-variant
           task: "agent_zero function has NIM variant"
           action:
             type: grep
             target: "pmoves/tensorzero/config/tensorzero.toml"
-            pattern: "hosted_nim"
-            expect: "NIM variant in agent_zero function"
+            pattern: "functions.agent_zero.variants.hosted_nim_nemotron"
+            expect: "hosted_nim_nemotron variant registered under agent_zero function"
         - id: nims.tensorzero.metrics
           task: "NIM requests tracked in ClickHouse"
           action:
@@ -106,8 +106,13 @@ root:
           action:
             type: grep
             target: "pmoves/config/gpu-models.yaml"
-            pattern: "nim"
-            expect: "NIM model with VRAM estimate in model registry"
+            pattern: "nemotron-super:49b"
+            expect: "nemotron-super:49b entry with vram_mb: 30000 (30 GB budget for NIM)"
+        - id: nims.gpu-orch.vram-budget
+          task: "NIM VRAM budget matches registry"
+          action:
+            type: manual
+            expect: "gpu-models.yaml nemotron-super:49b reserves 30000 MB (RTX 5090 32GB leaves ~2GB headroom)"
         - id: nims.gpu-orch.lifecycle
           task: "NIM model lifecycle events on NATS"
           action:


### PR DESCRIPTION
## Summary

- TAC tree references actual registered model names (Phase 3-4 expectations)
- New `smoke-new-models` Make target verifies NIM health + TZ catalog + Agent Zero registration
- Soft-fail pattern: target always exits 0 (status check, not a gate)

## Files

- `pmoves/configs/tac_trees/nvidia-nims.tac.yaml` — Phase 3 (TensorZero) and Phase 4 (GPU orchestrator) expectations updated
- `pmoves/Makefile` — new `smoke-new-models` target

## Changes Detail

**TAC tree Phase 3 (TensorZero):**
- `nims.tensorzero.model`: pattern `models.nemotron_super_49b_nim`
- `nims.tensorzero.agent-zero-variant`: pattern `functions.agent_zero.variants.hosted_nim_nemotron`

**TAC tree Phase 4 (GPU Orchestrator):**
- `nims.gpu-orch.model-registry`: `nemotron-super:49b` with `vram_mb: 30000`
- New `nims.gpu-orch.vram-budget`: 30000 MB reservation on RTX 5090 (32 GB budget)

**Make target `smoke-new-models`:**
1. NIM health check via `curl http://localhost:${NIM_HOST_PORT:-8000}/v1/health/ready`
2. TensorZero catalog check for 3 new models (pure shell, no Python)
3. Agent Zero provider registration grep

## Dependencies

- Forward-looking checklist: expected state lands after PR #1211 (TensorZero models) + #1212 (GPU registry) + #1216 (Agent Zero NIM provider) are merged
- Until those merge, `smoke-new-models` correctly reports `MISSING` / `NOT registered` (this is intentional gap detection)

## Validation

- YAML parses: `python -c "import yaml; yaml.safe_load(open('pmoves/configs/tac_trees/nvidia-nims.tac.yaml'))"`
- Makefile syntax: `make -n smoke-new-models` expands cleanly
- Live run: `make smoke-new-models` exits 0

## Test plan

- [ ] `make smoke-new-models` runs without errors
- [ ] After PRs #1211/#1212/#1216 merge: smoke target reports all `present`/`registered`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a smoke-check target to run readiness and catalog checks for newly integrated model providers.
  * Enhanced validation to verify specific model presence and enforce an explicit VRAM budget for targeted GPU models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->