### PR TITLE
feat(rocm): AMD R9700 RDNA4 node — llamacpp_rocm provider + Make targets + topology

### DIFF
--- a/pmoves/Makefile
+++ b/pmoves/Makefile
@@ -156,6 +156,7 @@ include mk/infra.mk
 include mk/build-gate.mk
 include mk/nvidia-5090.mk
 include mk/nvidia-dgx-spark.mk
+include mk/amd-rdna4.mk
 include mk/hf.mk
 include mk/provider.mk
 

--- a/pmoves/config/provider_catalog.yaml
+++ b/pmoves/config/provider_catalog.yaml
@@ -589,3 +589,49 @@ providers:
             weight: 0.0
         strength_ref: null             # Needs seed entry
         vram_mb: 0                     # GPU-resident; tracked via gpu-orchestrator
+
+  # ---------------------------------------------------------------------------
+  # llamacpp_rocm — AMD RDNA4 (dual R9700) via llama.cpp ROCm/HIP backend
+  # ---------------------------------------------------------------------------
+  # OpenAI-compatible endpoint served by `llama-server` (ships with llama.cpp)
+  # running on the 9850X3D dual-R9700 workstation via Tailscale hostname.
+  # Ollama's bundled ROCm v6 libs do NOT include gfx1201 kernels (RDNA4), so
+  # the canonical runtime is llama.cpp's HIP backend (built against ROCm 7.1+).
+  # See pmoves/docs/operations/TOPOLOGY.md for the rdna4 node entry.
+  llamacpp_rocm:
+    env_var: LLAMACPP_ROCM_API_KEY
+    key_pattern: ".*"
+    api_base: "http://pmoves-rdna4:8080/v1"
+    tz_type: openai
+    tier: llm
+    models:
+      gemma_4_31b_rocm:
+        model_name: "gemma-4-31b-it-Q4_K_M.gguf"
+        tz_model_key: gemma_4_31b_rocm
+        serves:
+          # Variant name matches functions.multimodal_large.variants.gemma_4_31b_rocm
+          # and functions.agent_zero.variants.local_gemma_4_31b_rocm in tensorzero.toml.
+          - function: multimodal_large
+            variant_name: gemma_4_31b_rocm
+            role: secondary
+            weight: 0.0
+          - function: agent_zero
+            variant_name: local_gemma_4_31b_rocm
+            role: secondary
+            weight: 0.0
+        strength_ref: null
+        vram_mb: 18000                 # Q4 on single R9700; FP16 splits across both cards
+      gemma_4_26b_a4b_rocm:
+        model_name: "gemma-4-26B-A4B-it-Q4_K_M.gguf"
+        tz_model_key: gemma_4_26b_a4b_rocm
+        serves:
+          - function: multimodal_large
+            variant_name: gemma_4_26b_a4b_rocm
+            role: secondary
+            weight: 0.0
+          - function: agent_zero
+            variant_name: local_gemma_4_26b_a4b_rocm
+            role: secondary
+            weight: 0.0
+        strength_ref: null
+        vram_mb: 15000                 # Q4 MoE, 3.8B active

--- a/pmoves/configs/agent-profiles/rocm_claw.yaml
+++ b/pmoves/configs/agent-profiles/rocm_claw.yaml
@@ -1,0 +1,62 @@
+# ROCm Claw — AMD RDNA4 GPU Agentic Claw
+# Hybrid: OpenClaw + TensorZero/llama.cpp-rocm + NATS mesh participation
+#
+# Runs on the dual-R9700 (RDNA4 gfx1201) workstation for large-context
+# multimodal inference via llama.cpp HIP backend. Ollama is NOT used
+# because its bundled ROCm v6 libs lack gfx1201 kernels (as of 2026-04).
+# Canonical runtime: llama-server (OpenAI-compatible, ships with llama.cpp).
+
+name: rocm_claw
+role: amd-rdna4-multimodal-claw
+description: "AMD R9700 (dual RDNA4, 64GB VRAM) claw for Gemma 4 multimodal inference via llama.cpp ROCm backend"
+
+node_affinity:
+  - rdna4
+hostname_pattern: "pmoves-rdna4"
+
+model:
+  provider: llamacpp_rocm
+  model: gemma-4-31b-it-Q4_K_M.gguf
+  endpoint: http://pmoves-rdna4:8080/v1
+  fallback: tensorzero
+
+capabilities:
+  - multimodal_inference
+  - large_context_256k
+  - dual_gpu_split
+  - rocm_hip_backend
+  - gguf_native
+  - gpu_monitoring
+
+nats:
+  url: nats://nats:pmoves@nats:4222
+  subscribe:
+    - mesh.gpu.command.v1
+    - pinokio.agent.session.v1
+  publish:
+    - mesh.gpu.status.v1
+    - mesh.gpu.model.loaded.v1
+    - mesh.gpu.model.unloaded.v1
+    - mesh.gpu.command.result.v1
+
+exec_permissions:
+  - rocm-smi
+  - rocminfo
+  - llama-server
+  - huggingface-cli
+  - python3
+  - curl
+  - git
+  - make
+  - nats
+
+health:
+  endpoint: http://pmoves-rdna4:8080/v1/models
+  heartbeat_subject: mesh.gpu.status.v1
+  heartbeat_interval_seconds: 10
+
+agent_zero:
+  subordinate: true
+  profile: rocm_claw
+  inherit_context: true
+  report_to: agent_zero

