### PR TITLE
test(voice): VibeVoice WebSocket harness + NATS chain e2e verifier (Session 12 Lane 3)

### DIFF
--- a/pmoves/services/flute-gateway/tests/test_vibevoice_realtime.py
+++ b/pmoves/services/flute-gateway/tests/test_vibevoice_realtime.py
@@ -1,0 +1,166 @@
+"""VibeVoice WebSocket realtime harness (deferred Task #41).
+
+Tests the live VibeVoice realtime endpoint via WebSocket. Unlike the unit
+tests in test_voicebox.py, these tests cannot be mocked meaningfully — the
+WebSocket protocol behavior is the contract being verified. They are marked
+@pytest.mark.functional so the default hermetic suite skips them.
+
+To run:
+    PYTHONPATH=pmoves pytest pmoves/services/flute-gateway/tests/test_vibevoice_realtime.py \\
+        -m functional -v
+
+Prerequisite:
+    VibeVoice realtime server running at the URL specified by VIBEVOICE_URL
+    (default: http://host.docker.internal:7860). Start with:
+        make -C pmoves up-vibevoice
+
+Why this exists:
+    Session 11 deferred VibeVoice synthesis testing because VibeVoice uses a
+    separate WebSocket endpoint (`/stream`), not the unified Gradio
+    `/generate_unified_tts` endpoint that other Ultimate-TTS engines use. The
+    flute-gateway VibeVoiceProvider wraps this WebSocket; this harness verifies
+    the wrapper end-to-end against a real server.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+# Add parent directory to path for imports
+_parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _parent_dir not in sys.path:
+    sys.path.insert(0, _parent_dir)
+
+from providers.vibevoice import (
+    VibeVoiceBusyError,
+    VibeVoiceNoAudioError,
+    VibeVoiceProvider,
+)
+
+
+def _vibevoice_url() -> str:
+    """Return the VibeVoice URL to test against."""
+    return os.environ.get("VIBEVOICE_URL", "http://host.docker.internal:7860")
+
+
+async def _is_vibevoice_reachable(provider: VibeVoiceProvider) -> bool:
+    """Check if VibeVoice is reachable; tests skip if not."""
+    try:
+        return await asyncio.wait_for(provider.health_check(), timeout=3.0)
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def provider():
+    return VibeVoiceProvider(base_url=_vibevoice_url())
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_vibevoice_health_check_returns_true_when_reachable(provider):
+    """If VibeVoice is running, /config should return 200."""
+    if not await _is_vibevoice_reachable(provider):
+        pytest.skip(f"VibeVoice not reachable at {_vibevoice_url()} — start with `make -C pmoves up-vibevoice`")
+    assert await provider.health_check() is True
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_vibevoice_get_config_returns_dict(provider):
+    """get_config should return a dict with at least default_voice or model info."""
+    if not await _is_vibevoice_reachable(provider):
+        pytest.skip(f"VibeVoice not reachable at {_vibevoice_url()}")
+    config = await provider.get_config()
+    assert isinstance(config, dict)
+    # Empty dict is allowed on error, but a healthy server should populate something
+    if config:
+        # Common keys VibeVoice exposes — at least one should be present
+        assert any(k in config for k in ("default_voice", "voices", "model", "sample_rate"))
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_vibevoice_synthesize_short_text_yields_pcm16(provider):
+    """Synthesize a short phrase and assert PCM16 audio bytes come back.
+
+    PCM16 at 24kHz mono = 48,000 bytes per second. A 1-2 word phrase should
+    produce at least ~24,000 bytes (0.5 seconds) of audio under normal load.
+    """
+    if not await _is_vibevoice_reachable(provider):
+        pytest.skip(f"VibeVoice not reachable at {_vibevoice_url()}")
+
+    try:
+        audio = await asyncio.wait_for(
+            provider.synthesize("hello world"),
+            timeout=30.0,
+        )
+    except VibeVoiceBusyError:
+        pytest.skip("VibeVoice reported busy — transient, not a bug")
+    except VibeVoiceNoAudioError as exc:
+        pytest.fail(f"VibeVoice returned no audio: {exc}")
+    except asyncio.TimeoutError:
+        pytest.fail("VibeVoice synthesis timed out after 30s")
+
+    assert isinstance(audio, bytes)
+    assert len(audio) > 0, "VibeVoice returned empty audio"
+    # PCM16 has 2 bytes per sample — total length should be even
+    assert len(audio) % 2 == 0, f"PCM16 byte length should be even, got {len(audio)}"
+    # Sanity check: at least 0.1 seconds of audio (24000*0.1*2 = 4800 bytes)
+    assert len(audio) >= 4800, f"Audio suspiciously short: {len(audio)} bytes ({len(audio)/48000:.2f}s)"
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_vibevoice_stream_yields_multiple_chunks(provider):
+    """Synthesize via the streaming API and confirm multiple chunks arrive.
+
+    The WebSocket streaming endpoint should yield audio progressively rather
+    than as a single large blob. Verifies the streaming contract.
+    """
+    if not await _is_vibevoice_reachable(provider):
+        pytest.skip(f"VibeVoice not reachable at {_vibevoice_url()}")
+
+    chunks: list[bytes] = []
+    try:
+        async with asyncio.timeout(30.0):
+            async for chunk in provider.synthesize_stream("Streaming test phrase one two three"):
+                chunks.append(chunk)
+    except VibeVoiceBusyError:
+        pytest.skip("VibeVoice busy")
+    except asyncio.TimeoutError:
+        pytest.fail("Stream timed out after 30s")
+
+    assert len(chunks) >= 1, "VibeVoice streamed zero chunks"
+    total_bytes = sum(len(c) for c in chunks)
+    assert total_bytes > 0, "VibeVoice streamed empty chunks"
+    # For a longer phrase, expect at least 1 second of audio
+    assert total_bytes >= 24000, (
+        f"Streamed audio suspiciously short: {total_bytes} bytes "
+        f"({total_bytes/48000:.2f}s) across {len(chunks)} chunks"
+    )
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_vibevoice_handles_empty_text_gracefully(provider):
+    """Empty text should either return empty audio or raise a clean error.
+
+    The client should NOT hang or return malformed data on empty input.
+    """
+    if not await _is_vibevoice_reachable(provider):
+        pytest.skip(f"VibeVoice not reachable at {_vibevoice_url()}")
+
+    try:
+        async with asyncio.timeout(10.0):
+            audio = await provider.synthesize("")
+    except (VibeVoiceNoAudioError, VibeVoiceBusyError):
+        # Acceptable: clean error
+        return
+    except asyncio.TimeoutError:
+        pytest.fail("VibeVoice hung on empty input")
+
+    # Acceptable: returned bytes (possibly empty or silence)
+    assert isinstance(audio, bytes)

--- a/pmoves/tools/voice_chain_e2e_test.py
+++ b/pmoves/tools/voice_chain_e2e_test.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""End-to-end voice chain verifier (Session 12 Lane 3).
+
+Publishes a synthetic `agentzero.task.result.v1` message with `meta.voice_mode=true`
+and waits for the voice-relay to transform and re-publish it on
+`voice.agent.response.v1`. Reports timing (publish → republish latency) and
+asserts the relay's payload transformation is correct.
+
+This proves the voice chain works end-to-end through the bus layer:
+
+    test publisher (this script)
+         │
+         ▼ agentzero.task.result.v1
+         │
+    voice-relay (port 8121)
+         │
+         ▼ voice.agent.response.v1
+         │
+    test subscriber (this script)
+
+Prerequisites:
+    - NATS broker running (default: nats://nats:pmoves@nats:4222)
+    - voice-relay service running (port 8121, /healthz returns nats_connected=true)
+    - Flute-Gateway is NOT required (this only tests the bus, not synthesis)
+
+Usage:
+    # Default (NATS + voice-relay running)
+    python pmoves/tools/voice_chain_e2e_test.py
+
+    # Custom NATS URL
+    NATS_URL=nats://localhost:4222 python pmoves/tools/voice_chain_e2e_test.py
+
+    # Longer wait window (for slow runners)
+    python pmoves/tools/voice_chain_e2e_test.py --wait 15
+
+Exit codes:
+    0  Success — relay observed and payload transformation verified
+    1  Timeout — relay did not republish within the wait window
+    2  Connection / setup error
+    3  Payload validation failed (relay is alive but transformation is broken)
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any, Dict
+
+try:
+    import nats
+except ImportError:
+    print("ERROR: nats-py not installed. Install with: pip install nats-py", file=sys.stderr)
+    sys.exit(2)
+
+
+INPUT_SUBJECT = "agentzero.task.result.v1"
+OUTPUT_SUBJECT = "voice.agent.response.v1"
+
+
+def _build_synthetic_task(text: str, task_id: str) -> Dict[str, Any]:
+    """Build a synthetic agent-zero task result with voice_mode enabled."""
+    return {
+        "task_id": task_id,
+        "output": text,
+        "meta": {
+            "voice_mode": True,
+            "platform": "voice-chain-e2e-test",
+            "user_id": "voice-chain-test-user",
+            "model": "claude-opus-4-6",
+            "sources": ["voice_chain_e2e_test.py"],
+        },
+    }
+
+
+def _validate_relay_payload(payload: Dict[str, Any], expected_text: str, expected_task_id: str) -> list[str]:
+    """Return a list of validation errors (empty list = valid)."""
+    errors: list[str] = []
+    # voice-relay may wrap the payload in an envelope (services.common.events.envelope)
+    # or publish bare — handle both shapes.
+    inner = payload
+    if "data" in payload and isinstance(payload.get("data"), dict):
+        inner = payload["data"]
+
+    if inner.get("response_text") != expected_text:
+        errors.append(
+            f"response_text mismatch: got {inner.get('response_text')!r}, "
+            f"expected {expected_text!r}"
+        )
+    if inner.get("message_id") != expected_task_id:
+        errors.append(
+            f"message_id mismatch: got {inner.get('message_id')!r}, "
+            f"expected {expected_task_id!r}"
+        )
+    if inner.get("platform") != "voice-chain-e2e-test":
+        errors.append(f"platform mismatch: got {inner.get('platform')!r}")
+    if inner.get("user_id") != "voice-chain-test-user":
+        errors.append(f"user_id mismatch: got {inner.get('user_id')!r}")
+    if not inner.get("timestamp"):
+        errors.append("timestamp missing or empty")
+    return errors
+
+
+async def run_test(nats_url: str, wait_seconds: float, text: str) -> int:
+    """Run the voice chain e2e test. Returns the exit code."""
+    task_id = str(uuid.uuid4())
+    received_event = asyncio.Event()
+    received_payload: Dict[str, Any] = {}
+    publish_ts: float | None = None
+    receive_ts: float | None = None
+
+    print(f"voice-chain-e2e: connecting to NATS at {nats_url}")
+    try:
+        nc = await nats.connect(nats_url, connect_timeout=5)
+    except Exception as exc:
+        print(f"ERROR: NATS connect failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"voice-chain-e2e: connected — subscribing to {OUTPUT_SUBJECT}")
+
+    async def output_handler(msg) -> None:
+        nonlocal receive_ts
+        receive_ts = time.monotonic()
+        try:
+            data = json.loads(msg.data.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            print(f"WARN: failed to decode {OUTPUT_SUBJECT} payload: {exc}", file=sys.stderr)
+            return
+
+        # voice-relay may publish for OTHER tasks during this test — only react to ours
+        inner = data.get("data", data) if isinstance(data, dict) else data
+        if not isinstance(inner, dict):
+            return
+        if inner.get("message_id") != task_id:
+            return  # not our message; ignore
+
+        received_payload.update(data)
+        received_event.set()
+
+    sub = await nc.subscribe(OUTPUT_SUBJECT, cb=output_handler)
+    # Tiny delay to ensure subscription is registered before publish
+    await asyncio.sleep(0.1)
+
+    print(f"voice-chain-e2e: publishing synthetic {INPUT_SUBJECT} with task_id={task_id}")
+    payload = _build_synthetic_task(text, task_id)
+    publish_ts = time.monotonic()
+    await nc.publish(INPUT_SUBJECT, json.dumps(payload).encode("utf-8"))
+    await nc.flush()
+
+    print(f"voice-chain-e2e: waiting up to {wait_seconds}s for relay republish on {OUTPUT_SUBJECT}")
+    try:
+        await asyncio.wait_for(received_event.wait(), timeout=wait_seconds)
+    except asyncio.TimeoutError:
+        print(
+            f"FAIL: voice-relay did not republish within {wait_seconds}s.\n"
+            f"  Check: voice-relay is running (`make -C pmoves up-voice-relay` or similar)\n"
+            f"  Check: voice-relay /healthz reports nats_connected=true\n"
+            f"  Check: voice-relay subscribed to {INPUT_SUBJECT}",
+            file=sys.stderr,
+        )
+        await sub.unsubscribe()
+        await nc.close()
+        return 1
+
+    latency_ms = (receive_ts - publish_ts) * 1000.0 if publish_ts and receive_ts else -1.0
+    print(f"voice-chain-e2e: received relay republish after {latency_ms:.1f}ms")
+
+    errors = _validate_relay_payload(received_payload, text, task_id)
+    if errors:
+        print("FAIL: relay payload validation errors:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        print(f"  Full payload received: {json.dumps(received_payload, indent=2)}", file=sys.stderr)
+        await sub.unsubscribe()
+        await nc.close()
+        return 3
+
+    print("PASS: voice chain end-to-end verified")
+    print(f"  task_id:        {task_id}")
+    print(f"  text:           {text!r}")
+    print(f"  publish→relay:  {latency_ms:.1f}ms")
+    print(f"  payload shape:  {sorted(received_payload.keys())}")
+
+    await sub.unsubscribe()
+    await nc.close()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Voice chain end-to-end NATS verifier")
+    parser.add_argument(
+        "--nats-url",
+        default=os.environ.get("NATS_URL", "nats://nats:pmoves@nats:4222"),
+        help="NATS broker URL (default: nats://nats:pmoves@nats:4222 or $NATS_URL)",
+    )
+    parser.add_argument(
+        "--wait",
+        type=float,
+        default=10.0,
+        help="Seconds to wait for relay republish (default: 10)",
+    )
+    parser.add_argument(
+        "--text",
+        default="Voice chain end-to-end test",
+        help="Text payload to send (default: 'Voice chain end-to-end test')",
+    )
+    args = parser.parse_args()
+
+    return asyncio.run(run_test(args.nats_url, args.wait, args.text))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Verification tools for the existing Pipecat + VibeVoice + voice-relay chain. The wiring was already built in earlier sessions (`PMOVES-Pipecat` submodule, `pmoves/services/flute-gateway/pipecat/` processors, `voice-relay` service at port 8121) — this PR proves it end-to-end.

Lane 3 of the Session 12 4-lane voice production orchestration plan. **No new code in the critical path** — these are verification/test tools.

## What's in this PR

### 1. VibeVoice WebSocket harness (`test_vibevoice_realtime.py`)

Closes the deferred **Task #41** from Session 11 ("VibeVoice separate endpoint test"). 5 functional tests that skip cleanly when VibeVoice realtime is unreachable (expected default state in CI).

Tests:
- `test_vibevoice_health_check_returns_true_when_reachable` — /config HTTP check
- `test_vibevoice_get_config_returns_dict` — config shape validation
- `test_vibevoice_synthesize_short_text_yields_pcm16` — full synthesize() via WebSocket, asserts PCM16 byte parity + minimum duration
- `test_vibevoice_stream_yields_multiple_chunks` — streaming contract verification
- `test_vibevoice_handles_empty_text_gracefully` — no-hang empty-input handling

All marked `@pytest.mark.functional`. Reuses retry/error patterns from `providers/vibevoice.py` (`VibeVoiceBusyError`, `VibeVoiceNoAudioError`).

### 2. NATS chain e2e verifier (`voice_chain_e2e_test.py`)

End-to-end test of the bus layer:
\`\`\`
test publisher → agentzero.task.result.v1 → voice-relay → voice.agent.response.v1 → test subscriber
\`\`\`

Publishes a synthetic \`agentzero.task.result.v1\` with \`meta.voice_mode=true\`, subscribes to \`voice.agent.response.v1\` to catch the relay republish, validates the payload transformation (platform, user_id, message_id, response_text, timestamp), and reports latency.

Exit codes (useful for CI):
- **0** — relay observed + payload valid
- **1** — timeout (relay didn't republish within window)
- **2** — NATS connection / setup error
- **3** — payload validation failed (relay alive but transformation broken)

CLI args: \`--nats-url\`, \`--wait\`, \`--text\`; env: \`NATS_URL\`. Auth follows CLAUDE.md NATS convention (\`nats://nats:pmoves@nats:4222\`).

## Pipecat MCP server decision

**Explicitly deferred.** \`.claude/commands/pipecat/connect.md\` and \`status.md\` already wrap the Flute-Gateway HTTP API. Building an MCP server would duplicate that surface without a concrete consumer. Revisit when a consumer materializes.

## Test plan

- [x] Both files parse + collect
- [x] VibeVoice tests skip cleanly when upstream unreachable
  \`\`\`
  PYTHONPATH=pmoves pytest pmoves/services/flute-gateway/tests/test_vibevoice_realtime.py -v -m functional
  ===== 5 skipped in 10.58s =====
  \`\`\`
- [ ] Run VibeVoice functional tests with \`make -C pmoves up-vibevoice\` first
- [ ] Run NATS e2e test with voice-relay running (\`python pmoves/tools/voice_chain_e2e_test.py\`)

## Cross-lane context

- Lane 1 (VoiceboxProvider): #1235
- Lane 2 (Correctness): Opening after Higgs upstream research agent completes
- Lane 4 (Architecture doc): Opening next

No hard dependencies between lanes. Merge order is flexible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)