### PR TITLE
feat(spark): DGX Spark node — topology + Make targets + TensorZero routing

### DIFF
--- a/pmoves/Makefile
+++ b/pmoves/Makefile
@@ -155,6 +155,7 @@ include mk/preflight.mk
 include mk/infra.mk
 include mk/build-gate.mk
 include mk/nvidia-5090.mk
+include mk/nvidia-dgx-spark.mk
 include mk/hf.mk
 include mk/provider.mk
 

--- a/pmoves/configs/agent-profiles/spark_claw.yaml
+++ b/pmoves/configs/agent-profiles/spark_claw.yaml
@@ -1,0 +1,64 @@
+# Spark Claw — DGX Spark Heavyweight NVIDIA GPU Claw
+# Hybrid: OpenClaw + TensorZero/Ollama CUDA + NATS mesh participation
+#
+# Runs on the NVIDIA DGX Spark (GB10 Grace-Blackwell, 128GB unified LPDDR5X)
+# for 200B-param-class multimodal inference. Unified memory architecture
+# eliminates CPU↔VRAM copies, so models up to ~200B params can run without
+# traditional VRAM constraints.
+
+name: spark_claw
+role: dgx-spark-heavyweight-claw
+description: "NVIDIA DGX Spark heavyweight claw for 200B-class multimodal inference (Gemma 4 31B, Nemotron Super 49B, Qwen3-Coder 480B)"
+
+node_affinity:
+  - dgx-spark
+hostname_pattern: "pmoves-dgx-spark"
+
+model:
+  provider: ollama_spark
+  model: gemma4:31b
+  endpoint: http://pmoves-dgx-spark:11434/v1
+  fallback: tensorzero
+
+capabilities:
+  - heavyweight_llm_inference
+  - unified_memory_200b
+  - multimodal_any_to_any
+  - gemma4_support
+  - nemotron_support
+  - qwen3_coder_large_support
+  - agentic_reasoning
+  - gpu_monitoring
+
+nats:
+  url: nats://nats:pmoves@nats:4222
+  subscribe:
+    - mesh.gpu.command.v1
+    - pinokio.agent.session.v1
+  publish:
+    - mesh.gpu.status.v1
+    - mesh.gpu.model.loaded.v1
+    - mesh.gpu.model.unloaded.v1
+    - mesh.gpu.command.result.v1
+    - pinokio.telemetry.v1
+
+exec_permissions:
+  - nvidia-smi
+  - ollama
+  - docker
+  - python3
+  - curl
+  - git
+  - make
+  - nats
+
+health:
+  endpoint: http://pmoves-dgx-spark:11434/api/tags
+  heartbeat_subject: mesh.gpu.status.v1
+  heartbeat_interval_seconds: 10
+
+agent_zero:
+  subordinate: true
+  profile: spark_claw
+  inherit_context: true
+  report_to: agent_zero

--- a/pmoves/docs/operations/TOPOLOGY.md
+++ b/pmoves/docs/operations/TOPOLOGY.md
@@ -2,7 +2,7 @@
 
 > Single source of truth for all physical/virtual nodes, service assignments, agent teams, route flows, and runner strategy.
 >
-> Last updated: 2026-03-27
+> Last updated: 2026-04-13
 
 ---
 
@@ -13,6 +13,7 @@
 | Z890 (Windows 11) | LAN (dual NIC) | `ts:<z890>` | pmoves-z890 | Dev, GPU (RTX 3090 Ti) | `self-hosted, ai-lab` (secondary) | 32C / 128GB | electricity |
 | POWERFULMOVES (5090) | LAN (dual NIC) | `ts:<5090-linux>`, `ts:<5090-win>` | pmoves-powerfulmoves, powerfulmoves-1 | Primary GPU (RTX 5090) | `self-hosted, ai-lab, gpu, cuda` | 24C / 64GB | electricity |
 | 4090 Laptop (Windows) | LAN | `ts:<laptop>` | pmoves-4090 | Control Plane, Edge Orchestration, Agent Zero + Claws | — | RTX 4090 | electricity |