--- a/pmoves/docs/operations/TOPOLOGY.md
+++ b/pmoves/docs/operations/TOPOLOGY.md
@@ -14,6 +14,7 @@
 | POWERFULMOVES (5090) | LAN (dual NIC) | `ts:<5090-linux>`, `ts:<5090-win>` | pmoves-powerfulmoves, powerfulmoves-1 | Primary GPU (RTX 5090) | `self-hosted, ai-lab, gpu, cuda` | 24C / 64GB | electricity |
 | 4090 Laptop (Windows) | LAN | `ts:<laptop>` | pmoves-4090 | Control Plane, Edge Orchestration, Agent Zero + Claws | — | RTX 4090 | electricity |
 | DGX Spark | LAN | `ts:<dgx-spark>` | pmoves-dgx-spark | Heavyweight Inference (Gemma 4 31B, Nemotron Super 49B, Qwen3-Coder 480B) | `self-hosted, ai-lab, gpu, cuda, spark` (pending) | 20C Arm / 128GB unified LPDDR5X | electricity |
+| R9700 Workstation (Linux) | LAN | `ts:<rdna4>` | pmoves-rdna4 | Heavyweight ROCm Inference (Gemma 4 31B/26B-A4B via llama.cpp) | `self-hosted, ai-lab, gpu, rocm, rdna4` (pending) | 9850X3D / 32GB + 2x R9700 (64GB VRAM total) | electricity |
 | Jetson Orin #1 | LAN (RustDesk + SSH) | `ts:<nano>` | pmoves-nano (rename to pmoves-nano-1 pending) | Edge Inference (Nemotron/NemoClaw), Claws | — | Orin (sm_87) | electricity |
 | Jetson Orin #2 | LAN (RustDesk + SSH) | TBD | TBD | Edge Inference (Nemotron/NemoClaw), Claws | — | Orin (sm_87) | electricity |
 | KVM4-1 | — | — | pmoves-kvm4-1 | API Gateway | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
@@ -68,6 +69,29 @@ NVIDIA DGX Spark (GB10 Grace-Blackwell Superchip) on Tailscale. Purpose-built fo
 3. Registration in `agent-teams.yaml` under `agents/gpu-inference` tier
 4. TensorZero `ollama_spark` provider points at `http://pmoves-dgx-spark:11434/v1`
 5. `spark_claw` agent profile activates after first heartbeat on `mesh.gpu.status.v1`
