### PR TITLE
feat(hardening): K8s NetworkPolicies + common tests + async HTTP migration (Rec #11-13)

### DIFF
--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - pmoves-core-deployment.yaml
   - pmoves-core-service.yaml
   - ingress.yaml
+  - ../networkpolicies

--- a/deploy/k8s/networkpolicies/allow-dns.yaml
+++ b/deploy/k8s/networkpolicies/allow-dns.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: pmoves
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/deploy/k8s/networkpolicies/allow-external-api.yaml
+++ b/deploy/k8s/networkpolicies/allow-external-api.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-external-api
+  namespace: pmoves
+spec:
+  podSelector:
+    matchLabels:
+      external-api: enabled
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80

--- a/deploy/k8s/networkpolicies/allow-ingress.yaml
+++ b/deploy/k8s/networkpolicies/allow-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      role: gateway
+      app.kubernetes.io/part-of: pmoves-ai
   policyTypes:
     - Ingress
   ingress:

--- a/deploy/k8s/networkpolicies/allow-ingress.yaml
+++ b/deploy/k8s/networkpolicies/allow-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress
+  namespace: pmoves
+spec:
+  podSelector:
+    matchLabels:
+      role: gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - from: []
+      ports:
+        - protocol: TCP
+          port: 8086
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 443

--- a/deploy/k8s/networkpolicies/allow-monitoring.yaml
+++ b/deploy/k8s/networkpolicies/allow-monitoring.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring
+  namespace: pmoves
+spec:
+  podSelector:
+    matchLabels:
+      monitoring: enabled
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: monitoring
+      ports:
+        - protocol: TCP
+          port: 9090
+        - protocol: TCP
+          port: 8080

--- a/deploy/k8s/networkpolicies/allow-nats-mesh.yaml
+++ b/deploy/k8s/networkpolicies/allow-nats-mesh.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-nats-mesh
+  namespace: pmoves
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 4222
+        - protocol: TCP
+          port: 8222
+  egress:
+    - to:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 4222
+        - protocol: TCP
+          port: 8222

--- a/deploy/k8s/networkpolicies/default-deny.yaml
+++ b/deploy/k8s/networkpolicies/default-deny.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: pmoves
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/deploy/k8s/networkpolicies/kustomization.yaml
+++ b/deploy/k8s/networkpolicies/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - default-deny.yaml
+  - allow-dns.yaml
+  - allow-nats-mesh.yaml
+  - allow-ingress.yaml
+  - allow-monitoring.yaml
+  - allow-external-api.yaml

--- a/pmoves/services/__init__.py
+++ b/pmoves/services/__init__.py
@@ -22,17 +22,18 @@ __all__ = [
     "common",
 ]
 
-# Import common package directly since it's a real package with __init__.py
-from . import common  # noqa: E402, F401
-
+# Ensure path and legacy alias are set BEFORE importing common,
+# because common/__init__.py -> config.py imports `services.common.env`.
 _BASE = Path(__file__).resolve().parent
 _ROOT = _BASE.parent
 _ROOT_STR = str(_ROOT)
 if _ROOT_STR not in sys.path:
     sys.path.insert(0, _ROOT_STR)
 
-# Register legacy top-level alias before dependent modules import `services.*`.
 sys.modules.setdefault("services", sys.modules[__name__])
+
+# Import common package directly since it's a real package with __init__.py
+from . import common  # noqa: E402, F401
 
 _ALIASES: Dict[str, Path] = {
     "publisher": _BASE / "publisher" / "publisher.py",

--- a/pmoves/services/agent-zero/main.py
+++ b/pmoves/services/agent-zero/main.py
@@ -809,8 +809,7 @@ def list_mcp_commands(
 
 
 async def _execute_command(cmd: str, args: Dict[str, Any]) -> Dict[str, Any]:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, mcp_server.execute_command, cmd, args)
+    return await mcp_server.execute_command_async(cmd, args)
 
 
 @app.post("/mcp/execute", response_model=MCPExecuteResponse)

--- a/pmoves/services/agent-zero/mcp_server.py
+++ b/pmoves/services/agent-zero/mcp_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -7,7 +8,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import requests
+import httpx
 import yaml
 
 # Bootstrap import paths using shared module
@@ -62,18 +63,24 @@ def load_form(name: str) -> Dict[str, Any]:
     return yaml.safe_load(p.read_text(encoding="utf-8"))
 
 
-def geometry_publish_cgp(cgp: Dict[str, Any]) -> Dict[str, Any]:
-    r = requests.post(f"{GATEWAY_URL}/geometry/event", json={"type": CGP_SPEC_VERSION, "data": cgp}, timeout=20)
-    r.raise_for_status()
-    return r.json()
+async def geometry_publish_cgp(cgp: Dict[str, Any]) -> Dict[str, Any]:
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        r = await client.post(
+            f"{GATEWAY_URL}/geometry/event",
+            json={"type": CGP_SPEC_VERSION, "data": cgp},
+        )
+        r.raise_for_status()
+        return r.json()
 
 
-def geometry_jump(point_id: str) -> Dict[str, Any]:
-    r = requests.get(f"{GATEWAY_URL}/shape/point/{point_id}/jump", timeout=10)
-    r.raise_for_status(); return r.json()
+async def geometry_jump(point_id: str) -> Dict[str, Any]:
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.get(f"{GATEWAY_URL}/shape/point/{point_id}/jump")
+        r.raise_for_status()
+        return r.json()
 
 
-def geometry_decode_text(
+async def geometry_decode_text(
     mode: str, constellation_id: str, k: int = 5, shape_id: Optional[str] = None
 ) -> Dict[str, Any]:
     body: Dict[str, Any] = {
@@ -85,34 +92,46 @@ def geometry_decode_text(
     }
     if shape_id:
         body["shape_id"] = shape_id
-    r = requests.post(f"{GATEWAY_URL}/geometry/decode/text", json=body, timeout=60)
-    r.raise_for_status(); return r.json()
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        r = await client.post(f"{GATEWAY_URL}/geometry/decode/text", json=body)
+        r.raise_for_status()
+        return r.json()
 
 
-def geometry_calibration_report(data: Dict[str, Any]) -> Dict[str, Any]:
-    r = requests.post(f"{GATEWAY_URL}/geometry/calibration/report", json={"cgp": data}, timeout=20)
-    r.raise_for_status(); return r.json()
+async def geometry_calibration_report(data: Dict[str, Any]) -> Dict[str, Any]:
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        r = await client.post(
+            f"{GATEWAY_URL}/geometry/calibration/report", json={"cgp": data}
+        )
+        r.raise_for_status()
+        return r.json()
 
 
-def ingest_youtube(url: str) -> Dict[str, Any]:
+async def ingest_youtube(url: str) -> Dict[str, Any]:
     yt = os.environ.get("YT_URL", "http://localhost:8077")
-    r = requests.post(f"{yt}/yt/ingest", json={"url": url}, timeout=120)
-    r.raise_for_status(); return r.json()
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        r = await client.post(f"{yt}/yt/ingest", json={"url": url})
+        r.raise_for_status()
+        return r.json()
 
 
-def media_transcript(video_id: str) -> Dict[str, Any]:
+async def media_transcript(video_id: str) -> Dict[str, Any]:
     yt = os.environ.get("YT_URL", "http://localhost:8077")
-    r = requests.post(f"{yt}/yt/transcript", json={"video_id": video_id}, timeout=600)
-    r.raise_for_status(); return r.json()
+    async with httpx.AsyncClient(timeout=600.0) as client:
+        r = await client.post(f"{yt}/yt/transcript", json={"video_id": video_id})
+        r.raise_for_status()
+        return r.json()
 
 
-def comfy_render(flow_id: str, inputs: Dict[str, Any]) -> Dict[str, Any]:
+async def comfy_render(flow_id: str, inputs: Dict[str, Any]) -> Dict[str, Any]:
     rw = os.environ.get("RENDER_WEBHOOK_URL", "http://localhost:8085")
-    # Minimal placeholder: forward to render-webhook if such endpoint exists in your service
-    r = requests.post(f"{rw}/comfy/render", json={"flow_id": flow_id, "inputs": inputs}, timeout=120)
-    if r.status_code >= 400:
-        return {"ok": False, "status": r.status_code, "detail": r.text[:300]}
-    return r.json()
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        r = await client.post(
+            f"{rw}/comfy/render", json={"flow_id": flow_id, "inputs": inputs}
+        )
+        if r.status_code >= 400:
+            return {"ok": False, "status": r.status_code, "detail": r.text[:300]}
+        return r.json()
 
 
 def _ensure_notebook_credentials() -> None:
@@ -139,7 +158,7 @@ def _summarize_note(note: Dict[str, Any]) -> Optional[str]:
     return content[:277].rstrip() + "..."
 
 
-def notebook_search(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def notebook_search(payload: Dict[str, Any]) -> Dict[str, Any]:
     _ensure_notebook_credentials()
 
     query = (payload.get("query") or payload.get("text") or "").strip()
@@ -198,38 +217,38 @@ def notebook_search(payload: Dict[str, Any]) -> Dict[str, Any]:
     data: Optional[Dict[str, Any]] = None
     selected_endpoint: Optional[str] = None
     last_404 = False
-    for endpoint, body in attempts:
-        try:
-            response = requests.post(
-                f"{NOTEBOOK_API_URL.rstrip('/')}{endpoint}",
-                json=body,
-                headers=headers,
-                timeout=20,
-            )
-        except requests.exceptions.RequestException as exc:
-            raise ValueError(f"Open Notebook request failed: {exc}") from None
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        for endpoint, body in attempts:
+            try:
+                response = await client.post(
+                    f"{NOTEBOOK_API_URL.rstrip('/')}{endpoint}",
+                    json=body,
+                    headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                raise ValueError(f"Open Notebook request failed: {exc}") from None
 
-        if response.status_code == 404:
-            last_404 = True
-            continue
-        if response.status_code in (401, 403):
-            raise ValueError(
-                "Open Notebook authentication failed; check OPEN_NOTEBOOK_API_TOKEN / OPEN_NOTEBOOK_PASSWORD alignment."
-            ) from None
-        try:
-            response.raise_for_status()
-        except requests.exceptions.HTTPError:
-            detail = response.text.strip() or f"status {response.status_code}"
-            raise ValueError(f"Open Notebook search failed: {detail}") from None
-        try:
-            parsed = response.json()
-        except ValueError:
-            raise ValueError("Open Notebook returned non-JSON search response") from None
-        if not isinstance(parsed, dict):
-            raise ValueError("Open Notebook search response must be a JSON object") from None
-        data = parsed
-        selected_endpoint = endpoint
-        break
+            if response.status_code == 404:
+                last_404 = True
+                continue
+            if response.status_code in (401, 403):
+                raise ValueError(
+                    "Open Notebook authentication failed; check OPEN_NOTEBOOK_API_TOKEN / OPEN_NOTEBOOK_PASSWORD alignment."
+                ) from None
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError:
+                detail = response.text.strip() or f"status {response.status_code}"
+                raise ValueError(f"Open Notebook search failed: {detail}") from None
+            try:
+                parsed = response.json()
+            except ValueError:
+                raise ValueError("Open Notebook returned non-JSON search response") from None
+            if not isinstance(parsed, dict):
+                raise ValueError("Open Notebook search response must be a JSON object") from None
+            data = parsed
+            selected_endpoint = endpoint
+            break
 
     if data is None:
         if last_404:
@@ -298,35 +317,35 @@ def _generate_error_id() -> str:
     return str(uuid.uuid4())[:8]
 
 
-def _e2b_request(
+async def _e2b_request(
     method: str,
     url: str,
     json_body: Dict = None,
     timeout: int = 30
-) -> Optional[requests.Response]:
+) -> Optional[httpx.Response]:
     """
     Make E2B API request with proper error handling.
 
     Returns None on network errors, allowing caller to handle gracefully.
     """
     try:
-        response = requests.request(
-            method,
-            url,
-            json=json_body,
-            headers=_e2b_headers(),
-            timeout=timeout
-        )
-        return response
-    except requests.exceptions.Timeout:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.request(
+                method,
+                url,
+                json=json_body,
+                headers=_e2b_headers(),
+            )
+            return response
+    except httpx.TimeoutException:
         return None
-    except requests.exceptions.ConnectionError:
+    except httpx.ConnectError:
         return None
-    except requests.exceptions.RequestException:
+    except httpx.HTTPError:
         return None
 
 
-def _e2b_json_response(response: requests.Response, error_context: str) -> Dict[str, Any]:
+def _e2b_json_response(response: httpx.Response, error_context: str) -> Dict[str, Any]:
     """
     Safely parse JSON response from E2B API.
 
@@ -377,7 +396,7 @@ def _e2b_json_response(response: requests.Response, error_context: str) -> Dict[
     return result
 
 
-def e2b_sandbox_create(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def e2b_sandbox_create(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Create a new E2B sandbox for code execution."""
     duration = int(payload.get("duration", 3600))
     memory_mb = int(payload.get("memory_mb", 2048))
@@ -389,7 +408,7 @@ def e2b_sandbox_create(payload: Dict[str, Any]) -> Dict[str, Any]:
         "cpu_limit": cpu_limit
     }
 
-    response = _e2b_request(
+    response = await _e2b_request(
         "POST",
         f"{E2B_MCP_SERVER_URL}/sandbox/create",
         request_body,
@@ -402,7 +421,7 @@ def e2b_sandbox_create(payload: Dict[str, Any]) -> Dict[str, Any]:
     return _e2b_json_response(response, "sandbox_create")
 
 
-def e2b_sandbox_execute(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def e2b_sandbox_execute(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Execute code in an existing E2B sandbox."""
     sandbox_id = payload.get("sandbox_id")
     if not sandbox_id:
@@ -420,7 +439,7 @@ def e2b_sandbox_execute(payload: Dict[str, Any]) -> Dict[str, Any]:
         "code": code
     }
 
-    response = _e2b_request(
+    response = await _e2b_request(
         "POST",
         f"{E2B_MCP_SERVER_URL}/sandbox/execute",
         request_body,
@@ -433,13 +452,13 @@ def e2b_sandbox_execute(payload: Dict[str, Any]) -> Dict[str, Any]:
     return _e2b_json_response(response, "sandbox_execute")
 
 
-def e2b_sandbox_terminate(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def e2b_sandbox_terminate(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Terminate an existing E2B sandbox."""
     sandbox_id = payload.get("sandbox_id")
     if not sandbox_id:
         raise ValueError("'sandbox_id' is required")
 
-    response = _e2b_request(
+    response = await _e2b_request(
         "DELETE",
         f"{E2B_MCP_SERVER_URL}/sandbox/{sandbox_id}",
         timeout=10
@@ -451,7 +470,7 @@ def e2b_sandbox_terminate(payload: Dict[str, Any]) -> Dict[str, Any]:
     return _e2b_json_response(response, "sandbox_terminate")
 
 
-def e2b_desktop_create(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def e2b_desktop_create(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Create a new E2B desktop sandbox with GUI access."""
     duration = int(payload.get("duration", 3600))
     memory_mb = int(payload.get("memory_mb", 2048))
@@ -463,7 +482,7 @@ def e2b_desktop_create(payload: Dict[str, Any]) -> Dict[str, Any]:
         "resolution": resolution
     }
 
-    response = _e2b_request(
+    response = await _e2b_request(
         "POST",
         f"{E2B_MCP_SERVER_URL}/desktop/create",
         request_body,
@@ -482,7 +501,7 @@ def e2b_desktop_create(payload: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def e2b_spell_execute(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def e2b_spell_execute(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Execute an E2B spell (predefined code pattern)."""
     spell_name = payload.get("spell_name")
     if not spell_name:
@@ -497,7 +516,7 @@ def e2b_spell_execute(payload: Dict[str, Any]) -> Dict[str, Any]:
         "timeout": timeout
     }
 
-    response = _e2b_request(
+    response = await _e2b_request(
         "POST",
         f"{E2B_MCP_SERVER_URL}/spell/execute",
         request_body,
@@ -510,7 +529,7 @@ def e2b_spell_execute(payload: Dict[str, Any]) -> Dict[str, Any]:
     return _e2b_json_response(response, "spell_execute")
 
 
-def e2b_surf_scrape(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def e2b_surf_scrape(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Scrape/web surf a URL and extract content."""
     url = payload.get("url")
     if not url:
@@ -527,7 +546,7 @@ def e2b_surf_scrape(payload: Dict[str, Any]) -> Dict[str, Any]:
         "follow_links": follow_links
     }
 
-    response = _e2b_request(
+    response = await _e2b_request(
         "POST",
         f"{E2B_MCP_SERVER_URL}/surf/scrape",
         request_body,
@@ -561,19 +580,19 @@ COMMAND_REGISTRY: Dict[str, str] = {
 }
 
 
-def execute_command(cmd: Optional[str], payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+async def execute_command(cmd: Optional[str], payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Execute an MCP command using the local runtime helpers."""
 
     payload = payload or {}
     if not cmd:
         raise ValueError("'cmd' is required")
     if cmd == "geometry.publish_cgp":
-        return geometry_publish_cgp(payload.get("cgp") or {})
+        return await geometry_publish_cgp(payload.get("cgp") or {})
     if cmd == "geometry.jump":
         point_id = payload.get("point_id")
         if not point_id:
             raise ValueError("'point_id' is required")
-        return geometry_jump(point_id)
+        return await geometry_jump(point_id)
     if cmd == "geometry.decode_text":
         mode = payload.get("mode", "geometry")
         constellation_id = payload.get("constellation_id")
@@ -581,27 +600,27 @@ def execute_command(cmd: Optional[str], payload: Optional[Dict[str, Any]] = None
             raise ValueError("'constellation_id' is required")
         k = int(payload.get("k", 5))
         shape_id = payload.get("shape_id")
-        return geometry_decode_text(mode, constellation_id, k, shape_id=shape_id)
+        return await geometry_decode_text(mode, constellation_id, k, shape_id=shape_id)
     if cmd == "geometry.calibration.report":
-        return geometry_calibration_report(payload.get("cgp") or payload.get("data") or {})
+        return await geometry_calibration_report(payload.get("cgp") or payload.get("data") or {})
     if cmd == "ingest.youtube":
         url = payload.get("url")
         if not url:
             raise ValueError("'url' is required")
-        return ingest_youtube(url)
+        return await ingest_youtube(url)
     if cmd == "media.transcribe":
         video_id = payload.get("video_id")
         if not video_id:
             raise ValueError("'video_id' is required")
-        return media_transcript(video_id)
+        return await media_transcript(video_id)
     if cmd == "comfy.render":
         flow_id = payload.get("flow_id")
         if not flow_id:
             raise ValueError("'flow_id' is required")
         inputs = payload.get("inputs") or {}
-        return comfy_render(flow_id, inputs)
+        return await comfy_render(flow_id, inputs)
     if cmd == "notebook.search":
-        return notebook_search(payload)
+        return await notebook_search(payload)
     if cmd == "form.get":
         current_form = payload.get("name", FORM_NAME)
         return {"form": load_form(current_form)}
@@ -611,17 +630,17 @@ def execute_command(cmd: Optional[str], payload: Optional[Dict[str, Any]] = None
         return {"ok": True, "form": new_form}
     # E2B Agentic Computer Use Commands
     if cmd == "e2b.sandbox.create":
-        return e2b_sandbox_create(payload)
+        return await e2b_sandbox_create(payload)
     if cmd == "e2b.sandbox.execute":
-        return e2b_sandbox_execute(payload)
+        return await e2b_sandbox_execute(payload)
     if cmd == "e2b.sandbox.terminate":
-        return e2b_sandbox_terminate(payload)
+        return await e2b_sandbox_terminate(payload)
     if cmd == "e2b.desktop.create":
-        return e2b_desktop_create(payload)
+        return await e2b_desktop_create(payload)
     if cmd == "e2b.spell.execute":
-        return e2b_spell_execute(payload)
+        return await e2b_spell_execute(payload)
     if cmd == "e2b.surf.scrape":
-        return e2b_surf_scrape(payload)
+        return await e2b_surf_scrape(payload)
     raise ValueError(f"Unknown E2B command: {cmd}")
 
 
@@ -638,6 +657,7 @@ def main():
     # Lightweight MCP-like shim over stdio: accepts line-delimited JSON commands
     form = load_form(FORM_NAME)
     _stdout({"event": "ready", "form": form.get("name")})
+    loop = asyncio.new_event_loop()
     for line in sys.stdin:
         line = line.strip()
         if not line:
@@ -648,9 +668,11 @@ def main():
             _stdout({"error": "invalid_json"}); continue
         cmd = req.get("cmd")
         try:
-            _stdout(execute_command(cmd, req))
+            result = loop.run_until_complete(execute_command(cmd, req))
+            _stdout(result)
         except Exception as e:
             _stdout({"error": str(e)})
+    loop.close()
 
 
 if __name__ == "__main__":

--- a/pmoves/services/agent-zero/mcp_server.py
+++ b/pmoves/services/agent-zero/mcp_server.py
@@ -580,8 +580,8 @@ COMMAND_REGISTRY: Dict[str, str] = {
 }
 
 
-async def execute_command(cmd: Optional[str], payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Execute an MCP command using the local runtime helpers."""
+async def execute_command_async(cmd: Optional[str], payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Execute an MCP command using the local runtime helpers (async)."""
 
     payload = payload or {}
     if not cmd:
@@ -644,6 +644,16 @@ async def execute_command(cmd: Optional[str], payload: Optional[Dict[str, Any]] 
     raise ValueError(f"Unknown E2B command: {cmd}")
 
 
+def execute_command(cmd: Optional[str], payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Synchronous wrapper for backward compatibility.
+
+    Existing callers that expect a blocking (sync) ``execute_command`` continue
+    to work without any code changes.  Internally this spins up a fresh event
+    loop and delegates to :func:`execute_command_async`.
+    """
+    return asyncio.run(execute_command_async(cmd, payload))
+
+
 def list_commands() -> List[Dict[str, Any]]:
     """Return metadata for exposed MCP commands."""
 
@@ -668,7 +678,7 @@ def main():
             _stdout({"error": "invalid_json"}); continue
         cmd = req.get("cmd")
         try:
-            result = loop.run_until_complete(execute_command(cmd, req))
+            result = loop.run_until_complete(execute_command_async(cmd, req))
             _stdout(result)
         except Exception as e:
             _stdout({"error": str(e)})

--- a/pmoves/services/agent-zero/mcp_server.py
+++ b/pmoves/services/agent-zero/mcp_server.py
@@ -320,7 +320,7 @@ def _generate_error_id() -> str:
 async def _e2b_request(
     method: str,
     url: str,
-    json_body: Dict = None,
+    json_body: dict[str, Any] | None = None,
     timeout: int = 30
 ) -> Optional[httpx.Response]:
     """

--- a/pmoves/services/agent-zero/requirements.txt
+++ b/pmoves/services/agent-zero/requirements.txt
@@ -2,6 +2,7 @@
 fastapi
 uvicorn
 pydantic
+httpx
 nats-py
 jsonschema
 PyYAML

--- a/pmoves/services/agent-zero/tests/test_main.py
+++ b/pmoves/services/agent-zero/tests/test_main.py
@@ -4,8 +4,9 @@ import asyncio
 import importlib.util
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import Callable, Dict
+from typing import Any, Callable, Dict
 
+import httpx
 import pytest
 
 pytest.importorskip("fastapi")
@@ -73,6 +74,34 @@ def _prepare_agent_zero(module, monkeypatch):
     return module
 
 
+class _DummyAsyncClient:
+    def __init__(self, captured: dict[str, dict[str, object]], *args: Any, **kwargs: Any) -> None:
+        captured["client"] = {"timeout": kwargs.get("timeout")}
+        self._captured = captured
+
+    async def __aenter__(self) -> "_DummyAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, url: str, *, json: dict[str, object]) -> "_DummyResponse":
+        self._captured["request"] = {"url": url, "json": json}
+        return _DummyResponse(url)
+
+
+class _DummyResponse:
+    def __init__(self, url: str) -> None:
+        self.status_code = 200
+        self._request = httpx.Request("POST", url)
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        return None
+
+    def json(self) -> dict[str, object]:
+        return {"ok": True}
+
+
 def test_environment_endpoint_reflects_env_overrides(monkeypatch, load_service_module):
     monkeypatch.setenv("PORT", "9090")
     monkeypatch.setenv("NATS_URL", "nats://demo:4222")
@@ -120,11 +149,11 @@ def test_mcp_endpoints_expose_registry(monkeypatch, load_service_module):
 
     executed: dict[str, tuple[str, dict]] = {}
 
-    def fake_execute(cmd, args):
+    async def fake_execute(cmd, args):
         executed["call"] = (cmd, args)
         return {"ok": True, "args": args}
 
-    monkeypatch.setattr(module.mcp_server, "execute_command", fake_execute)
+    monkeypatch.setattr(module.mcp_server, "execute_command_async", fake_execute)
 
     with TestClient(module.app) as client:
         commands_response = client.get("/mcp/commands")
@@ -153,22 +182,10 @@ def test_geometry_decode_text_uses_new_payload(monkeypatch, load_service_module)
 
     captured: dict[str, dict[str, object]] = {}
 
-    class DummyResponse:
-        status_code = 200
+    def fake_async_client(*args: Any, **kwargs: Any) -> _DummyAsyncClient:
+        return _DummyAsyncClient(captured, *args, **kwargs)
 
-        def raise_for_status(self) -> None:  # pragma: no cover - simple stub
-            return None
-
-        def json(self) -> dict[str, object]:
-            return {"ok": True}
-
-    def fake_post(url: str, json: dict[str, object], timeout: int) -> DummyResponse:
-        captured["url"] = url
-        captured["json"] = json
-        captured["timeout"] = timeout
-        return DummyResponse()
-
-    monkeypatch.setattr(module.mcp_server.requests, "post", fake_post)
+    monkeypatch.setattr(module.mcp_server.httpx, "AsyncClient", fake_async_client)
 
     with TestClient(module.app) as client:
         response = client.post(
@@ -188,10 +205,10 @@ def test_geometry_decode_text_uses_new_payload(monkeypatch, load_service_module)
     payload = response.json()
     assert payload["result"]["ok"] is True
 
-    assert captured["url"] == f"{module.mcp_server.GATEWAY_URL}/geometry/decode/text"
-    assert captured["timeout"] == 60
+    assert captured["request"]["url"] == f"{module.mcp_server.GATEWAY_URL}/geometry/decode/text"
+    assert captured["client"]["timeout"] == 60.0
 
-    request_body = captured["json"]
+    request_body = captured["request"]["json"]
     assert request_body["mode"] == "geometry"
     assert request_body["constellation_id"] == "const-123"
     assert request_body["k"] == 3

--- a/pmoves/services/agent-zero/tests/test_mcp_server.py
+++ b/pmoves/services/agent-zero/tests/test_mcp_server.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict
 
+import httpx
 import pytest
-import requests
 
 
 @pytest.fixture(scope="module")
@@ -26,13 +27,55 @@ class _DummyResponse:
         self.status_code = status_code
         self._payload = payload or {}
         self.text = text
+        self._request: httpx.Request | None = None
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
-            raise requests.exceptions.HTTPError(f"status {self.status_code}", response=self)
+            raise httpx.HTTPStatusError(
+                f"status {self.status_code}",
+                request=self._request or httpx.Request("POST", "http://notebook.invalid"),
+                response=httpx.Response(self.status_code),
+            )
 
     def json(self) -> Dict[str, Any]:
         return self._payload
+
+
+def _install_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+    mcp_module: ModuleType,
+    responses: list[_DummyResponse],
+    captured: Dict[str, Any],
+) -> None:
+    queue = list(responses)
+
+    class _DummyAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self) -> "_DummyAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: Dict[str, Any],
+            headers: Dict[str, str],
+        ) -> _DummyResponse:
+            captured.setdefault("calls", []).append(
+                {"url": url, "json": json, "headers": headers}
+            )
+            if not queue:
+                raise AssertionError(f"Unexpected extra request to {url}")
+            response = queue.pop(0)
+            response._request = httpx.Request("POST", url)
+            return response
+
+    monkeypatch.setattr(mcp_module.httpx, "AsyncClient", _DummyAsyncClient)
 
 
 def test_notebook_search_uses_modern_endpoint(monkeypatch: pytest.MonkeyPatch, mcp_module: ModuleType) -> None:
@@ -41,23 +84,26 @@ def test_notebook_search_uses_modern_endpoint(monkeypatch: pytest.MonkeyPatch, m
     monkeypatch.setattr(mcp_module, "NOTEBOOK_WORKSPACE", None)
 
     captured: Dict[str, Any] = {}
+    _install_async_client(
+        monkeypatch,
+        mcp_module,
+        [
+            _DummyResponse(
+                200,
+                payload={
+                    "results": [{"id": "n1", "title": "First note"}],
+                    "total_count": 1,
+                    "search_type": "text",
+                },
+            )
+        ],
+        captured,
+    )
+    result = asyncio.run(mcp_module.notebook_search({"query": "pmoves", "limit": 3}))
 
-    def _post(url: str, json: Dict[str, Any], headers: Dict[str, str], timeout: int) -> _DummyResponse:
-        captured["url"] = url
-        captured["json"] = json
-        captured["headers"] = headers
-        captured["timeout"] = timeout
-        return _DummyResponse(
-            200,
-            payload={"results": [{"id": "n1", "title": "First note"}], "total_count": 1, "search_type": "text"},
-        )
-
-    monkeypatch.setattr(mcp_module.requests, "post", _post)
-    result = mcp_module.notebook_search({"query": "pmoves", "limit": 3})
-
-    assert captured["url"] == "http://notebook:5055/api/search"
-    assert captured["json"] == {"query": "pmoves", "limit": 3}
-    assert captured["timeout"] == 20
+    assert captured["calls"][0]["url"] == "http://notebook:5055/api/search"
+    assert captured["calls"][0]["json"] == {"query": "pmoves", "limit": 3}
+    assert captured["timeout"] == 20.0
     assert result["ok"] is True
     assert result["total"] == 1
     assert result["endpoint"] == "/api/search"
@@ -69,22 +115,33 @@ def test_notebook_search_with_filters_uses_modern_endpoint(monkeypatch: pytest.M
     monkeypatch.setattr(mcp_module, "NOTEBOOK_API_TOKEN", "token")
     monkeypatch.setattr(mcp_module, "NOTEBOOK_WORKSPACE", None)
 
-    calls: list[tuple[str, Dict[str, Any]]] = []
-    sequence = [
-        _DummyResponse(200, payload={"results": [{"note": {"id": "modern-1", "title": "Modern note"}}], "total": 1}),
-    ]
+    captured: Dict[str, Any] = {}
+    _install_async_client(
+        monkeypatch,
+        mcp_module,
+        [
+            _DummyResponse(
+                200,
+                payload={
+                    "results": [{"note": {"id": "modern-1", "title": "Modern note"}}],
+                    "total": 1,
+                },
+            )
+        ],
+        captured,
+    )
+    result = asyncio.run(
+        mcp_module.notebook_search({"query": "pmoves", "limit": 2, "notebook_id": "nb-1"})
+    )
 
-    def _post(url: str, json: Dict[str, Any], headers: Dict[str, str], timeout: int) -> _DummyResponse:
-        calls.append((url, json))
-        return sequence[len(calls) - 1]
-
-    monkeypatch.setattr(mcp_module.requests, "post", _post)
-    result = mcp_module.notebook_search({"query": "pmoves", "limit": 2, "notebook_id": "nb-1"})
-
-    assert [url for url, _ in calls] == [
+    assert [call["url"] for call in captured["calls"]] == [
         "http://notebook:5055/api/search",
     ]
-    assert calls[0][1] == {"query": "pmoves", "limit": 2, "filters": {"notebook_id": "nb-1"}}
+    assert captured["calls"][0]["json"] == {
+        "query": "pmoves",
+        "limit": 2,
+        "filters": {"notebook_id": "nb-1"},
+    }
     assert result["endpoint"] == "/api/search"
     assert result["notes"][0]["id"] == "modern-1"
 
@@ -96,27 +153,34 @@ def test_notebook_search_with_filters_falls_back_to_legacy_endpoint(
     monkeypatch.setattr(mcp_module, "NOTEBOOK_API_TOKEN", "token")
     monkeypatch.setattr(mcp_module, "NOTEBOOK_WORKSPACE", None)
 
-    calls: list[tuple[str, Dict[str, Any]]] = []
-    sequence = [
-        _DummyResponse(404, payload={"detail": "not found"}),
-        _DummyResponse(404, payload={"detail": "not found"}),
-        _DummyResponse(200, payload={"results": [{"note": {"id": "legacy-1", "title": "Legacy note"}}], "total": 1}),
-    ]
+    captured: Dict[str, Any] = {}
+    _install_async_client(
+        monkeypatch,
+        mcp_module,
+        [
+            _DummyResponse(404, payload={"detail": "not found"}),
+            _DummyResponse(404, payload={"detail": "not found"}),
+            _DummyResponse(
+                200,
+                payload={
+                    "results": [{"note": {"id": "legacy-1", "title": "Legacy note"}}],
+                    "total": 1,
+                },
+            ),
+        ],
+        captured,
+    )
+    result = asyncio.run(
+        mcp_module.notebook_search({"query": "pmoves", "limit": 2, "notebook_id": "nb-1"})
+    )
 
-    def _post(url: str, json: Dict[str, Any], headers: Dict[str, str], timeout: int) -> _DummyResponse:
-        calls.append((url, json))
-        return sequence[len(calls) - 1]
-
-    monkeypatch.setattr(mcp_module.requests, "post", _post)
-    result = mcp_module.notebook_search({"query": "pmoves", "limit": 2, "notebook_id": "nb-1"})
-
-    assert [url for url, _ in calls] == [
+    assert [call["url"] for call in captured["calls"]] == [
         "http://notebook:5055/api/search",
         "http://notebook:5055/search",
         "http://notebook:5055/api/v1/notebooks/search",
     ]
-    assert calls[0][1]["filters"] == {"notebook_id": "nb-1"}
-    assert calls[2][1]["filters"] == {"notebook_id": "nb-1"}
+    assert captured["calls"][0]["json"]["filters"] == {"notebook_id": "nb-1"}
+    assert captured["calls"][2]["json"]["filters"] == {"notebook_id": "nb-1"}
     assert result["endpoint"] == "/api/v1/notebooks/search"
     assert result["notes"][0]["id"] == "legacy-1"
 
@@ -125,16 +189,20 @@ def test_notebook_search_supports_data_key(monkeypatch: pytest.MonkeyPatch, mcp_
     monkeypatch.setattr(mcp_module, "NOTEBOOK_API_URL", "http://notebook:5055")
     monkeypatch.setattr(mcp_module, "NOTEBOOK_API_TOKEN", "token")
     monkeypatch.setattr(mcp_module, "NOTEBOOK_WORKSPACE", None)
-    monkeypatch.setattr(
-        mcp_module.requests,
-        "post",
-        lambda *args, **kwargs: _DummyResponse(
-            200,
-            payload={"data": [{"id": "n-data-1", "title": "Data note"}], "total": 1},
-        ),
+    captured: Dict[str, Any] = {}
+    _install_async_client(
+        monkeypatch,
+        mcp_module,
+        [
+            _DummyResponse(
+                200,
+                payload={"data": [{"id": "n-data-1", "title": "Data note"}], "total": 1},
+            )
+        ],
+        captured,
     )
 
-    result = mcp_module.notebook_search({"query": "pmoves", "limit": 1})
+    result = asyncio.run(mcp_module.notebook_search({"query": "pmoves", "limit": 1}))
     assert result["notes"][0]["id"] == "n-data-1"
     assert result["total"] == 1
 
@@ -145,11 +213,13 @@ def test_notebook_search_surfaces_auth_errors_as_value_error(
     monkeypatch.setattr(mcp_module, "NOTEBOOK_API_URL", "http://notebook:5055")
     monkeypatch.setattr(mcp_module, "NOTEBOOK_API_TOKEN", "token")
     monkeypatch.setattr(mcp_module, "NOTEBOOK_WORKSPACE", None)
-    monkeypatch.setattr(
-        mcp_module.requests,
-        "post",
-        lambda *args, **kwargs: _DummyResponse(401, payload={"detail": "unauthorized"}, text="unauthorized"),
+    captured: Dict[str, Any] = {}
+    _install_async_client(
+        monkeypatch,
+        mcp_module,
+        [_DummyResponse(401, payload={"detail": "unauthorized"}, text="unauthorized")],
+        captured,
     )
 
     with pytest.raises(ValueError, match="authentication failed"):
-        mcp_module.notebook_search({"query": "pmoves", "limit": 1})
+        asyncio.run(mcp_module.notebook_search({"query": "pmoves", "limit": 1}))

--- a/pmoves/tests/test_common/test_bootstrap.py
+++ b/pmoves/tests/test_common/test_bootstrap.py
@@ -1,0 +1,65 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[3]
+if str(repo_root) not in sys.path:
+    sys.path.append(str(repo_root))
+
+sys.modules.setdefault("services", importlib.import_module("pmoves.services"))
+
+from services.common.bootstrap import bootstrap_import_paths, ensure_import_paths
+
+
+def test_bootstrap_adds_service_dir():
+    """bootstrap_import_paths adds the service dir to sys.path."""
+    fake_file = str(repo_root / "pmoves" / "services" / "my-svc" / "main.py")
+    original_path = sys.path[:]
+    try:
+        bootstrap_import_paths(file_ref=fake_file)
+        # The service dir (parent[0]) should be in sys.path
+        service_dir = str(Path(fake_file).resolve().parent)
+        assert service_dir in sys.path
+        # The services dir (parent[1]) should also be in sys.path
+        services_dir = str(Path(fake_file).resolve().parents[1])
+        assert services_dir in sys.path
+    finally:
+        sys.path[:] = original_path
+
+
+def test_bootstrap_with_extra_roots():
+    """bootstrap_import_paths adds extra_roots to sys.path."""
+    extra = Path("/tmp/fake_extra_root")
+    original_path = sys.path[:]
+    try:
+        bootstrap_import_paths(
+            file_ref=str(repo_root / "pmoves" / "services" / "svc" / "main.py"),
+            extra_roots=[extra],
+        )
+        assert str(extra) in sys.path
+    finally:
+        sys.path[:] = original_path
+
+
+def test_bootstrap_idempotent():
+    """Calling bootstrap_import_paths twice does not duplicate entries."""
+    fake_file = str(repo_root / "pmoves" / "services" / "my-svc" / "main.py")
+    original_path = sys.path[:]
+    try:
+        bootstrap_import_paths(file_ref=fake_file)
+        path_snapshot = sys.path[:]
+        bootstrap_import_paths(file_ref=fake_file)
+        # No duplicates added
+        assert sys.path == path_snapshot
+    finally:
+        sys.path[:] = original_path
+
+
+def test_ensure_import_paths_calls_bootstrap():
+    """ensure_import_paths delegates to bootstrap_import_paths."""
+    with patch("services.common.bootstrap.bootstrap_import_paths") as mock_bs:
+        ensure_import_paths()
+        mock_bs.assert_called_once()

--- a/pmoves/tests/test_common/test_config.py
+++ b/pmoves/tests/test_common/test_config.py
@@ -1,0 +1,55 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[3]
+if str(repo_root) not in sys.path:
+    sys.path.append(str(repo_root))
+
+sys.modules.setdefault("services", importlib.import_module("pmoves.services"))
+
+from services.common.config import BaseServiceSettings, TensorZeroSettings, env_bool
+
+
+def test_env_bool_truthy_values():
+    """env_bool returns True for truthy strings."""
+    for val in ("1", "true", "yes", "on"):
+        with patch.dict(os.environ, {"TEST_BOOL": val}):
+            assert env_bool("TEST_BOOL") is True
+    # Also test case insensitivity
+    for val in ("TRUE", "True", "YES", "ON"):
+        with patch.dict(os.environ, {"TEST_BOOL": val}):
+            assert env_bool("TEST_BOOL") is True
+
+
+def test_env_bool_falsy_values():
+    """env_bool returns False for falsy strings."""
+    for val in ("0", "false", "no", "off", ""):
+        with patch.dict(os.environ, {"TEST_BOOL": val}):
+            assert env_bool("TEST_BOOL") is False
+
+
+def test_env_bool_default():
+    """env_bool returns default when env var is unset."""
+    os.environ.pop("TEST_BOOL_UNSET", None)
+    assert env_bool("TEST_BOOL_UNSET", default=False) is False
+    assert env_bool("TEST_BOOL_UNSET", default=True) is True
+
+
+def test_base_service_settings_from_env(monkeypatch):
+    """BaseServiceSettings loads from environment variables."""
+    monkeypatch.setenv("NATS_URL", "nats://test:4222")
+    monkeypatch.setenv("PORT", "9090")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("DOCKED_MODE", "true")
+    monkeypatch.setenv("DEBUG", "1")
+    settings = BaseServiceSettings()
+    assert settings.nats_url == "nats://test:4222"
+    assert settings.port == 9090
+    assert settings.log_level == "DEBUG"
+    assert settings.docked_mode is True
+    assert settings.debug is True

--- a/pmoves/tests/test_common/test_health.py
+++ b/pmoves/tests/test_common/test_health.py
@@ -1,0 +1,53 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[3]
+if str(repo_root) not in sys.path:
+    sys.path.append(str(repo_root))
+
+sys.modules.setdefault("services", importlib.import_module("pmoves.services"))
+
+from services.common.health import (
+    build_health_payload,
+    create_health_endpoint,
+    get_uptime_seconds,
+)
+
+
+def test_build_health_payload_status_ok():
+    """build_health_payload returns correct structure with status='ok'."""
+    payload = build_health_payload(service_name="test-svc", status="ok")
+    assert payload["status"] == "ok"
+    assert payload["service"] == "test-svc"
+    assert "uptime_seconds" in payload
+    assert isinstance(payload["uptime_seconds"], float)
+
+
+def test_build_health_payload_custom_status():
+    """build_health_payload passes through custom status."""
+    payload = build_health_payload(
+        service_name="my-svc",
+        status="degraded",
+        extra={"db": "unhealthy"},
+    )
+    assert payload["status"] == "degraded"
+    assert payload["service"] == "my-svc"
+    assert payload["db"] == "unhealthy"
+
+
+def test_get_uptime_seconds_positive():
+    """get_uptime_seconds returns a positive value."""
+    uptime = get_uptime_seconds()
+    assert uptime > 0
+
+
+def test_create_health_endpoint_returns_callable():
+    """create_health_endpoint returns an async callable."""
+    handler = create_health_endpoint(service_name="test-svc")
+    assert callable(handler)
+    assert asyncio.iscoroutinefunction(handler)

--- a/pmoves/tests/test_common/test_logging.py
+++ b/pmoves/tests/test_common/test_logging.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[3]
+if str(repo_root) not in sys.path:
+    sys.path.append(str(repo_root))
+
+sys.modules.setdefault("services", importlib.import_module("pmoves.services"))
+
+from services.common.logging import configure_structlog, get_logger, setup_logging
+
+
+def test_configure_structlog_default():
+    """configure_structlog with defaults does not raise."""
+    configure_structlog()
+    # If structlog is available, it was configured; if not, basicConfig was called.
+    # Either way, no exception.
+
+
+def test_configure_structlog_custom_level():
+    """configure_structlog accepts custom log_level."""
+    configure_structlog(log_level="DEBUG")
+    # No exception raised
+
+
+def test_get_logger_returns_logger():
+    """get_logger returns a logger-like object."""
+    logger = get_logger("test.module")
+    assert logger is not None
+    assert callable(getattr(logger, "info", None)) or callable(getattr(logger, "debug", None))
+
+
+def test_setup_logging_returns_logger():
+    """setup_logging configures structlog and returns a logger."""
+    logger = setup_logging("test.setup", log_level="INFO")
+    assert logger is not None
+    assert callable(getattr(logger, "info", None)) or callable(getattr(logger, "debug", None))

--- a/pmoves/tests/test_common/test_nats_client.py
+++ b/pmoves/tests/test_common/test_nats_client.py
@@ -1,0 +1,86 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[3]
+if str(repo_root) not in sys.path:
+    sys.path.append(str(repo_root))
+
+sys.modules.setdefault("services", importlib.import_module("pmoves.services"))
+
+from services.common.nats_client import (
+    DEFAULT_NATS_URL,
+    NatsConnectionConfig,
+    create_nats_connection,
+)
+
+
+def test_default_nats_url_from_env(monkeypatch):
+    """DEFAULT_NATS_URL reads from NATS_URL env var."""
+    monkeypatch.setenv("NATS_URL", "nats://custom:4222")
+    # Re-import to pick up env change
+    import importlib
+    from services.common import nats_client as nc_mod
+    importlib.reload(nc_mod)
+    assert nc_mod.DEFAULT_NATS_URL == "nats://custom:4222"
+    # Restore
+    monkeypatch.delenv("NATS_URL")
+    importlib.reload(nc_mod)
+
+
+def test_nats_connection_config_defaults():
+    """NatsConnectionConfig has sensible defaults."""
+    config = NatsConnectionConfig()
+    assert config.max_reconnect_attempts == 60
+    assert config.reconnect_time_wait == 2.0
+    assert config.connect_timeout == 10.0
+    assert config.ping_interval == 120.0
+    assert config.max_outstanding_pings == 2
+    assert config.name is None
+    assert config.error_cb is None
+
+
+def test_nats_connection_config_custom():
+    """NatsConnectionConfig accepts custom values."""
+    cb = MagicMock()
+    config = NatsConnectionConfig(
+        url="nats://host:1234",
+        name="test-svc",
+        max_reconnect_attempts=5,
+        connect_timeout=3.0,
+        error_cb=cb,
+    )
+    assert config.url == "nats://host:1234"
+    assert config.name == "test-svc"
+    assert config.max_reconnect_attempts == 5
+    assert config.connect_timeout == 3.0
+    assert config.error_cb is cb
+    kwargs = config.to_connect_kwargs()
+    assert kwargs["name"] == "test-svc"
+    assert kwargs["error_cb"] is cb
+
+
+@pytest.mark.asyncio
+async def test_create_nats_connection_success():
+    """create_nats_connection returns a connected client."""
+    mock_nc = MagicMock()
+    mock_nats_module = MagicMock()
+    mock_nats_module.connect = AsyncMock(return_value=mock_nc)
+    with patch.dict("sys.modules", {"nats": mock_nats_module}):
+        result = await create_nats_connection()
+        assert result is mock_nc
+        mock_nats_module.connect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_nats_connection_retry_on_failure():
+    """create_nats_connection raises ConnectionError on failure."""
+    mock_nats_module = MagicMock()
+    mock_nats_module.connect = AsyncMock(side_effect=Exception("connection refused"))
+    with patch.dict("sys.modules", {"nats": mock_nats_module}):
+        with pytest.raises(ConnectionError, match="NATS connection failed"):
+            await create_nats_connection()

--- a/pmoves/tests/test_common/test_tensorzero_config.py
+++ b/pmoves/tests/test_common/test_tensorzero_config.py
@@ -1,0 +1,73 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[3]
+if str(repo_root) not in sys.path:
+    sys.path.append(str(repo_root))
+
+sys.modules.setdefault("services", importlib.import_module("pmoves.services"))
+
+from services.common.tensorzero import (
+    sync_openai_compat_env,
+    tensorzero_openai_base,
+)
+
+
+def test_tensorzero_openai_base_from_env(monkeypatch):
+    """When TENSORZERO_BASE_URL is set, it is used directly."""
+    monkeypatch.delenv("TENSORZERO_BASE_URL", raising=False)
+    monkeypatch.delenv("TENSORZERO_URL", raising=False)
+    monkeypatch.delenv("DOCKED_MODE", raising=False)
+    monkeypatch.setenv("TENSORZERO_BASE_URL", "http://my-tz:3030")
+    result = tensorzero_openai_base()
+    assert "my-tz:3030" in result
+    assert result.endswith("/openai/v1")
+
+
+def test_tensorzero_openai_base_from_tensorzero_url(monkeypatch):
+    """When TENSORZERO_URL is set (no TENSORZERO_BASE_URL), derive the base."""
+    monkeypatch.delenv("TENSORZERO_BASE_URL", raising=False)
+    monkeypatch.delenv("DOCKED_MODE", raising=False)
+    monkeypatch.setenv("TENSORZERO_URL", "http://parent-tz:3000")
+    result = tensorzero_openai_base()
+    assert "parent-tz:3000" in result
+    assert result.endswith("/openai/v1")
+
+
+def test_sync_openai_compat_env_sets_vars(monkeypatch):
+    """sync_openai_compat_env sets OPENAI_API_KEY from TENSORZERO_API_KEY."""
+    monkeypatch.delenv("OPENAI_COMPATIBLE_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.setenv("TENSORZERO_BASE_URL", "http://tz:3030")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    def fake_secret(key):
+        # OPENAI_API_KEY is not set -> return empty to trigger TZ fallback
+        if key == "OPENAI_API_KEY":
+            return ""
+        if key == "TENSORZERO_API_KEY":
+            return "test-tz-key"
+        return ""
+
+    sync_openai_compat_env(get_secret=fake_secret)
+
+    # OPENAI_API_KEY should have been derived from TENSORZERO_API_KEY
+    assert os.environ.get("OPENAI_API_KEY") == "test-tz-key"
+
+
+def test_check_connectivity_timeout(monkeypatch):
+    """When TensorZero is unreachable, tensorzero_openai_base returns empty."""
+    monkeypatch.delenv("TENSORZERO_BASE_URL", raising=False)
+    monkeypatch.delenv("TENSORZERO_URL", raising=False)
+    monkeypatch.delenv("DOCKED_MODE", raising=False)
+    # With DOCKED_MODE not set, it defaults to host.docker.internal
+    with patch(
+        "services.common.tensorzero._check_tensorzero_sync", return_value=False
+    ):
+        result = tensorzero_openai_base(check_connectivity=True)
+        assert result == ""


### PR DESCRIPTION
## Summary

Implements **Recommendations #11-13** — K8s NetworkPolicies, common library tests, and async HTTP migration.

### Rec #11 — K8s NetworkPolicies
`deploy/k8s/networkpolicies/` with 6 policies:
- default-deny — deny all ingress/egress
- allow-dns — DNS resolution
- allow-nats-mesh — inter-service NATS
- allow-ingress — gateway agent traffic
- allow-monitoring — Prometheus scraping
- allow-external-api — HuggingFace, OpenAI egress
+ kustomization.yaml

### Rec #12 — Common Library Tests
`pmoves/tests/test_common/` with 6 test files, **25 tests** covering:
bootstrap, config, health, logging, nats_client, tensorzero

### Rec #13 — Async HTTP Migration
`mcp_server.py` migrated from sync `requests` to async `httpx.AsyncClient`:
- 16 async functions
- All error handling preserved
- `main()` uses asyncio event loop for stdio shim

**Related**: Review Recommendations #11, #12, #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Kubernetes network policies for DNS, ingress, monitoring, and internal service mesh communications within the cluster.

* **Improvements**
  * Optimized service execution with native async patterns for improved performance and resource efficiency.

* **Tests**
  * Added comprehensive test coverage for configuration, health monitoring, logging, and connectivity modules.

* **Chores**
  * Updated runtime dependencies to support async HTTP operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->