+| DGX Spark | LAN | `ts:<dgx-spark>` | pmoves-dgx-spark | Heavyweight Inference (Gemma 4 31B, Nemotron Super 49B, Qwen3-Coder 480B) | `self-hosted, ai-lab, gpu, cuda, spark` (pending) | 20C Arm / 128GB unified LPDDR5X | electricity |
 | Jetson Orin #1 | LAN (RustDesk + SSH) | `ts:<nano>` | pmoves-nano (rename to pmoves-nano-1 pending) | Edge Inference (Nemotron/NemoClaw), Claws | — | Orin (sm_87) | electricity |
 | Jetson Orin #2 | LAN (RustDesk + SSH) | TBD | TBD | Edge Inference (Nemotron/NemoClaw), Claws | — | Orin (sm_87) | electricity |
 | KVM4-1 | — | — | pmoves-kvm4-1 | API Gateway | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
@@ -48,6 +49,25 @@ Both Jetson Orin Nanos have SSH configured (`pmovesnvme@.110`, `pmovesnvme@.144`
 5. Agent Zero + Claws deployment
 
 **Total VPS cost:** $30/mo + electricity for local nodes.
+
+### DGX Spark — Heavyweight Inference Node (Pending)
+
+NVIDIA DGX Spark (GB10 Grace-Blackwell Superchip) on Tailscale. Purpose-built for 200B-param-class inference via unified memory:
+
+- **CPU+GPU:** 20-core Arm (10x Cortex-X925 + 10x Cortex-A725) + GB10 Grace-Blackwell
+- **Memory:** 128GB unified LPDDR5X (CPU+GPU coherent, no VRAM↔RAM copies)
+- **Throughput:** 1 petaFLOP FP4
+- **Target models:** Gemma 4 31B (FP16), Gemma 4 26B-A4B, Nemotron Super 49B, Qwen3-Coder 480B
+- **Runtime:** Ollama (CUDA) primary; NVIDIA NIM optional
+- **Ports:** 11434 (Ollama), 8200 (NIM if deployed — same default as 5090)
+- **Tailscale hostname:** `pmoves-dgx-spark`
+
+**Pending setup:**
+1. Tailscale join + tag assignment (`tag:spark`)
+2. Ollama install + `gemma4:31b`, `gemma4:26b-a4b`, `nemotron:49b` model pulls
+3. Registration in `agent-teams.yaml` under `agents/gpu-inference` tier
+4. TensorZero `ollama_spark` provider points at `http://pmoves-dgx-spark:11434/v1`
+5. `spark_claw` agent profile activates after first heartbeat on `mesh.gpu.status.v1`
 
 ---
 

--- a/pmoves/mk/nvidia-dgx-spark.mk
+++ b/pmoves/mk/nvidia-dgx-spark.mk
@@ -1,0 +1,34 @@
+# nvidia-dgx-spark.mk — Make targets for the NVIDIA DGX Spark node
+# Pattern: SSH/Tailscale to the GB10 Grace-Blackwell superchip workstation.
+#
+# Tailscale hostname: pmoves-dgx-spark
+# Hardware: GB10 Grace-Blackwell, 128GB unified LPDDR5X, 1 petaFLOP FP4
+# Runtime: Ollama (CUDA backend) primary; NVIDIA NIM optional
+# Ports: 11434 (Ollama), 8200 (NIM if deployed)
+
+OLLAMA_SPARK_HOST ?= pmoves-dgx-spark
+OLLAMA_SPARK_PORT ?= 11434
+
+.PHONY: spark-ssh spark-ollama-status spark-gpu-status spark-ollama-ls spark-ollama-pull spark-gemma4-pull spark-health
+
+spark-ssh: ## SSH to DGX Spark via Tailscale
+	@ssh -o StrictHostKeyChecking=no root@$(OLLAMA_SPARK_HOST)
+
+spark-ollama-status: ## Check Ollama service status on DGX Spark
+	@ssh -o ConnectTimeout=5 root@$(OLLAMA_SPARK_HOST) 'ollama list' 2>/dev/null || echo "spark: unreachable"
+
+spark-gpu-status: ## Check GB10 GPU utilization on DGX Spark
+	@ssh -o ConnectTimeout=5 root@$(OLLAMA_SPARK_HOST) 'nvidia-smi --query-gpu=name,memory.used,memory.total,utilization.gpu --format=csv,noheader' 2>/dev/null || echo "spark: unreachable"
+
+spark-ollama-ls: ## List local Ollama models on DGX Spark
+	@ssh -o ConnectTimeout=5 root@$(OLLAMA_SPARK_HOST) 'ollama list' 2>/dev/null || echo "spark: unreachable"
+
+spark-ollama-pull: ## Pull a model on DGX Spark: make spark-ollama-pull MODEL=gemma4:31b
+	@test -n "$(MODEL)" || { echo "ERROR: MODEL required (e.g. MODEL=gemma4:31b)"; exit 1; }
+	@ssh -o ConnectTimeout=10 root@$(OLLAMA_SPARK_HOST) "ollama pull $(MODEL)" || { echo "spark: pull failed"; exit 1; }
+
+spark-gemma4-pull: ## Pull all 4 Gemma 4 variants on DGX Spark (E2B + E4B + 26B-A4B + 31B)
+	@ssh -o ConnectTimeout=10 root@$(OLLAMA_SPARK_HOST) "ollama pull gemma4:e2b && ollama pull gemma4:e4b && ollama pull gemma4:26b-a4b && ollama pull gemma4:31b" || { echo "spark: gemma4 pull failed"; exit 1; }
+
+spark-health: ## Check DGX Spark Ollama HTTP endpoint via Tailscale
+	@curl -sf http://$(OLLAMA_SPARK_HOST):$(OLLAMA_SPARK_PORT)/api/tags >/dev/null 2>&1 && echo "spark: ready" || echo "spark: not ready (or unreachable)"

--- a/pmoves/tensorzero/config/tensorzero.toml
+++ b/pmoves/tensorzero/config/tensorzero.toml
@@ -378,6 +378,40 @@ api_base = "http://pmoves-ollama:11434/v1"
 model_name = "gemma4:31b"
 api_key_location = "none"
 
+# --- DGX Spark Node Routing (GB10 Grace-Blackwell, 128GB unified LPDDR5X) ---
+# Heavyweight inference via Ollama CUDA backend on pmoves-dgx-spark.
+# Unified memory fits 200B-param-class models without VRAM copies.
+
+# Gemma 4 31B on DGX Spark (SOTA multimodal, unified memory)
+[models.gemma_4_31b_spark]
+routing = ["ollama_spark"]
+
+[models.gemma_4_31b_spark.providers.ollama_spark]
+type = "openai"
+api_base = "http://pmoves-dgx-spark:11434/v1"
+model_name = "gemma4:31b"
+api_key_location = "none"
+
+# Gemma 4 26B-A4B MoE on DGX Spark
+[models.gemma_4_26b_a4b_spark]
+routing = ["ollama_spark"]
+
+[models.gemma_4_26b_a4b_spark.providers.ollama_spark]
+type = "openai"
+api_base = "http://pmoves-dgx-spark:11434/v1"
+model_name = "gemma4:26b-a4b"
+api_key_location = "none"
+
+# Nemotron Super 49B on DGX Spark (Ollama native, no NIM container required)
+[models.nemotron_super_49b_spark]
+routing = ["ollama_spark"]
+
+[models.nemotron_super_49b_spark.providers.ollama_spark]
+type = "openai"
+api_base = "http://pmoves-dgx-spark:11434/v1"
+model_name = "nemotron:49b"
+api_key_location = "none"
+
 [models.chat_together]
 routing = ["together_primary"]
 
@@ -638,6 +672,12 @@ model = "glm_4_long"
 [functions.agent_zero.variants.hosted_nim_nemotron]
 type = "chat_completion"
 model = "nemotron_super_49b_nim"
+weight = 0.0
+
+# Nemotron Super 49B on DGX Spark — Ollama native, no NIM container (weight=0)
+[functions.agent_zero.variants.hosted_spark_nemotron]
+type = "chat_completion"
+model = "nemotron_super_49b_spark"
 weight = 0.0
 
 # Qwen3-Coder-Next 80B — local MoE (safe rollout, weight=0)
@@ -995,14 +1035,27 @@ weight = 0.0
 [functions.multimodal_large]
 type = "chat"
 
+# Gemma 4 26B-A4B — local Ollama fallback (safe rollout, weight=0)
 [functions.multimodal_large.variants.gemma_4_26b_a4b]
 type = "chat_completion"
 model = "gemma_4_26b_a4b_local"
 weight = 0.0
 
+# Gemma 4 31B — local Ollama fallback (safe rollout, weight=0)
 [functions.multimodal_large.variants.gemma_4_31b]
 type = "chat_completion"
 model = "gemma_4_31b_local"
+weight = 0.0
+
+# DGX Spark variants — all weight=0.0 for safe rollout
+[functions.multimodal_large.variants.gemma_4_31b_spark]
+type = "chat_completion"
+model = "gemma_4_31b_spark"
+weight = 0.0
+
+[functions.multimodal_large.variants.gemma_4_26b_a4b_spark]
+type = "chat_completion"
+model = "gemma_4_26b_a4b_spark"
 weight = 0.0
 
 # --- Per-Stack Coding Functions (4090 Coding Workstation) ---


### PR DESCRIPTION
## Summary

Provisions the NVIDIA DGX Spark (GB10 Grace-Blackwell, 128GB unified LPDDR5X) as a new fleet node on Tailscale. 3 atomic commits:

1. **`feat(topology)`** — Add DGX Spark to Node Inventory + "Heavyweight Inference Node (Pending)" subsection
2. **`feat(spark)`** — New `pmoves/mk/nvidia-dgx-spark.mk` (7 SSH-based targets) + `spark_claw` agent profile + Makefile include
3. **`feat(spark)`** — TensorZero `ollama_spark` provider + 3 model blocks + 3 function variants at weight=0.0

## Files (5)

- `pmoves/docs/operations/TOPOLOGY.md` — node inventory + DGX Spark status subsection
- `pmoves/mk/nvidia-dgx-spark.mk` (new) — spark-ssh, spark-ollama-status, spark-gpu-status, spark-ollama-ls, spark-ollama-pull, spark-gemma4-pull, spark-health
- `pmoves/configs/agent-profiles/spark_claw.yaml` (new) — mirrors nemotron_claw schema, provider ollama_spark, primary model gemma4:31b
- `pmoves/Makefile` — 1-line `include mk/nvidia-dgx-spark.mk` addition
- `pmoves/tensorzero/config/tensorzero.toml` — 3 model blocks (gemma_4_31b_spark, gemma_4_26b_a4b_spark, nemotron_super_49b_spark) + new `multimodal_large` function + `hosted_spark_nemotron` agent_zero variant

## Hardware spec (for context)

| Attribute | Value |
|-----------|-------|
| Superchip | NVIDIA GB10 Grace-Blackwell |
| CPU | 20-core Arm (10x Cortex-X925 + 10x Cortex-A725) |
| Memory | 128 GB unified LPDDR5X (CPU+GPU coherent) |
| FP4 throughput | 1 petaFLOP |
| Target models | Gemma 4 31B, Nemotron Super 49B, Qwen3-Coder 480B |
| Runtime | Ollama (CUDA) primary; NIM optional |

## Dependencies

- **Conflicts with PR #1226 (Gemma 4 base)** on `multimodal_large` function block — both PRs create it fresh. Rebase-after-merge pattern handles cleanly: whichever merges first defines the block; the second PR's rebase drops the duplicate block header and keeps only its variants.
- **No other conflicts** — topology + Make target + profile are new files.

## Safe rollout

All 3 TensorZero function variants at `weight = 0.0`. The node itself needs Tailscale join + Ollama model pulls before any traffic routes to it (see pending setup list in TOPOLOGY.md).

## Test plan

- [ ] `make -C pmoves spark-health` (after node provisioning) returns "ready"
- [ ] `make -C pmoves spark-gemma4-pull` successfully pulls all 4 Gemma 4 variants
- [ ] `curl http://localhost:3030/v1/models` shows `gemma_4_31b_spark`, `gemma_4_26b_a4b_spark`, `nemotron_super_49b_spark`

🤖 Generated with [Claude Code](https://claude.com/claude-code)