+
+### AMD R9700 (RDNA4) — ROCm Inference Node (Pending)
+
+AMD Radeon AI PRO R9700 dual-GPU workstation on Tailscale. Unique value: 64GB VRAM (2x32GB) at lower capital cost than equivalent NVIDIA cards, with native RDNA4 support in ROCm 7.1+:
+
+- **CPU:** AMD Ryzen 9 9850X3D (8-core with 3D V-Cache)
+- **RAM:** 32GB DDR5
+- **GPU:** 2x AMD Radeon AI PRO R9700 (32GB VRAM each, 64GB total, gfx1201 / RDNA4)
+- **Runtime:** llama.cpp HIP backend (ROCm 7.1+). **Ollama is NOT used** — its bundled ROCm v6 libs lack gfx1201 kernels as of 2026-04.
+- **Server:** `llama-server` (OpenAI-compatible, ships with llama.cpp) on port 8080
+- **Target models:** Gemma 4 31B Q4 (single card), Gemma 4 31B FP16 (dual-card split), Gemma 4 26B-A4B, any GGUF up to 64GB
+- **Benchmark reference:** ~99 tok/s for 7B Q4 (tlee933/llama.cpp-rdna4-gfx1201 fork); competitive with RTX 4070 Ti
+- **Tailscale hostname:** `pmoves-rdna4`
+
+**Pending setup:**
+1. Tailscale join + tag assignment (`tag:rdna4`)
+2. ROCm 7.1+ install + gfx1201 kernel verification
+3. llama.cpp HIP build (or use `tlee933/llama.cpp-rdna4-gfx1201` fork)
+4. GGUF model download to `/opt/llama-models` via `make rdna4-model-pull HF_REPO=bartowski/google_gemma-4-31B-it-GGUF FILE=gemma-4-31b-it-Q4_K_M.gguf`
+5. `make rdna4-llamacpp-up` to start llama-server with dual-GPU tensor-split
+6. Registration in `agent-teams.yaml` under `agents/gpu-inference` tier
+7. TensorZero `llamacpp_rocm` provider points at `http://pmoves-rdna4:8080/v1`
+8. `rocm_claw` agent profile activates after first heartbeat on `mesh.gpu.status.v1`
 
 ---
 

--- a/pmoves/mk/amd-rdna4.mk
+++ b/pmoves/mk/amd-rdna4.mk
@@ -1,0 +1,37 @@
+# amd-rdna4.mk — Make targets for the AMD Radeon AI PRO R9700 (RDNA4) node
+# Pattern: SSH/Tailscale to the 9850X3D workstation with dual R9700.
+#
+# Tailscale hostname: pmoves-rdna4
+# GPU: 2x AMD Radeon AI PRO R9700 (32GB VRAM each, 64GB total, gfx1201)
+# CPU: AMD Ryzen 9 9850X3D, 32GB RAM
+# Runtime: llama.cpp HIP backend (ROCm 7.1+). NOT Ollama — bundled ROCm
+# v6 libs lack gfx1201 kernels. `llama-server` is OpenAI-compatible.
+
+LLAMACPP_ROCM_HOST ?= pmoves-rdna4
+LLAMACPP_ROCM_PORT ?= 8080
+RDNA4_MODEL_DIR ?= /opt/llama-models
+
+.PHONY: rdna4-ssh rdna4-rocm-status rdna4-gpu-status rdna4-llamacpp-status rdna4-llamacpp-up rdna4-model-ls rdna4-model-pull
+
+rdna4-ssh: ## SSH to R9700 workstation via Tailscale
+	@ssh -o StrictHostKeyChecking=no root@$(LLAMACPP_ROCM_HOST)
+
+rdna4-rocm-status: ## Check ROCm version and gfx1201 device visibility
+	@ssh -o ConnectTimeout=5 root@$(LLAMACPP_ROCM_HOST) 'rocm-smi --showproductname 2>/dev/null && rocminfo | grep -A2 "gfx1201" | head -10' 2>/dev/null || echo "rdna4: unreachable"
+
+rdna4-gpu-status: ## Check dual-R9700 VRAM and utilization
+	@ssh -o ConnectTimeout=5 root@$(LLAMACPP_ROCM_HOST) 'rocm-smi --showmeminfo vram --showuse' 2>/dev/null || echo "rdna4: unreachable"
+
+rdna4-llamacpp-status: ## Check llama-server readiness on R9700 (HTTP /v1/models)
+	@ssh -o ConnectTimeout=5 root@$(LLAMACPP_ROCM_HOST) "curl -sf http://127.0.0.1:$(LLAMACPP_ROCM_PORT)/v1/models" >/dev/null 2>&1 && echo "llama-server: ready" || echo "llama-server: not ready (or rdna4 unreachable)"
+
+rdna4-llamacpp-up: ## Start llama-server on R9700 with default model (Gemma 4 31B Q4)
+	@ssh -o ConnectTimeout=5 root@$(LLAMACPP_ROCM_HOST) "cd '$(RDNA4_MODEL_DIR)' && nohup llama-server --model gemma-4-31b-it-Q4_K_M.gguf --port $(LLAMACPP_ROCM_PORT) --host 0.0.0.0 --n-gpu-layers 999 --split-mode row --tensor-split 0.5,0.5 >/var/log/llama-server.log 2>&1 &" || { echo "rdna4: llamacpp-up failed"; exit 1; }
+
+rdna4-model-ls: ## List GGUF models on R9700
+	@ssh -o ConnectTimeout=5 root@$(LLAMACPP_ROCM_HOST) 'ls -lh $(RDNA4_MODEL_DIR)/*.gguf 2>/dev/null' || echo "rdna4: unreachable"
+
+rdna4-model-pull: ## Download GGUF model on R9700: make rdna4-model-pull HF_REPO=bartowski/google_gemma-4-31B-it-GGUF FILE=gemma-4-31b-it-Q4_K_M.gguf
+	@test -n "$(HF_REPO)" || { echo "ERROR: HF_REPO required"; exit 1; }
+	@test -n "$(FILE)" || { echo "ERROR: FILE required"; exit 1; }
+	@ssh -o ConnectTimeout=5 root@$(LLAMACPP_ROCM_HOST) "cd '$(RDNA4_MODEL_DIR)' && huggingface-cli download '$(HF_REPO)' '$(FILE)' --local-dir . --local-dir-use-symlinks False" || { echo "rdna4: model-pull failed"; exit 1; }

