### PR TITLE
fix(review): address PR #1226 post-merge CodeRabbit findings

### DIFF
--- a/pmoves/config/gpu-models.yaml
+++ b/pmoves/config/gpu-models.yaml
@@ -272,7 +272,10 @@ models:
     quantization: "Q4_K_M"
     context_length: 131072
 
-  - id: "gemma4:26b-a4b"
+  # Ollama publishes this as plain ":26b" tag (A4B MoE architecture is implied).
+  # Verified via https://registry.ollama.ai/v2/library/gemma4/manifests/26b (200 OK)
+  # — the ":26b-a4b" tag returns MANIFEST_UNKNOWN.
+  - id: "gemma4:26b"
     provider: ollama
     vram_mb: 15000
     description: "Google Gemma 4 26B-A4B MoE - 3.8B active, speed-focused, 256K ctx, LMArena 1441"

--- a/pmoves/configs/flare-model-namespace.yaml
+++ b/pmoves/configs/flare-model-namespace.yaml
@@ -113,9 +113,13 @@ mappings:
   gemma-4-26b-a4b:
     flare_name: "pmoves/gemma-4-26b-a4b"
     provider: "ollama"
-    model_id: "gemma4:26b-a4b"
+    # Ollama publishes the A4B MoE variant as the default ":26b" tag.
+    # Verified via registry.ollama.ai manifest API (":26b-a4b" returns 404).
+    model_id: "gemma4:26b"
     lane: "local"
-    nodes: [5090, 4090]
+    # 15000MB quantized footprint > 4090 laptop available VRAM (16384-2048=14336MB) → OOM.
+    # Restricted to 5090 (24GB) until a higher-VRAM 4090 desktop variant is onboarded.
+    nodes: [5090]
 
   gemma-4-31b:
     flare_name: "pmoves/gemma-4-31b"

--- a/pmoves/supabase/initdb/12_model_registry_seed.sql
+++ b/pmoves/supabase/initdb/12_model_registry_seed.sql
@@ -675,6 +675,8 @@ BEGIN
   -- Gemma 4 26B-A4B MoE - 3.8B active, speed-focused, 256K ctx
   -- HF pipeline_tag: image-text-to-text (vision only, NO audio/video despite HF multimodal family)
   -- Ollama publishes this as plain ":26b" tag (A4B MoE architecture is implied)
