### PR TITLE
feat(models): onboard Gemma 4 family (E2B/E4B/26B-A4B/31B)

### DIFF
--- a/pmoves/config/gpu-models.yaml
+++ b/pmoves/config/gpu-models.yaml
@@ -254,6 +254,40 @@ models:
     quantization: "E2B"
     context_length: 32768
 
+  # Gemma 4 Family (Google, Apache 2.0, released 2026-04-02)
+  # Current SOTA open multimodal family — beats Llama 4 on AIME/LiveCodeBench/GPQA/τ2-bench
+  - id: "gemma4:e2b"
+    provider: ollama
+    vram_mb: 3200
+    description: "Google Gemma 4 E2B - Effective 2B multimodal (any-to-any), 128K ctx, Apache 2.0"
+    priority_default: 5
+    quantization: "Q4_K_M"
+    context_length: 131072
+
+  - id: "gemma4:e4b"
+    provider: ollama
+    vram_mb: 5200
+    description: "Google Gemma 4 E4B - Effective 4B multimodal (any-to-any), 128K ctx, Apache 2.0"
+    priority_default: 6
+    quantization: "Q4_K_M"
+    context_length: 131072
+
+  - id: "gemma4:26b-a4b"
+    provider: ollama
+    vram_mb: 15000
+    description: "Google Gemma 4 26B-A4B MoE - 3.8B active, speed-focused, 256K ctx, LMArena 1441"
+    priority_default: 8
+    quantization: "Q4_K_M-MoE"
+    context_length: 262144
+
+  - id: "gemma4:31b"
+    provider: ollama
+    vram_mb: 18000
+    description: "Google Gemma 4 31B Dense - SOTA quality, 256K ctx, LMArena 1452, beats Llama 4"
+    priority_default: 9
+    quantization: "Q4_K_M"
+    context_length: 262144
+
   # TTS Models (Ultimate TTS Studio)
   - id: "kokoro"
     provider: tts

--- a/pmoves/configs/flare-model-namespace.yaml
+++ b/pmoves/configs/flare-model-namespace.yaml
@@ -92,3 +92,34 @@ mappings:
     model_id: "gemma3n:e2b"
     lane: "edge"
     nodes: [jetson]
+
+  # --- Gemma 4 Family (Google, Apache 2.0, released 2026-04-02) ---
+  # TODO: extend nodes enum with [rdna4, dgx-spark] once PR 2/3 land.
+  # Using existing [5090, 4090, z890, jetson] for now.
+  gemma-4-e2b:
+    flare_name: "pmoves/gemma-4-e2b"
+    provider: "ollama"
+    model_id: "gemma4:e2b"
+    lane: "local"
+    nodes: [5090, 4090, z890]
+
+  gemma-4-e4b:
+    flare_name: "pmoves/gemma-4-e4b"
+    provider: "ollama"
+    model_id: "gemma4:e4b"
+    lane: "local"
+    nodes: [5090, 4090, z890]
+
+  gemma-4-26b-a4b:
+    flare_name: "pmoves/gemma-4-26b-a4b"
+    provider: "ollama"
+    model_id: "gemma4:26b-a4b"
+    lane: "local"
+    nodes: [5090, 4090]
+
+  gemma-4-31b:
+    flare_name: "pmoves/gemma-4-31b"
+    provider: "ollama"
+    model_id: "gemma4:31b"
+    lane: "local"
+    nodes: [5090]

--- a/pmoves/supabase/initdb/12_model_registry_seed.sql
+++ b/pmoves/supabase/initdb/12_model_registry_seed.sql
@@ -630,6 +630,90 @@ BEGIN
     description = EXCLUDED.description,
     updated_at = NOW();
 