--- a/pmoves/tensorzero/config/tensorzero.toml
+++ b/pmoves/tensorzero/config/tensorzero.toml
@@ -412,6 +412,31 @@ api_base = "http://pmoves-dgx-spark:11434/v1"
 model_name = "nemotron:49b"
 api_key_location = "none"
 
+# --- AMD R9700 RDNA4 Node Routing (dual R9700, 64GB VRAM, ROCm 7.1+) ---
+# Heavyweight inference via llama.cpp HIP backend on pmoves-rdna4.
+# Ollama is NOT used here because its bundled ROCm v6 libs lack gfx1201 kernels.
+# Canonical runtime is `llama-server` (OpenAI-compatible, ships with llama.cpp).
+
+# Gemma 4 31B on AMD R9700 (llama.cpp ROCm, Q4 single card or FP16 dual split)
+[models.gemma_4_31b_rocm]
+routing = ["llamacpp_rocm"]
+
+[models.gemma_4_31b_rocm.providers.llamacpp_rocm]
+type = "openai"
+api_base = "http://pmoves-rdna4:8080/v1"
+model_name = "gemma-4-31b-it-Q4_K_M.gguf"
+api_key_location = "none"
+
+# Gemma 4 26B-A4B MoE on AMD R9700
+[models.gemma_4_26b_a4b_rocm]
+routing = ["llamacpp_rocm"]
+
+[models.gemma_4_26b_a4b_rocm.providers.llamacpp_rocm]
+type = "openai"
+api_base = "http://pmoves-rdna4:8080/v1"
+model_name = "gemma-4-26B-A4B-it-Q4_K_M.gguf"
+api_key_location = "none"
+
 [models.chat_together]
 routing = ["together_primary"]
 
@@ -678,6 +703,18 @@ weight = 0.0
 [functions.agent_zero.variants.hosted_spark_nemotron]
 type = "chat_completion"
 model = "nemotron_super_49b_spark"
+weight = 0.0
+
+# Gemma 4 31B on AMD R9700 — llama.cpp ROCm fallback for agent_zero (weight=0)
+[functions.agent_zero.variants.local_gemma_4_31b_rocm]
+type = "chat_completion"
+model = "gemma_4_31b_rocm"
+weight = 0.0
+
+# Gemma 4 26B-A4B MoE on AMD R9700 — llama.cpp ROCm fallback (weight=0)
+[functions.agent_zero.variants.local_gemma_4_26b_a4b_rocm]
+type = "chat_completion"
+model = "gemma_4_26b_a4b_rocm"
 weight = 0.0
 
 # Qwen3-Coder-Next 80B — local MoE (safe rollout, weight=0)
@@ -1056,6 +1093,17 @@ weight = 0.0
 [functions.multimodal_large.variants.gemma_4_26b_a4b_spark]
 type = "chat_completion"
 model = "gemma_4_26b_a4b_spark"
+weight = 0.0
+
+# AMD R9700 variants — llama.cpp ROCm (safe rollout, weight=0)
+[functions.multimodal_large.variants.gemma_4_31b_rocm]
+type = "chat_completion"
+model = "gemma_4_31b_rocm"
+weight = 0.0
+
+[functions.multimodal_large.variants.gemma_4_26b_a4b_rocm]
+type = "chat_completion"
+model = "gemma_4_26b_a4b_rocm"
 weight = 0.0
 
 # --- Per-Stack Coding Functions (4090 Coding Workstation) ---