+  -- Clean up legacy tag from pre-rename (gemma4:26b-a4b -> gemma4:26b)
+  DELETE FROM pmoves_core.models WHERE provider_id = v_ollama_local_id AND model_id = 'gemma4:26b-a4b';
   INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
   VALUES (
     v_ollama_local_id,

--- a/pmoves/supabase/initdb/12_model_registry_seed.sql
+++ b/pmoves/supabase/initdb/12_model_registry_seed.sql
@@ -673,13 +673,15 @@ BEGIN
     updated_at = NOW();
 
   -- Gemma 4 26B-A4B MoE - 3.8B active, speed-focused, 256K ctx
+  -- HF pipeline_tag: image-text-to-text (vision only, NO audio/video despite HF multimodal family)
+  -- Ollama publishes this as plain ":26b" tag (A4B MoE architecture is implied)
   INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
   VALUES (
     v_ollama_local_id,
     'gemma_4_26b_a4b_local',
-    'gemma4:26b-a4b',
+    'gemma4:26b',
     'chat',
-    '["chat", "code_generation", "vision", "audio", "multimodal"]'::jsonb,
+    '["chat", "code_generation", "vision"]'::jsonb,
     15000,
     262144,
     'Google Gemma 4 26B-A4B MoE - 3.8B active, LMArena 1441, Apache 2.0',
@@ -694,13 +696,14 @@ BEGIN
     updated_at = NOW();
 
   -- Gemma 4 31B Dense - SOTA quality, 256K ctx, LMArena 1452
+  -- HF pipeline_tag: image-text-to-text (vision only, NO audio/video — E-prefix variants only)
   INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
   VALUES (
     v_ollama_local_id,
     'gemma_4_31b_local',
     'gemma4:31b',
     'chat',
-    '["chat", "code_generation", "reasoning", "vision", "audio", "multimodal"]'::jsonb,
+    '["chat", "code_generation", "reasoning", "vision"]'::jsonb,
     18000,
     262144,
     'Google Gemma 4 31B Dense - SOTA quality, beats Llama 4 on AIME/LiveCodeBench, Apache 2.0',

--- a/pmoves/tensorzero/config/tensorzero.toml
+++ b/pmoves/tensorzero/config/tensorzero.toml
@@ -365,7 +365,9 @@ routing = ["ollama_local"]
 [models.gemma_4_26b_a4b_local.providers.ollama_local]
 type = "openai"
 api_base = "http://pmoves-ollama:11434/v1"
-model_name = "gemma4:26b-a4b"
+# Ollama publishes the 26B A4B MoE variant as the default ":26b" tag.
+# Verified via registry.ollama.ai manifest API (":26b-a4b" returns 404).
+model_name = "gemma4:26b"
 api_key_location = "none"
 
 # Gemma 4 31B Dense (SOTA multimodal, 256K ctx, ~18GB Q4)
@@ -399,7 +401,9 @@ routing = ["ollama_spark"]
 [models.gemma_4_26b_a4b_spark.providers.ollama_spark]
 type = "openai"
 api_base = "http://pmoves-dgx-spark:11434/v1"
-model_name = "gemma4:26b-a4b"
+# Ollama publishes the 26B A4B MoE variant as the default ":26b" tag.
+# Verified via registry.ollama.ai manifest API (":26b-a4b" returns 404).
+model_name = "gemma4:26b"
 api_key_location = "none"
 
 # Nemotron Super 49B on DGX Spark (Ollama native, no NIM container required)


### PR DESCRIPTION
## Summary
- **Fix confirmed production bug**: gemma4:26b-a4b 4090 OOM — removed 4090 from nodes list. 15000MB quantized footprint exceeds laptop 4090 available VRAM (16384−2048=14336MB).
- **Fix Ollama tag mismatch**: registry publishes the 26B A4B MoE variant as the default `:26b` tag, not `:26b-a4b`. Verified via `registry.ollama.ai/v2/library/gemma4/manifests/{26b|26b-a4b}` (200 vs 404). Updated in 4 files.
- **Fix multimodal capability flags**: Gemma 4 26B-A4B and 31B have HF `pipeline_tag: image-text-to-text` (vision only, NO audio/video). Only E2B/E4B are `any-to-any`. Removed incorrect audio/video/multimodal flags from the two dense/MoE seed rows.
- **Verified false positive**: tensorzero.toml `coding_qwen3_coder_next_80b_local` reference — model block exists at line 297 with proper routing; variant at line 1003 resolves correctly. No changes.

## Context
PR #1226 (Gemma 4 family onboarding) merged to main on 2026-04-13. CodeRabbit posted 4 inline threads after merge. One was a confirmed production bug (4090 VRAM under-allocation); two more turned out to be bigger than initially flagged once verification landed. This PR trims the landmines before Phase 6 runtime deploy (DGX Spark + R9700 bring-up) so the fleet doesn't ship with OOM + unpullable-tag breakage.

## Verification
- [x] **Finding 1 (4090 OOM)**: Confirmed via `pmoves/config/gpu-models.yaml:275-281` → `vram_mb: 15000`. 4090 laptop has 16384MB total, reserves 2048MB → 14336MB available. 15000 > 14336 → OOM on load. The 18000MB `gemma4:31b` entry already correctly restricted to `nodes: [5090]`.
- [x] **Finding 2 (Ollama tag verification)**: Mismatch discovered. Queried `https://registry.ollama.ai/v2/library/gemma4/manifests/{tag}` for all 5 candidate tags:
  - `gemma4:e2b` → 200 OK
  - `gemma4:e4b` → 200 OK
  - `gemma4:26b` → 200 OK (17.9 GB layer)
  - `gemma4:31b` → 200 OK
  - `gemma4:26b-a4b` → **404 MANIFEST_UNKNOWN**
  The `:26b-a4b` form appears in the HTML tags listing for the gemma4 library page but is not a pullable manifest. Canonical A4B MoE tag is the default `:26b`.
- [x] **Finding 3 (HF multimodal verification)**: Queried HF API for all 4 variants:
  - `google/gemma-4-E2B-it` → `pipeline_tag: any-to-any` (keep audio+video+multimodal — unchanged)
  - `google/gemma-4-E4B-it` → `pipeline_tag: any-to-any` (keep audio+video+multimodal — unchanged)
  - `google/gemma-4-26B-A4B-it` → `pipeline_tag: image-text-to-text` (**removed audio/video/multimodal**)
  - `google/gemma-4-31B-it` → `pipeline_tag: image-text-to-text` (**removed audio**)
- [x] **Finding 4 (TensorZero variant ref)**: Verified non-issue. `[models.coding_qwen3_coder_next_80b_local]` block exists at line 297 with `routing = ["ollama_local"]` and a complete provider subblock. The variant at line 1003 resolves cleanly. No structural problem.

## Files touched (4)
- `pmoves/config/gpu-models.yaml` — id rename `:26b-a4b` → `:26b` + explanatory comment
- `pmoves/configs/flare-model-namespace.yaml` — model_id rename + 4090 node removal + OOM comment
- `pmoves/supabase/initdb/12_model_registry_seed.sql` — model_id rename (26B) + capabilities trim (26B + 31B)
- `pmoves/tensorzero/config/tensorzero.toml` — model_name rename in 2 provider blocks (local + spark)

## Known follow-ups (out of scope for this PR)
Two additional files still reference the obsolete `gemma4:26b-a4b` tag and must be fixed in a separate PR:
- `pmoves/mk/nvidia-dgx-spark.mk:31` — `spark-gemma4-pull` target runs `ollama pull gemma4:26b-a4b` (will fail with 404 at operator bring-up time)
- `pmoves/docs/operations/TOPOLOGY.md:68` — documentation reference

These were intentionally left alone to keep this PR atomic and inside the CodeRabbit-thread scope. Recommend landing them as a tiny follow-up.

## Test plan
- [ ] Dry-run `make -C pmoves brand-defaults` (no-op on this commit — no env.shared changes expected)
- [ ] `pytest pmoves/tests/` (no new tests; regression only)
- [ ] Before Phase 6 bring-up: `ssh root@<spark-host> "ollama pull gemma4:26b"` to confirm canonical tag pulls
- [ ] After merge: open follow-up PR for `nvidia-dgx-spark.mk` + `TOPOLOGY.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Gemma 4 26B model configuration to align with Ollama's supported model tags for improved compatibility.
  * Adjusted GPU node targeting to optimize resource allocation for the Gemma 4 26B model.

* **Chores**
  * Refined model capability declarations for Gemma 4 26B and 31B variants to reflect actual feature support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->