+  -- Gemma 4 E2B - Effective 2B multimodal (any-to-any, 128K ctx)
+  INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
+  VALUES (
+    v_ollama_local_id,
+    'gemma_4_e2b_local',
+    'gemma4:e2b',
+    'chat',
+    '["chat", "vision", "audio", "video", "multimodal"]'::jsonb,
+    3200,
+    131072,
+    'Google Gemma 4 E2B - Effective 2B multimodal, Apache 2.0',
+    true
+  )
+  ON CONFLICT (provider_id, model_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    capabilities = EXCLUDED.capabilities,
+    vram_mb = EXCLUDED.vram_mb,
+    context_length = EXCLUDED.context_length,
+    description = EXCLUDED.description,
+    updated_at = NOW();
+
+  -- Gemma 4 E4B - Effective 4B multimodal (any-to-any, 128K ctx)
+  INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
+  VALUES (
+    v_ollama_local_id,
+    'gemma_4_e4b_local',
+    'gemma4:e4b',
+    'chat',
+    '["chat", "vision", "audio", "video", "multimodal"]'::jsonb,
+    5200,
+    131072,
+    'Google Gemma 4 E4B - Effective 4B multimodal, Apache 2.0',
+    true
+  )
+  ON CONFLICT (provider_id, model_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    capabilities = EXCLUDED.capabilities,
+    vram_mb = EXCLUDED.vram_mb,
+    context_length = EXCLUDED.context_length,
+    description = EXCLUDED.description,
+    updated_at = NOW();
+
+  -- Gemma 4 26B-A4B MoE - 3.8B active, speed-focused, 256K ctx
+  INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
+  VALUES (
+    v_ollama_local_id,
+    'gemma_4_26b_a4b_local',
+    'gemma4:26b-a4b',
+    'chat',
+    '["chat", "code_generation", "vision", "audio", "multimodal"]'::jsonb,
+    15000,
+    262144,
+    'Google Gemma 4 26B-A4B MoE - 3.8B active, LMArena 1441, Apache 2.0',
+    true
+  )
+  ON CONFLICT (provider_id, model_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    capabilities = EXCLUDED.capabilities,
+    vram_mb = EXCLUDED.vram_mb,
+    context_length = EXCLUDED.context_length,
+    description = EXCLUDED.description,
+    updated_at = NOW();
+
+  -- Gemma 4 31B Dense - SOTA quality, 256K ctx, LMArena 1452
+  INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
+  VALUES (
+    v_ollama_local_id,
+    'gemma_4_31b_local',
+    'gemma4:31b',
+    'chat',
+    '["chat", "code_generation", "reasoning", "vision", "audio", "multimodal"]'::jsonb,
+    18000,
+    262144,
+    'Google Gemma 4 31B Dense - SOTA quality, beats Llama 4 on AIME/LiveCodeBench, Apache 2.0',
+    true
+  )
+  ON CONFLICT (provider_id, model_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    capabilities = EXCLUDED.capabilities,
+    vram_mb = EXCLUDED.vram_mb,
+    context_length = EXCLUDED.context_length,
+    description = EXCLUDED.description,
+    updated_at = NOW();
+
 END $$;
 
 -- =============================================================================

--- a/pmoves/tensorzero/config/tensorzero.toml
+++ b/pmoves/tensorzero/config/tensorzero.toml
@@ -333,6 +333,51 @@ api_base = "http://jetson-ollama:11434/v1"
 model_name = "gemma3n:e2b"
 api_key_location = "none"
 
+# --- Gemma 4 Family (Google, Apache 2.0, released 2026-04-02) ---
+# Current SOTA open multimodal — beats Llama 4 on AIME/LiveCodeBench/GPQA.
+# All variants routed to ollama_local by default. DGX Spark and AMD R9700
+# add dedicated routing variants in follow-up PRs.
+
+# Gemma 4 E2B (Effective 2B, 128K ctx, ~3GB Q4)
+[models.gemma_4_e2b_local]
+routing = ["ollama_local"]
+
+[models.gemma_4_e2b_local.providers.ollama_local]
+type = "openai"
+api_base = "http://pmoves-ollama:11434/v1"
+model_name = "gemma4:e2b"
+api_key_location = "none"
+
+# Gemma 4 E4B (Effective 4B, 128K ctx, ~5GB Q4)
+[models.gemma_4_e4b_local]
+routing = ["ollama_local"]
+
+[models.gemma_4_e4b_local.providers.ollama_local]
+type = "openai"
+api_base = "http://pmoves-ollama:11434/v1"
+model_name = "gemma4:e4b"
+api_key_location = "none"
+
+# Gemma 4 26B-A4B MoE (3.8B active, 256K ctx, ~15GB Q4)
+[models.gemma_4_26b_a4b_local]
+routing = ["ollama_local"]
+
+[models.gemma_4_26b_a4b_local.providers.ollama_local]
+type = "openai"
+api_base = "http://pmoves-ollama:11434/v1"
+model_name = "gemma4:26b-a4b"
+api_key_location = "none"
+
+# Gemma 4 31B Dense (SOTA multimodal, 256K ctx, ~18GB Q4)
+[models.gemma_4_31b_local]
+routing = ["ollama_local"]
+
+[models.gemma_4_31b_local.providers.ollama_local]
+type = "openai"
+api_base = "http://pmoves-ollama:11434/v1"
+model_name = "gemma4:31b"
+api_key_location = "none"
+
 [models.chat_together]
 routing = ["together_primary"]
 
@@ -929,6 +974,35 @@ weight = 1.0
 [functions.multimodal_edge.variants.gemma_3n_e2b_edge]
 type = "chat_completion"
 model = "gemma_3n_e2b_edge"
+weight = 0.0
+
+# Gemma 4 E2B — new SOTA edge multimodal (safe rollout, weight=0)
+[functions.multimodal_edge.variants.gemma_4_e2b]
+type = "chat_completion"
+model = "gemma_4_e2b_local"
+weight = 0.0
+
+# Gemma 4 E4B — new SOTA edge multimodal (safe rollout, weight=0)
+[functions.multimodal_edge.variants.gemma_4_e4b]
+type = "chat_completion"
+model = "gemma_4_e4b_local"
+weight = 0.0
+
+# --- Function: Multimodal Large ----------------------------------------------
+# Gemma 4 26B-A4B and 31B for high-quality multimodal inference on heavyweight
+# GPU nodes (DGX Spark, dual R9700, 5090). Dedicated function keeps the
+# routing policy separate from multimodal_edge (E2B/E4B on smaller nodes).
+[functions.multimodal_large]
+type = "chat"
+
+[functions.multimodal_large.variants.gemma_4_26b_a4b]
+type = "chat_completion"
+model = "gemma_4_26b_a4b_local"
+weight = 0.0
+
+[functions.multimodal_large.variants.gemma_4_31b]
+type = "chat_completion"
+model = "gemma_4_31b_local"
 weight = 0.0
 
 # --- Per-Stack Coding Functions (4090 Coding Workstation) ---


### PR DESCRIPTION
## Summary

Onboards the **Gemma 4** family (released 2026-04-02 by Google) to the PMOVES model registry — current SOTA open multimodal family, Apache 2.0.

## Models added (4)

| Variant | Params | Active | Context | VRAM (Q4) | Notes |
|---------|--------|--------|---------|-----------|-------|
| Gemma 4 E2B | 5.1B | Effective 2B | 128K | ~3 GB | any-to-any multimodal, edge |
| Gemma 4 E4B | 8.0B | Effective 4B | 128K | ~5 GB | any-to-any multimodal, edge |
| Gemma 4 26B-A4B | 26B | 3.8B (MoE) | 256K | ~15 GB | Speed, LMArena 1441 |
| Gemma 4 31B | 32.7B | Dense | 256K | ~18 GB | **SOTA**, LMArena 1452, beats Llama 4 |

## Files (4)

- `pmoves/config/gpu-models.yaml` — 4 new entries
- `pmoves/configs/flare-model-namespace.yaml` — 4 flare mappings (uses existing node enum with TODO for `rdna4`/`dgx-spark` in follow-up PRs)
- `pmoves/supabase/initdb/12_model_registry_seed.sql` — 4 new INSERTs inside the existing ollama `DO $$` block
- `pmoves/tensorzero/config/tensorzero.toml` — 4 model blocks + 2 new variants in `multimodal_edge` + new `multimodal_large` function with 2 variants

## Safe rollout

All new TensorZero function variants at `weight = 0.0`. Existing Gemma 3n variants retain their current weights (E4B at 1.0). Operators can flip weights manually once Gemma 4 has been pulled on target nodes.

## Dependencies

- None (base models layer — no new providers, reuses `ollama_local`)
- **Downstream:** PR 2 (DGX Spark) and PR 3 (AMD R9700 ROCm) will add node-specific routing variants via `ollama_spark` and `llamacpp_rocm` providers respectively, targeting the new `multimodal_large` function

## Verification

- ✅ `python3 -c "import yaml; yaml.safe_load(...)"` on both YAML files
- ✅ `python3 -c "import tomllib; tomllib.load(...)"` on tensorzero.toml
- ✅ HF MCP `hub_repo_details` confirms all 4 repos exist as of 2026-04-10

## References

- [Google Gemma 4 blog](https://blog.google/innovation-and-ai/technology/developers-tools/gemma-4/)
- [Welcome Gemma 4 (HF)](https://huggingface.co/blog/gemma4)
- [google/gemma-4-31B-it](https://huggingface.co/google/gemma-4-31B-it)
- [google/gemma-4-26B-A4B-it](https://huggingface.co/google/gemma-4-26B-A4B-it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new Gemma 4 AI models (E2B, E4B, 26B-A4B, 31B) with varying computational requirements and context window sizes (128K–256K tokens).
  * Gemma 4 models support multimodal capabilities and local deployment via Ollama.
  * Introduced "multimodal_large" function variant for larger model deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->