### PR TITLE
feat(flute): VoiceboxProvider integration + profile-create Make target (Session 12 Lane 1)

### DIFF
--- a/pmoves/Makefile
+++ b/pmoves/Makefile
@@ -2730,6 +2730,98 @@ vibevoice-smoke: ## Check VibeVoice realtime /config (requires VibeVoice running
 	curl -sS "http://localhost:$$port/config" | jq .
 
 # ────────────────────────────────────────────────────────────────────────────
+# VOICEBOX (Pinokio-managed voice production service)
+# ────────────────────────────────────────────────────────────────────────────
+# Voicebox is NOT docker-compose managed — it runs as a Pinokio app on the
+# host (default port 17493). The flute-gateway VoiceboxProvider talks to it
+# over HTTP via VOICEBOX_URL=http://host.docker.internal:17493 by default.
+#
+# First-run blocker: Voicebox ships with 0 voice profiles. Create at least
+# one profile via the Voicebox UI and download Qwen3-TTS 1.7B BEFORE
+# attempting synthesis, otherwise /generate/stream returns 404.
+
+.PHONY: up-voicebox
+up-voicebox: ## Start Voicebox via Pinokio (host-side, NOT docker-compose)
+	@echo "Voicebox is a Pinokio-managed app and must be launched via the Pinokio UI"
+	@echo "  pterm path: $$(curl -sf http://127.0.0.1:42000/pinokio/path/pterm 2>/dev/null || echo 'D:/pinokio/bin/npm/pterm.cmd')"
+	@echo "  start: pterm run voicebox.pinokio.git"
+	@echo "  expected URL: http://localhost:$${VOICEBOX_HOST_PORT:-17493}"
+	@echo "  flute-gateway uses: VOICEBOX_URL=$${VOICEBOX_URL:-http://host.docker.internal:$${VOICEBOX_HOST_PORT:-17493}}"
+
+.PHONY: voicebox-smoke
+voicebox-smoke: ## Smoke check Voicebox /health (expects 200, reports profile count)
+	@which jq >/dev/null 2>&1 || (echo "jq is required for voicebox-smoke" && exit 1)
+	@port=$${VOICEBOX_HOST_PORT:-17493}; \
+	code=$$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$$port/health" || true); \
+	if [ "$$code" != "200" ]; then \
+	  echo "✖ Voicebox /health => $$code (start via Pinokio: pterm run voicebox.pinokio.git)"; \
+	  exit 1; \
+	fi; \
+	echo "✔ Voicebox /health 200"; \
+	curl -sS "http://localhost:$$port/health" | jq '{model_loaded, model_downloaded, gpu_type, backend_variant}'; \
+	profile_count=$$(curl -sS "http://localhost:$$port/profiles" | jq 'length' 2>/dev/null || echo "?"); \
+	echo "  profiles: $$profile_count"; \
+	if [ "$$profile_count" = "0" ]; then \
+	  echo "  ⚠ no profiles configured — synthesis will fail until a profile is created via the Voicebox UI"; \
+	fi
+
+.PHONY: voicebox-status
+voicebox-status: ## List Voicebox voice profiles via /profiles
+	@which jq >/dev/null 2>&1 || (echo "jq is required for voicebox-status" && exit 1)
+	@port=$${VOICEBOX_HOST_PORT:-17493}; \
+	code=$$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$$port/profiles" || true); \
+	if [ "$$code" != "200" ]; then \
+	  echo "✖ Voicebox /profiles => $$code"; \
+	  exit 1; \
+	fi; \
+	curl -sS "http://localhost:$$port/profiles" | jq '.[] | {id, name, default_engine, language}'
+
+.PHONY: voicebox-profile-create
+voicebox-profile-create: ## Create a default Voicebox preset profile (Kokoro, no audio sample needed)
+	@which jq >/dev/null 2>&1 || (echo "jq is required for voicebox-profile-create" && exit 1)
+	@port=$${VOICEBOX_HOST_PORT:-17493}; \
+	engine=$${VOICEBOX_PROFILE_ENGINE:-kokoro}; \
+	echo "Voicebox: creating default '$$engine' preset profile..."; \
+	echo "  fetching presets via GET /profiles/presets/$$engine"; \
+	preset_json=$$(curl -sf "http://localhost:$$port/profiles/presets/$$engine"); \
+	if [ -z "$$preset_json" ]; then \
+	  echo "✖ failed to fetch preset voices for engine '$$engine' (start Voicebox first: pterm run voicebox.pinokio.git)"; \
+	  exit 1; \
+	fi; \
+	voice_id=$$(echo "$$preset_json" | jq -r '.voices[0].voice_id // empty'); \
+	voice_name=$$(echo "$$preset_json" | jq -r '.voices[0].name // empty'); \
+	if [ -z "$$voice_id" ]; then \
+	  echo "✖ no preset voices returned for engine '$$engine' (response: $$preset_json)"; \
+	  exit 1; \
+	fi; \
+	echo "  selected voice: $$voice_name ($$voice_id)"; \
+	profile_name=$${VOICEBOX_PROFILE_NAME:-PMOVES Default}; \
+	body=$$(jq -nc \
+	  --arg name "$$profile_name" \
+	  --arg engine "$$engine" \
+	  --arg voice_id "$$voice_id" \
+	  '{name: $$name, voice_type: "preset", language: "en", preset_engine: $$engine, preset_voice_id: $$voice_id, default_engine: $$engine}'); \
+	echo "  POST /profiles body: $$body"; \
+	resp=$$(curl -sf -X POST "http://localhost:$$port/profiles" \
+	  -H "Content-Type: application/json" \
+	  -d "$$body"); \
+	if [ -z "$$resp" ]; then \
+	  echo "✖ Voicebox /profiles POST failed (try voicebox-status to inspect existing profiles)"; \
+	  exit 1; \
+	fi; \
+	profile_id=$$(echo "$$resp" | jq -r '.id'); \
+	echo "✔ Voicebox profile created"; \
+	echo "  id:   $$profile_id"; \
+	echo "  name: $$profile_name"; \
+	echo "  engine: $$engine"; \
+	echo "  voice: $$voice_name ($$voice_id)"; \
+	echo ""; \
+	echo "  Test synthesis: curl http://localhost:$$port/generate/stream -X POST \\"; \
+	echo "                   -H 'Content-Type: application/json' \\"; \
+	echo "                   -d '{\"profile_id\":\"$$profile_id\",\"text\":\"Hello world\",\"engine\":\"$$engine\"}' \\"; \
+	echo "                   -o /tmp/voicebox-test.wav"
+
+# ────────────────────────────────────────────────────────────────────────────
 # FLUTE-GATEWAY VOICE SERVICE
 # ────────────────────────────────────────────────────────────────────────────
 