### PR DESCRIPTION
## Summary

Provisions the dual-R9700 RDNA4 workstation (64GB VRAM, ROCm 7.1+) as a new fleet node via llama.cpp HIP backend. 3 atomic commits.

## Hardware

| Attribute | Value |
|-----------|-------|
| CPU | AMD Ryzen 9 9850X3D (8-core 3D V-Cache) |
| RAM | 32 GB DDR5 |
| GPU | 2x AMD Radeon AI PRO R9700 (32GB each, 64GB total) |
| Architecture | RDNA4 gfx1201 |
| Runtime | llama.cpp HIP backend (ROCm 7.1+) |
| Server | `llama-server` OpenAI-compatible, port 8080 |
| Tailscale hostname | `pmoves-rdna4` |

## Key decision: llama.cpp, NOT Ollama

Ollama's bundled ROCm v6 libs DO NOT include gfx1201 kernels as of 2026-04. Users report ROCm backend init failures → CPU fallback. Canonical runtime is `llama-server` (ships with llama.cpp), which is natively ROCm-aware via its HIP backend. See [tlee933/llama.cpp-rdna4-gfx1201](https://github.com/tlee933/llama.cpp-rdna4-gfx1201) for a production-ready fork achieving ~99 tok/s on 7B Q4 (competitive with RTX 4070 Ti).

## Files (5)

- `pmoves/config/provider_catalog.yaml` — new `llamacpp_rocm` provider block with 2 models, each `serves[]` both `multimodal_large` AND `agent_zero`
- `pmoves/tensorzero/config/tensorzero.toml` — 2 new model blocks, 2 new `agent_zero` variants, new `multimodal_large` function + 2 variants
- `pmoves/mk/amd-rdna4.mk` (new) — 7 SSH-based targets (rdna4-ssh, rdna4-rocm-status, rdna4-gpu-status, rdna4-llamacpp-status, rdna4-llamacpp-up, rdna4-model-ls, rdna4-model-pull)
- `pmoves/configs/agent-profiles/rocm_claw.yaml` (new) — mirrors nemotron_claw schema, provider llamacpp_rocm, exec_permissions include rocm-smi/rocminfo/llama-server/huggingface-cli
- `pmoves/Makefile` — 1-line `include mk/amd-rdna4.mk` addition
- `pmoves/docs/operations/TOPOLOGY.md` — node inventory + "AMD R9700 (RDNA4) — ROCm Inference Node (Pending)" subsection

## Target models

| Model | Context | VRAM (Q4) | Notes |
|-------|---------|-----------|-------|
| Gemma 4 31B | 256K | ~18 GB | Single card; FP16 (~65GB) splits across both |
| Gemma 4 26B-A4B | 256K | ~15 GB | MoE, 3.8B active |
| any GGUF up to 64GB | — | — | Full dual-card split via `--tensor-split 0.5,0.5` |

## Dependencies

- **Conflicts with PR #1226 (Gemma 4 base)** and **PR #1228 (DGX Spark)** on `multimodal_large` function block — all 3 PRs create it fresh. First to merge defines the block; subsequent PRs rebase cleanly (block header dropped, variants kept).
- **No docker-compose edits** — R9700 host runs natively, not as a container.

## Safe rollout

All 4 new TensorZero function variants at `weight = 0.0`. Node provisioning pending (see TOPOLOGY.md "Pending setup" list).

## Test plan

- [ ] `make -C pmoves rdna4-rocm-status` confirms gfx1201 visible
- [ ] `make -C pmoves rdna4-gpu-status` shows 64GB VRAM available
- [ ] `make -C pmoves rdna4-llamacpp-status` returns "ready" after `rdna4-llamacpp-up`
- [ ] `curl http://localhost:3030/v1/models` shows `gemma_4_31b_rocm`, `gemma_4_26b_a4b_rocm`

## References

- [Phoronix: ROCm 7.1 vs Vulkan on R9700](https://www.phoronix.com/review/rocm-71-llama-cpp-vulkan)
- [tlee933/llama.cpp-rdna4-gfx1201](https://github.com/tlee933/llama.cpp-rdna4-gfx1201)
- [AMD R9700 ROCm PyTorch guide](https://www.amd.com/content/dam/amd/en/documents/products/graphics/workstation/radeon-ai-pro-rocm-pytorch-guide.pdf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)