--- a/pmoves/services/flute-gateway/main.py
+++ b/pmoves/services/flute-gateway/main.py
@@ -41,6 +41,10 @@ from providers import (
     VibeVoiceBusyError,
     VibeVoiceNoAudioError,
     VibeVoiceProvider,
+    VoiceboxBusyError,
+    VoiceboxError,
+    VoiceboxNoProfileError,
+    VoiceboxProvider,
     WhisperProvider,
     UltimateTTSError,
     UltimateTTSProvider,
@@ -129,6 +133,9 @@ SUPABASE_KEY = get_secret("SUPABASE_SERVICE_ROLE_KEY", "")
 VIBEVOICE_URL = (os.getenv("VIBEVOICE_URL") or "http://host.docker.internal:7860").strip()
 WHISPER_URL = os.getenv("WHISPER_URL", "http://ffmpeg-whisper:8078")
 ULTIMATE_TTS_URL = os.getenv("ULTIMATE_TTS_URL", "http://host.docker.internal:7860")
+# Voicebox is a Pinokio-managed voice production service (default port 17493).
+# Set VOICEBOX_URL="" to disable. Auto-normalized for Docker contexts below.
+VOICEBOX_URL = os.getenv("VOICEBOX_URL", "http://host.docker.internal:17493")
 DEFAULT_PROVIDER = os.getenv("DEFAULT_VOICE_PROVIDER", "vibevoice")
 FLUTE_API_KEY = get_secret("FLUTE_API_KEY", "")
 
@@ -174,6 +181,8 @@ def _normalize_vibevoice_url(url: str) -> str:
 
 
 VIBEVOICE_URL = _normalize_vibevoice_url(VIBEVOICE_URL)
+# Voicebox runs on the host via Pinokio — same Docker-context normalization applies.
+VOICEBOX_URL = _normalize_vibevoice_url(VOICEBOX_URL)
 
 # API Key authentication dependency
 async def verify_api_key(x_api_key: str = Header(None, alias="X-API-Key")):
@@ -211,6 +220,7 @@ CHIT_EVENTS_FAILED = Counter(
 vibevoice_provider: Optional[VibeVoiceProvider] = None
 whisper_provider: Optional[WhisperProvider] = None
 ultimate_tts_provider: Optional[UltimateTTSProvider] = None
+voicebox_provider: Optional[VoiceboxProvider] = None
 nats_client = None
 
 
@@ -326,7 +336,7 @@ class ConfigResponse(BaseModel):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan - startup and shutdown with NATS service announcement."""
-    global vibevoice_provider, whisper_provider, ultimate_tts_provider, nats_client
+    global vibevoice_provider, whisper_provider, ultimate_tts_provider, voicebox_provider, nats_client
 
     logger.info("Starting Flute Gateway...")
 
@@ -358,6 +368,14 @@ async def lifespan(app: FastAPI):
     else:
         ultimate_tts_provider = None
         logger.info("Ultimate-TTS disabled (set ULTIMATE_TTS_URL to enable).")
+
+    # Initialize Voicebox provider (optional)
+    if VOICEBOX_URL:
+        voicebox_provider = VoiceboxProvider(VOICEBOX_URL)
+        logger.info("Voicebox provider enabled at %s (synthesis requires a profile)", VOICEBOX_URL)
+    else:
+        voicebox_provider = None
+        logger.info("Voicebox disabled (set VOICEBOX_URL to enable).")
 
     # Initialize NATS (optional)
     try:
@@ -428,6 +446,12 @@ async def health_check():
     else:
         providers["ultimate_tts"] = False
 
+    # Check Voicebox
+    if voicebox_provider:
+        providers["voicebox"] = await voicebox_provider.health_check()
+    else:
+        providers["voicebox"] = False
+
     # Check NATS
     nats_status = "connected" if nats_client and nats_client.is_connected else "disconnected"
 
@@ -463,6 +487,8 @@ async def get_config():
         providers.insert(0, "vibevoice")
     if ultimate_tts_provider:
         providers.append("ultimate_tts")
+    if voicebox_provider:
+        providers.append("voicebox")
 
     return ConfigResponse(
         providers=providers,
@@ -564,6 +590,35 @@ async def synthesize_speech(request: SynthesizeRequest):
                 sample_rate=24000,
                 format="wav"
             )
+        elif provider_name == "voicebox" and voicebox_provider:
+            audio_data = await voicebox_provider.synthesize(
+                text=request.text,
+                voice=request.voice,
+                engine=request.engine,
+            )
+            if not audio_data:
+                raise HTTPException(status_code=502, detail="Voicebox returned empty audio.")
+            duration = time.time() - start_time
+            TTS_DURATION.labels(provider="voicebox").observe(duration)
+
+            # Estimate audio duration from WAV (24kHz assumed; Voicebox uses Qwen3-TTS at 12kHz/24kHz)
+            audio_duration = len(audio_data) / 48000
+
+            REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize", status="200").inc()
+
+            # Publish CHIT voice attribution event (best-effort)
+            await _publish_chit_voice_event(
+                provider="voicebox",
+                text_length=len(request.text),
+                audio_duration=audio_duration,
+                voice=request.voice,
+            )
+
+            return SynthesizeResponse(
+                duration_seconds=audio_duration,
+                sample_rate=24000,
+                format="wav"
+            )
         else:
             if provider_name == "vibevoice" and not vibevoice_provider:
                 raise HTTPException(
@@ -575,9 +630,18 @@ async def synthesize_speech(request: SynthesizeRequest):
                     status_code=503,
                     detail="Ultimate-TTS provider not configured (set ULTIMATE_TTS_URL to the running studio URL).",
                 )
+            if provider_name == "voicebox" and not voicebox_provider:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Voicebox provider not configured (set VOICEBOX_URL to the running Voicebox server URL).",
+                )
             raise HTTPException(status_code=400, detail=f"Provider '{provider_name}' not available")
 
-    except (VibeVoiceBusyError, VibeVoiceNoAudioError, UltimateTTSError) as exc:
+    except VoiceboxNoProfileError as exc:
+        # Voicebox first-run not complete — distinct status so operators can act
+        REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize", status="503").inc()
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except (VibeVoiceBusyError, VibeVoiceNoAudioError, UltimateTTSError, VoiceboxBusyError, VoiceboxError) as exc:
         REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize", status="502").inc()
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     except HTTPException as exc:
@@ -670,6 +734,34 @@ async def synthesize_speech_audio(request: SynthesizeRequest):
                 headers={"Content-Disposition": 'attachment; filename="ultimate_tts.wav"'},
             )
 
+        elif provider_name == "voicebox" and voicebox_provider:
+            wav_bytes = await voicebox_provider.synthesize(
+                text=request.text,
+                voice=request.voice,
+                engine=request.engine,
+            )
+            if not wav_bytes:
+                raise HTTPException(status_code=502, detail="Voicebox returned empty audio.")
+
+            if output_format == "pcm":
+                # Extract PCM from WAV
+                try:
+                    with io.BytesIO(wav_bytes) as buf:
+                        with wave.open(buf, "rb") as wf:
+                            pcm_data = wf.readframes(wf.getnframes())
+                    REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize/audio", status="200").inc()
+                    return Response(content=pcm_data, media_type="application/octet-stream")
+                except wave.Error:
+                    REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize/audio", status="200").inc()
+                    return Response(content=wav_bytes, media_type="application/octet-stream")
+
+            REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize/audio", status="200").inc()
+            return Response(
+                content=wav_bytes,
+                media_type="audio/wav",
+                headers={"Content-Disposition": 'attachment; filename="voicebox.wav"'},
+            )
+
         if provider_name == "vibevoice" and not vibevoice_provider:
             raise HTTPException(
                 status_code=503,
@@ -680,8 +772,16 @@ async def synthesize_speech_audio(request: SynthesizeRequest):
                 status_code=503,
                 detail="Ultimate-TTS provider not configured (set ULTIMATE_TTS_URL to the running studio URL).",
             )
+        if provider_name == "voicebox" and not voicebox_provider:
+            raise HTTPException(
+                status_code=503,
+                detail="Voicebox provider not configured (set VOICEBOX_URL to the running Voicebox server URL).",
+            )
         raise HTTPException(status_code=400, detail=f"Provider '{provider_name}' not available")
-    except (VibeVoiceBusyError, VibeVoiceNoAudioError, UltimateTTSError) as exc:
+    except VoiceboxNoProfileError as exc:
+        REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize/audio", status="503").inc()
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except (VibeVoiceBusyError, VibeVoiceNoAudioError, UltimateTTSError, VoiceboxBusyError, VoiceboxError) as exc:
         REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize/audio", status="502").inc()
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     except HTTPException as exc:

--- a/pmoves/services/flute-gateway/main.py
+++ b/pmoves/services/flute-gateway/main.py
@@ -601,8 +601,16 @@ async def synthesize_speech(request: SynthesizeRequest):
             duration = time.time() - start_time
             TTS_DURATION.labels(provider="voicebox").observe(duration)
 
-            # Estimate audio duration from WAV (24kHz assumed; Voicebox uses Qwen3-TTS at 12kHz/24kHz)
-            audio_duration = len(audio_data) / 48000
+            # Parse WAV header to derive actual sample rate and duration
+            try:
+                with io.BytesIO(audio_data) as buf:
+                    with wave.open(buf, "rb") as wf:
+                        sample_rate = wf.getframerate()
+                        frame_count = wf.getnframes()
+                audio_duration = frame_count / sample_rate
+            except wave.Error:
+                audio_duration = len(audio_data) / 48000  # fallback
+                sample_rate = 24000
 
             REQUESTS_TOTAL.labels(endpoint="/v1/voice/synthesize", status="200").inc()
 
@@ -616,7 +624,7 @@ async def synthesize_speech(request: SynthesizeRequest):
 
             return SynthesizeResponse(
                 duration_seconds=audio_duration,
-                sample_rate=24000,
+                sample_rate=sample_rate,
                 format="wav"
             )
         else:

--- a/pmoves/services/flute-gateway/providers/__init__.py
+++ b/pmoves/services/flute-gateway/providers/__init__.py
@@ -2,6 +2,12 @@
 
 from .base import VoiceProvider
 from .vibevoice import VibeVoiceBusyError, VibeVoiceNoAudioError, VibeVoiceProvider
+from .voicebox import (
+    VoiceboxBusyError,
+    VoiceboxError,
+    VoiceboxNoProfileError,
+    VoiceboxProvider,
+)
 from .whisper import WhisperProvider
 from .ultimate_tts import UltimateTTSError, UltimateTTSProvider
 from .cloning import VoiceCloningProvider, CloningSynthesisProvider
@@ -11,6 +17,10 @@ __all__ = [
     "VibeVoiceProvider",
     "VibeVoiceNoAudioError",
     "VibeVoiceBusyError",
+    "VoiceboxProvider",
+    "VoiceboxError",
+    "VoiceboxBusyError",
+    "VoiceboxNoProfileError",
     "WhisperProvider",
     "UltimateTTSProvider",
     "UltimateTTSError",

--- a/pmoves/services/flute-gateway/providers/voicebox.py
+++ b/pmoves/services/flute-gateway/providers/voicebox.py
@@ -1,0 +1,345 @@
+"""Voicebox TTS/STT provider integration.
+
+Voicebox is a self-hosted voice production service (jamiepine/voicebox) that
+runs as a Pinokio app on the host. It exposes a profile-based synthesis API
+where each "profile" wraps a voice persona with optional cloning samples,
+default engine, and effects chain.
+
+Endpoints used by this provider:
+    POST /generate/stream   — synchronous WAV streaming (audio/wav response)
+    POST /transcribe        — multipart STT (returns text + duration)
+    GET  /profiles          — list voice profiles
+    GET  /health            — service + model status
+
+Mapping notes:
+    - `voice` parameter on the VoiceProvider ABC is interpreted as a Voicebox
+      `profile_id` (UUID string). If omitted, the provider auto-selects the
+      first profile from /profiles and caches the choice.
+    - `engine` kwarg defaults to "qwen" (matches Voicebox default) but can be
+      overridden per call.
+    - `model_size` kwarg defaults to "1.7B" (Qwen3-TTS-12Hz-1.7B-Base).
+
+First-run setup:
+    Voicebox ships with 0 profiles. Until at least one profile exists,
+    `/generate/stream` returns 404 "Profile not found" and this provider
+    raises `VoiceboxNoProfileError`. `health_check()` returns True in this
+    state because the service itself is up — the no-profile condition only
+    surfaces on synthesis attempts.
+
+    Profile creation is fully API-driven (no UI required). The simplest
+    path is a **preset profile** using a built-in voice from Kokoro,
+    Chatterbox, Qwen, etc. — no audio sample upload needed:
+
+        POST /profiles
+        {
+          "name": "PMOVES Default",
+          "voice_type": "preset",
+          "language": "en",
+          "preset_engine": "kokoro",
+          "preset_voice_id": "af_alloy",       # discover via GET /profiles/presets/kokoro
+          "default_engine": "kokoro"
+        }
+
+    PMOVES exposes this as a Make target that auto-discovers preset voices:
+
+        make -C pmoves voicebox-profile-create
+        # Override engine/name with env vars:
+        VOICEBOX_PROFILE_ENGINE=qwen_custom_voice make -C pmoves voicebox-profile-create
+
+    For voice cloning, use `voice_type=cloned` and then
+    `POST /profiles/{id}/samples` with a reference audio file (2-10s).
+    For text-described voices, use `voice_type=designed` with a
+    `design_prompt`. Both paths are documented in
+    `pmoves/docs/architecture/voice-chain-end-to-end.md`.
+"""
+
+import logging
+import os
+from typing import Any, AsyncIterator, Dict, Optional
+
+import httpx
+
+from .base import VoiceProvider
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceboxError(RuntimeError):
+    """Base exception for Voicebox provider failures."""
+
+
+class VoiceboxNoProfileError(VoiceboxError):
+    """Raised when synthesis is attempted but Voicebox has no voice profiles.
+
+    This is the canonical "first-run not complete" signal — the service is
+    reachable but the user has not yet created a voice profile via the
+    Voicebox UI. Distinct from `VoiceboxBusyError` (transient) and
+    connection failures (caught by health_check).
+    """
+
+
+class VoiceboxBusyError(VoiceboxError):
+    """Raised when Voicebox reports it cannot accept a synthesis request right now."""
+
+
+class VoiceboxProvider(VoiceProvider):
+    """Voicebox synthesis + transcription provider.
+
+    Talks to a Voicebox HTTP server (default port 17493 via Pinokio). Uses
+    the synchronous /generate/stream endpoint for synthesis (not the async
+    /generate which queues a background task).
+    """
+
+    DEFAULT_ENGINE = "qwen"
+    DEFAULT_MODEL_SIZE = "1.7B"
+
+    def __init__(self, base_url: str = "http://host.docker.internal:17493"):
+        """Initialize Voicebox provider.
+
+        Args:
+            base_url: Voicebox server base URL. Defaults to host.docker.internal:17493
+                so the gateway can reach a Pinokio-managed Voicebox running on the host.
+        """
+        super().__init__(base_url.rstrip("/"))
+        self.generate_endpoint = f"{self.base_url}/generate/stream"
+        self.transcribe_endpoint = f"{self.base_url}/transcribe"
+        self.profiles_endpoint = f"{self.base_url}/profiles"
+        self.health_endpoint = f"{self.base_url}/health"
+        self._timeout = float(os.getenv("VOICEBOX_TIMEOUT_SEC", "120"))
+        self._cached_profile_id: Optional[str] = None
+
+    async def _resolve_profile_id(self, voice: Optional[str]) -> str:
+        """Resolve the profile_id for a synthesis call.
+
+        If `voice` is explicitly provided, use it as the profile_id.
+        Otherwise auto-select the first available profile from /profiles
+        (cached after first lookup).
+
+        Raises:
+            VoiceboxNoProfileError: If no profiles are available on the server.
+        """
+        if voice:
+            return voice
+        if self._cached_profile_id:
+            return self._cached_profile_id
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(self.profiles_endpoint)
+                response.raise_for_status()
+                profiles = response.json()
+        except httpx.HTTPError as exc:
+            raise VoiceboxError(f"Failed to fetch Voicebox profiles: {exc}") from exc
+
+        if not profiles:
+            raise VoiceboxNoProfileError(
+                "Voicebox has no voice profiles. Create a profile via the Voicebox UI "
+                "(http://localhost:17493) and download Qwen3-TTS 1.7B before synthesizing."
+            )
+
+        first = profiles[0]
+        profile_id = first.get("id") if isinstance(first, dict) else None
+        if not profile_id:
+            raise VoiceboxError(f"Unexpected /profiles response shape: {first!r}")
+
+        self._cached_profile_id = profile_id
+        logger.info("Voicebox auto-selected profile_id=%s (%s)", profile_id, first.get("name", "?"))
+        return profile_id
+
+    async def synthesize(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        **kwargs,
+    ) -> bytes:
+        """Synthesize speech from text via /generate/stream (batch mode).
+
+        Args:
+            text: Text to synthesize.
+            voice: Voicebox profile_id. If None, auto-selects the first profile.
+            **kwargs: engine, model_size, language, seed, instruct, normalize,
+                max_chunk_chars, crossfade_ms
+
+        Returns:
+            Complete WAV audio as bytes.
+        """
+        chunks: list[bytes] = []
+        async for chunk in self.synthesize_stream(text, voice, **kwargs):
+            chunks.append(chunk)
+        audio = b"".join(chunks)
+        if not audio:
+            raise VoiceboxError("Voicebox produced no audio bytes")
+        return audio
+
+    async def synthesize_stream(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        **kwargs,
+    ) -> AsyncIterator[bytes]:
+        """Stream synthesized speech as WAV chunks via /generate/stream.
+
+        Args:
+            text: Text to synthesize.
+            voice: Voicebox profile_id. If None, auto-selects the first profile.
+            **kwargs: engine, model_size, language, seed, instruct, normalize,
+                max_chunk_chars, crossfade_ms
+
+        Yields:
+            WAV audio chunks (full WAV file split across chunks).
+        """
+        profile_id = await self._resolve_profile_id(voice)
+
+        payload: Dict[str, Any] = {
+            "profile_id": profile_id,
+            "text": text,
+            "engine": kwargs.get("engine", self.DEFAULT_ENGINE),
+            "model_size": kwargs.get("model_size", self.DEFAULT_MODEL_SIZE),
+            "language": kwargs.get("language"),
+            "seed": kwargs.get("seed"),
+            "instruct": kwargs.get("instruct"),
+            "normalize": kwargs.get("normalize", True),
+            "max_chunk_chars": kwargs.get("max_chunk_chars"),
+            "crossfade_ms": kwargs.get("crossfade_ms"),
+        }
+        # Drop None values so Voicebox uses its own defaults
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                async with client.stream("POST", self.generate_endpoint, json=payload) as response:
+                    if response.status_code == 404:
+                        raise VoiceboxNoProfileError(
+                            f"Voicebox returned 404 for profile_id={profile_id} — "
+                            "profile may have been deleted between resolve and synthesize."
+                        )
+                    if response.status_code == 503:
+                        raise VoiceboxBusyError(f"Voicebox busy: {response.status_code}")
+                    if response.status_code >= 400:
+                        body = await response.aread()
+                        raise VoiceboxError(
+                            f"Voicebox /generate/stream failed: {response.status_code} {body[:200]!r}"
+                        )
+                    async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
+                        if chunk:
+                            yield chunk
+        except httpx.TimeoutException as exc:
+            logger.error("Voicebox synthesis timed out after %ss", self._timeout)
+            raise VoiceboxError(f"Voicebox synthesis timed out: {exc}") from exc
+        except (VoiceboxError, VoiceboxBusyError, VoiceboxNoProfileError):
+            raise
+        except httpx.HTTPError as exc:
+            logger.error("Voicebox synthesis HTTP error: %s", exc)
+            raise VoiceboxError(f"Voicebox HTTP error: {exc}") from exc
+
+    async def recognize(
+        self,
+        audio_data: bytes,
+        language: Optional[str] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Transcribe audio via /transcribe (multipart upload).
+
+        Args:
+            audio_data: Audio file bytes (WAV preferred).
+            language: ISO language code, or None for auto-detect.
+            **kwargs: model (whisper model size override)
+
+        Returns:
+            Dictionary with 'text', 'duration', 'language'.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                files = {"file": ("audio.wav", audio_data, "audio/wav")}
+                data: Dict[str, str] = {}
+                if language:
+                    data["language"] = language
+                if "model" in kwargs and kwargs["model"]:
+                    data["model"] = kwargs["model"]
+
+                response = await client.post(
+                    self.transcribe_endpoint,
+                    files=files,
+                    data=data,
+                )
+
+                if response.status_code == 202:
+                    # Whisper model is downloading — surface as a transient error
+                    detail = response.json().get("detail", {}) if response.text else {}
+                    raise VoiceboxBusyError(
+                        f"Voicebox is downloading whisper model: {detail.get('message', '')}"
+                    )
+
+                response.raise_for_status()
+                result = response.json()
+                return {
+                    "text": (result.get("text") or "").strip(),
+                    "duration": result.get("duration", 0.0),
+                    "language": language or "auto",
+                }
+        except VoiceboxBusyError:
+            raise
+        except httpx.HTTPError as exc:
+            logger.error("Voicebox transcription failed: %s", exc)
+            raise VoiceboxError(f"Voicebox transcription error: {exc}") from exc
+
+    async def health_check(self) -> bool:
+        """Check if Voicebox service is reachable.
+
+        Returns True if the /health endpoint responds with 200, regardless of
+        whether a model is loaded or any profiles exist. Use `health_status()`
+        for richer diagnostics that distinguish "down" from "up but unconfigured".
+        """
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(self.health_endpoint)
+                return response.status_code == 200
+        except httpx.HTTPError as exc:
+            logger.warning("Voicebox health check failed: %s", exc)
+            return False
+
+    async def health_status(self) -> Dict[str, Any]:
+        """Return rich health diagnostics for Voicebox.
+
+        Combines /health and /profiles into a single status payload that
+        distinguishes 'service down', 'service up but no model', and
+        'service up but no profiles'.
+
+        Returns:
+            Dictionary with keys: reachable, model_loaded, model_downloaded,
+            gpu_available, gpu_type, profiles_count, ready_for_synthesis.
+        """
+        status: Dict[str, Any] = {
+            "reachable": False,
+            "model_loaded": False,
+            "model_downloaded": None,
+            "gpu_available": False,
+            "gpu_type": None,
+            "profiles_count": 0,
+            "ready_for_synthesis": False,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                health_resp = await client.get(self.health_endpoint)
+                if health_resp.status_code == 200:
+                    health = health_resp.json()
+                    status.update(
+                        {
+                            "reachable": True,
+                            "model_loaded": bool(health.get("model_loaded")),
+                            "model_downloaded": health.get("model_downloaded"),
+                            "gpu_available": bool(health.get("gpu_available")),
+                            "gpu_type": health.get("gpu_type"),
+                        }
+                    )
+                profiles_resp = await client.get(self.profiles_endpoint)
+                if profiles_resp.status_code == 200:
+                    profiles = profiles_resp.json() or []
+                    status["profiles_count"] = len(profiles)
+        except httpx.HTTPError as exc:
+            logger.debug("Voicebox health_status failed: %s", exc)
+
+        status["ready_for_synthesis"] = (
+            status["reachable"] and status["profiles_count"] > 0
+        )
+        return status

--- a/pmoves/services/flute-gateway/providers/voicebox.py
+++ b/pmoves/services/flute-gateway/providers/voicebox.py
@@ -193,7 +193,7 @@ class VoiceboxProvider(VoiceProvider):
         payload: Dict[str, Any] = {
             "profile_id": profile_id,
             "text": text,
-            "engine": kwargs.get("engine", self.DEFAULT_ENGINE),
+            "engine": kwargs.get("engine"),
             "model_size": kwargs.get("model_size", self.DEFAULT_MODEL_SIZE),
             "language": kwargs.get("language"),
             "seed": kwargs.get("seed"),
@@ -209,6 +209,7 @@ class VoiceboxProvider(VoiceProvider):
             async with httpx.AsyncClient(timeout=self._timeout) as client:
                 async with client.stream("POST", self.generate_endpoint, json=payload) as response:
                     if response.status_code == 404:
+                        self._cached_profile_id = None
                         raise VoiceboxNoProfileError(
                             f"Voicebox returned 404 for profile_id={profile_id} — "
                             "profile may have been deleted between resolve and synthesize."
@@ -340,6 +341,8 @@ class VoiceboxProvider(VoiceProvider):
             logger.debug("Voicebox health_status failed: %s", exc)
 
         status["ready_for_synthesis"] = (
-            status["reachable"] and status["profiles_count"] > 0
+            status["reachable"]
+            and status["model_loaded"]
+            and status["profiles_count"] > 0
         )
         return status

--- a/pmoves/services/flute-gateway/tests/test_voicebox.py
+++ b/pmoves/services/flute-gateway/tests/test_voicebox.py
@@ -1,0 +1,396 @@
+"""Unit tests for VoiceboxProvider with mocks.
+
+Tests the VoiceboxProvider class without requiring the live Voicebox service.
+Uses mocked httpx responses to simulate the /generate/stream, /transcribe,
+/profiles, and /health endpoints.
+
+Functional tests (live service required) are marked with @pytest.mark.functional
+and can be deselected with `pytest -m "not functional"`.
+"""
+
+import io
+import json
+import os
+import sys
+import wave
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+# Add parent directory to path for imports
+_parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _parent_dir not in sys.path:
+    sys.path.insert(0, _parent_dir)
+
+from providers.voicebox import (
+    VoiceboxBusyError,
+    VoiceboxError,
+    VoiceboxNoProfileError,
+    VoiceboxProvider,
+)
+
+
+def create_mock_wav_bytes(duration_samples: int = 24000) -> bytes:
+    """Create valid WAV bytes for testing."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(24000)
+        wf.writeframes(b"\x00\x00" * duration_samples)
+    return buf.getvalue()
+
+
+def _make_async_client_mock(get_response=None, post_response=None, stream_response=None):
+    """Build an AsyncClient mock that supports get / post / stream / context manager."""
+    mock_client = AsyncMock()
+    if get_response is not None:
+        mock_client.get = AsyncMock(return_value=get_response)
+    if post_response is not None:
+        mock_client.post = AsyncMock(return_value=post_response)
+    if stream_response is not None:
+        # stream() returns an async context manager
+        stream_cm = AsyncMock()
+        stream_cm.__aenter__ = AsyncMock(return_value=stream_response)
+        stream_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_client.stream = MagicMock(return_value=stream_cm)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
+class _MockStreamResponse:
+    """Mock httpx streaming response for /generate/stream tests."""
+
+    def __init__(self, status_code: int, chunks: list[bytes] | None = None, body: bytes = b""):
+        self.status_code = status_code
+        self._chunks = chunks or []
+        self._body = body
+
+    async def aiter_bytes(self, chunk_size: int = 65536):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aread(self) -> bytes:
+        return self._body
+
+
+class TestVoiceboxProviderInit:
+    """Test provider initialization."""
+
+    def test_init_default_url(self):
+        provider = VoiceboxProvider()
+        assert provider.base_url == "http://host.docker.internal:17493"
+        assert provider.generate_endpoint == "http://host.docker.internal:17493/generate/stream"
+        assert provider.transcribe_endpoint == "http://host.docker.internal:17493/transcribe"
+        assert provider.profiles_endpoint == "http://host.docker.internal:17493/profiles"
+        assert provider.health_endpoint == "http://host.docker.internal:17493/health"
+
+    def test_init_custom_url_strips_trailing_slash(self):
+        provider = VoiceboxProvider(base_url="http://localhost:17493/")
+        assert provider.base_url == "http://localhost:17493"
+        assert provider.generate_endpoint == "http://localhost:17493/generate/stream"
+
+    def test_init_default_engine_and_model_size(self):
+        provider = VoiceboxProvider()
+        assert provider.DEFAULT_ENGINE == "qwen"
+        assert provider.DEFAULT_MODEL_SIZE == "1.7B"
+
+    def test_init_no_cached_profile(self):
+        provider = VoiceboxProvider()
+        assert provider._cached_profile_id is None
+
+
+class TestVoiceboxProviderHealthCheck:
+    """Test the simple bool health_check for the gateway aggregator."""
+
+    @pytest.fixture
+    def provider(self):
+        return VoiceboxProvider(base_url="http://localhost:17493")
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_true_on_200(self, provider):
+        mock_response = MagicMock(status_code=200)
+        with patch("httpx.AsyncClient", return_value=_make_async_client_mock(get_response=mock_response)):
+            assert await provider.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_false_on_500(self, provider):
+        mock_response = MagicMock(status_code=500)
+        with patch("httpx.AsyncClient", return_value=_make_async_client_mock(get_response=mock_response)):
+            assert await provider.health_check() is False
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_false_on_connect_error(self, provider):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            assert await provider.health_check() is False
+
+
+class TestVoiceboxProviderHealthStatus:
+    """Test the rich health_status method."""
+
+    @pytest.fixture
+    def provider(self):
+        return VoiceboxProvider(base_url="http://localhost:17493")
+
+    @pytest.mark.asyncio
+    async def test_health_status_ready_for_synthesis(self, provider):
+        """Service up + model loaded + at least one profile = ready."""
+        mock_client = AsyncMock()
+
+        async def mock_get(url, *args, **kwargs):
+            response = MagicMock()
+            if "/health" in url:
+                response.status_code = 200
+                response.json.return_value = {
+                    "model_loaded": True,
+                    "model_downloaded": True,
+                    "gpu_available": True,
+                    "gpu_type": "CUDA (RTX 5090)",
+                }
+            elif "/profiles" in url:
+                response.status_code = 200
+                response.json.return_value = [{"id": "abc-123", "name": "Default"}]
+            return response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            status = await provider.health_status()
+
+        assert status["reachable"] is True
+        assert status["model_loaded"] is True
+        assert status["model_downloaded"] is True
+        assert status["gpu_available"] is True
+        assert status["gpu_type"] == "CUDA (RTX 5090)"
+        assert status["profiles_count"] == 1
+        assert status["ready_for_synthesis"] is True
+
+    @pytest.mark.asyncio
+    async def test_health_status_no_profiles_not_ready(self, provider):
+        """Service up but zero profiles = NOT ready for synthesis."""
+        mock_client = AsyncMock()
+
+        async def mock_get(url, *args, **kwargs):
+            response = MagicMock()
+            if "/health" in url:
+                response.status_code = 200
+                response.json.return_value = {"model_loaded": False, "gpu_available": True}
+            elif "/profiles" in url:
+                response.status_code = 200
+                response.json.return_value = []
+            return response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            status = await provider.health_status()
+
+        assert status["reachable"] is True
+        assert status["profiles_count"] == 0
+        assert status["ready_for_synthesis"] is False
+
+    @pytest.mark.asyncio
+    async def test_health_status_unreachable(self, provider):
+        """Service down = unreachable, not ready."""
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            status = await provider.health_status()
+
+        assert status["reachable"] is False
+        assert status["ready_for_synthesis"] is False
+
+
+class TestVoiceboxProviderProfileResolution:
+    """Test profile_id resolution and caching."""
+
+    @pytest.fixture
+    def provider(self):
+        return VoiceboxProvider(base_url="http://localhost:17493")
+
+    @pytest.mark.asyncio
+    async def test_resolve_explicit_voice_passes_through(self, provider):
+        """If voice is explicitly provided, use it directly without HTTP call."""
+        result = await provider._resolve_profile_id("explicit-profile-id")
+        assert result == "explicit-profile-id"
+        # Cached profile should NOT be set when voice is explicit
+        assert provider._cached_profile_id is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_no_voice_fetches_first_profile(self, provider):
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = [
+            {"id": "first-id", "name": "Alice"},
+            {"id": "second-id", "name": "Bob"},
+        ]
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient", return_value=_make_async_client_mock(get_response=mock_response)):
+            result = await provider._resolve_profile_id(None)
+
+        assert result == "first-id"
+        assert provider._cached_profile_id == "first-id"
+
+    @pytest.mark.asyncio
+    async def test_resolve_cached_profile_skips_http(self, provider):
+        provider._cached_profile_id = "cached-id"
+        # If called with no voice, cached value should be used without HTTP
+        result = await provider._resolve_profile_id(None)
+        assert result == "cached-id"
+
+    @pytest.mark.asyncio
+    async def test_resolve_empty_profiles_raises_no_profile_error(self, provider):
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient", return_value=_make_async_client_mock(get_response=mock_response)):
+            with pytest.raises(VoiceboxNoProfileError, match="no voice profiles"):
+                await provider._resolve_profile_id(None)
+
+    @pytest.mark.asyncio
+    async def test_resolve_http_error_raises_voicebox_error(self, provider):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(VoiceboxError, match="Failed to fetch Voicebox profiles"):
+                await provider._resolve_profile_id(None)
+
+
+class TestVoiceboxProviderSynthesize:
+    """Test synthesis via /generate/stream."""
+
+    @pytest.fixture
+    def provider(self):
+        provider = VoiceboxProvider(base_url="http://localhost:17493")
+        provider._cached_profile_id = "test-profile"
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_synthesize_stream_yields_chunks(self, provider):
+        wav = create_mock_wav_bytes()
+        # Split into 3 chunks for streaming test
+        chunk_size = len(wav) // 3
+        chunks = [wav[i:i+chunk_size] for i in range(0, len(wav), chunk_size)]
+        stream_response = _MockStreamResponse(status_code=200, chunks=chunks)
+
+        mock_client = _make_async_client_mock(stream_response=stream_response)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            collected = []
+            async for chunk in provider.synthesize_stream("hello", voice="test-profile"):
+                collected.append(chunk)
+
+        assert len(collected) == len(chunks)
+        assert b"".join(collected) == wav
+
+    @pytest.mark.asyncio
+    async def test_synthesize_returns_concatenated_bytes(self, provider):
+        wav = create_mock_wav_bytes()
+        stream_response = _MockStreamResponse(status_code=200, chunks=[wav])
+        mock_client = _make_async_client_mock(stream_response=stream_response)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await provider.synthesize("hello world", voice="test-profile")
+
+        assert result == wav
+
+    @pytest.mark.asyncio
+    async def test_synthesize_404_raises_no_profile_error(self, provider):
+        stream_response = _MockStreamResponse(status_code=404, body=b'{"detail":"Profile not found"}')
+        mock_client = _make_async_client_mock(stream_response=stream_response)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(VoiceboxNoProfileError):
+                await provider.synthesize("hello", voice="missing")
+
+    @pytest.mark.asyncio
+    async def test_synthesize_503_raises_busy_error(self, provider):
+        stream_response = _MockStreamResponse(status_code=503, body=b"busy")
+        mock_client = _make_async_client_mock(stream_response=stream_response)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(VoiceboxBusyError):
+                await provider.synthesize("hello", voice="test-profile")
+
+    @pytest.mark.asyncio
+    async def test_synthesize_500_raises_voicebox_error(self, provider):
+        stream_response = _MockStreamResponse(status_code=500, body=b"internal error")
+        mock_client = _make_async_client_mock(stream_response=stream_response)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(VoiceboxError, match="500"):
+                await provider.synthesize("hello", voice="test-profile")
+
+    @pytest.mark.asyncio
+    async def test_synthesize_empty_audio_raises(self, provider):
+        stream_response = _MockStreamResponse(status_code=200, chunks=[])
+        mock_client = _make_async_client_mock(stream_response=stream_response)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(VoiceboxError, match="no audio bytes"):
+                await provider.synthesize("hello", voice="test-profile")
+
+    @pytest.mark.asyncio
+    async def test_synthesize_timeout_raises(self, provider):
+        mock_client = AsyncMock()
+        mock_client.stream = MagicMock(side_effect=httpx.TimeoutException("timeout"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(VoiceboxError, match="timed out"):
+                await provider.synthesize("hello", voice="test-profile")
+
+
+class TestVoiceboxProviderRecognize:
+    """Test STT via /transcribe."""
+
+    @pytest.fixture
+    def provider(self):
+        return VoiceboxProvider(base_url="http://localhost:17493")
+
+    @pytest.mark.asyncio
+    async def test_recognize_returns_text_and_duration(self, provider):
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = {"text": "  hello world  ", "duration": 1.42}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient", return_value=_make_async_client_mock(post_response=mock_response)):
+            result = await provider.recognize(b"audio bytes", language="en")
+
+        assert result["text"] == "hello world"
+        assert result["duration"] == 1.42
+        assert result["language"] == "en"
+
+    @pytest.mark.asyncio
+    async def test_recognize_202_raises_busy_error(self, provider):
+        """Voicebox returns 202 while downloading whisper model."""
+        mock_response = MagicMock(status_code=202)
+        mock_response.text = '{"detail": {"message": "downloading"}}'
+        mock_response.json.return_value = {"detail": {"message": "Whisper model downloading"}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient", return_value=_make_async_client_mock(post_response=mock_response)):
+            with pytest.raises(VoiceboxBusyError, match="downloading"):
+                await provider.recognize(b"audio bytes")
+
+    @pytest.mark.asyncio
+    async def test_recognize_http_error_raises_voicebox_error(self, provider):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(VoiceboxError, match="transcription error"):
+                await provider.recognize(b"audio")


### PR DESCRIPTION
## Summary

Adds Voicebox as a first-class TTS/STT producer in Flute-Gateway. Lane 1 of the 4-lane Session 12 voice production orchestration plan — closes the "Voicebox not integrated" gap from TAC_VOICE_PRODUCTION.md Phase 6.

Voicebox is a Pinokio-managed voice production service (port 17493) with a profile-based synthesis API. This PR wires it into the Flute-Gateway provider chain alongside VibeVoice and Ultimate-TTS-Studio, and ships a Make target that creates a default preset profile via the Voicebox HTTP API — no UI interaction required for the common case.

## Key design decisions

1. **Use `/generate/stream` not `/generate`** — the non-streaming `/generate` queues an async background task; `/generate/stream` returns synchronous `audio/wav` bytes.
2. **`voice` parameter = `profile_id`** — auto-resolves first profile if none specified, cached after first lookup.
3. **`health_check()` is liveness, `health_status()` is readiness** — returning False for "no profiles" would break the gateway /healthz aggregator.
4. **`VoiceboxNoProfileError` → HTTP 503, not 502** — distinct status lets monitoring alert separately on "needs config" vs "upstream broken." Caught before the broader `VoiceboxError` tuple since exception order matters.
5. **Preset profiles are the first-run path** — `voicebox-profile-create` Make target auto-discovers preset voices via `GET /profiles/presets/{engine}` so no UI interaction is needed for the common case. Voice cloning still needs UI/programmatic sample upload.

## Files (5)

- NEW `pmoves/services/flute-gateway/providers/voicebox.py` — VoiceboxProvider (322 lines)
- NEW `pmoves/services/flute-gateway/tests/test_voicebox.py` — 25 hermetic unit tests
- EDIT `pmoves/services/flute-gateway/providers/__init__.py` — export VoiceboxProvider + errors
- EDIT `pmoves/services/flute-gateway/main.py` — 9 edit sites (import, env, instance, lifespan, /healthz, /v1/voice/config, 2× dispatcher branches, 2× exception handlers)
- EDIT `pmoves/Makefile` — up-voicebox, voicebox-smoke, voicebox-status, voicebox-profile-create targets

## Test plan

- [x] Hermetic unit tests: 25 new VoiceboxProvider tests pass
- [x] Full flute-gateway suite: 95 passed, 3 skipped, 0 failures (no regressions)
- [ ] Smoke test against live Voicebox via `make -C pmoves voicebox-smoke`
- [ ] Profile creation via `make -C pmoves voicebox-profile-create`
- [ ] End-to-end synthesis: `curl -X POST http://localhost:8055/v1/voice/synthesize -d '{"text":"...","provider":"voicebox"}'`

## Cross-lane context

Lane 1 is standalone. Lanes 2/3/4 of the Session 12 plan ship as separate PRs:
- Lane 2: TAC Phase 6 closeout + Higgs upstream stub + cgp_sub_probe.py voice subjects
- Lane 3: VibeVoice WebSocket harness + voice_chain_e2e_test.py NATS verifier
- Lane 4: voice-chain-end-to-end.md single-picture architecture doc

No hard dependencies between lanes. Merge order is flexible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Voicebox voice synthesis and transcription service integration
  * Introduced management commands for Voicebox setup, monitoring, and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->