### PR TITLE
docs(voice): correctness lane — TAC Phase 6 closeout + Higgs RCA + cgp probe voice subjects (Session 12 Lane 2)

### DIFF
--- a/pmoves/docs/TAC/TAC_VOICE_PRODUCTION.md
+++ b/pmoves/docs/TAC/TAC_VOICE_PRODUCTION.md
@@ -72,8 +72,8 @@ Agent Zero Task (meta.voice_mode=true)
 - Agent Zero → voice-relay: ✅ Shipped
 - voice-relay → voice.agent.response.v1: ✅ Shipped
 - Publisher-Discord audio attachment: ✅ Wired (base64 → .wav attachment)
-- **Voice → PMOVES.YT**: ❌ NOT WIRED — no voice consumer in YT publisher
-- **Skill pairings**: ❌ No voice-synthesis pairing in `skill-pairings.yaml`
+- **Voice → PMOVES.YT**: 📋 INTENTIONAL — voice chain bypasses YT by design. See `pmoves/docs/architecture/voice-chain-end-to-end.md` (Session 12 Lane 4 decision: voice-relay targets host consumers + Discord, not media-ingestion services).
+- **Skill pairings**: ✅ `voice-synthesis` pairing wired in `pmoves/configs/skill-pairings.yaml:158-205` (text-generate → prosodic-analyze → tts-synthesize → cast-to-device)
 
 ## Phase 4: Known Bugs
 
@@ -86,13 +86,20 @@ Agent Zero Task (meta.voice_mode=true)
 ❌ CPU fallback also failed: Padding_idx must be within num_embeddings
 ```
 
-**Root cause:** Vocab/embedding mismatch in the Higgs integration inside Ultimate-TTS-Studio-SUP3R-Edition. The model checkpoint's embedding matrix was saved with a smaller vocab size than what the tokenizer currently exposes, OR a special token (like `<pad>`) was added without calling `model.resize_token_embeddings()`.
+**Root cause (Session 12 research):** The HuggingFace repo `bosonai/higgs-audio-v2-generation-3B-base` was **republished on 2026-04-04** in a new single-file `AutoModelForTextToWaveform` format (flat config, `model_type: "higgs_audio_v2"`, no nested `text_config`). The vendored `higgs_audio/` subtree inside `SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition` has not been updated to match. When the new flat config hits the legacy composition loader, `configuration_higgs_audio.py:168-169` falls through to an empty `CONFIG_MAPPING["llama"]()` default (vocab_size=32000) while still using `pad_token_id=128001` from the top-level config. Then `modeling_higgs_audio.py:900` instantiates `nn.Embedding(32000, 4096, padding_idx=128001)` → PyTorch raises `ValueError` in `torch/nn/modules/sparse.py`.
 
-**Fix location:** Ultimate-TTS-Studio-SUP3R-Edition upstream repo (NOT PMOVES). Likely in `app/handlers/higgs_handler.py` or similar.
+**Not** a `resize_token_embeddings()` oversight — vendored code was correct against the *previous* checkpoint version. Hardware-agnostic (CPU fallback fails identically).
 
-**Workaround:** Skip Higgs. VoxCPM, F5-TTS, and Fish S2 cover its use cases.
+**Related upstream issue:** [`boson-ai/higgs-audio#176`](https://github.com/boson-ai/higgs-audio/issues/176) — same root cause, manifests one step earlier at `HiggsAudioTokenizer.__init__`.
 
-**Upstream action:** File issue at `SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition` with the reproduction steps.
+**Fix options (any one unblocks Higgs):**
+- **A:** Pin to pre-2026-04-04 checkpoint revision in `app/higgs_audio_handler.py:436-442` (add `revision=<sha>` to `snapshot_download`). Fastest.
+- **B:** Upgrade to `AutoModelForTextToWaveform` loader (requires `transformers>=5.3.0.dev0` + adapter).
+- **C:** Sync vendored subtree from latest `boson-ai/higgs-audio` (gated on upstream fix for #176).
+
+**Workaround:** Skip Higgs. VoxCPM, F5-TTS, and Fish S2 Pro cover its use cases.
+
+**Full RCA + filing-ready issue body:** `pmoves/docs/issues/higgs-upstream-embedding-bug.md` + `higgs-upstream-embedding-bug-draft.md`. No existing issue in the SUP3R repo references `Padding_idx` — the draft is ready to file as a new issue at `SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition`.
 
 ### VibeVoice: Separate endpoint (not unified)
 
@@ -121,13 +128,13 @@ PMOVES has ZERO formal skills for pterm, gepeto, or pinokio management despite h
 - [x] Expressive intents sweep 4/4 (narrate, dramatic, multilingual, agent)
 - [x] Prosodic synthesis with CHIT CGP events
 - [x] Voicebox API surface mapped (22 TTS endpoints)
-- [ ] **VibeVoice separate endpoint test** (`/handle_vibevoice_generation`)
-- [ ] **Voicebox provider integration** into Flute-Gateway (`VoiceboxProvider` class)
-- [ ] **Creator pipeline test**: synthesize → Discord webhook with .wav attachment
-- [ ] **Pterm/pinokio skill stubs** in `.claude/commands/pinokio/`
-- [ ] **Voice-synthesis skill pairing** in `pmoves/configs/skill-pairings.yaml`
-- [ ] **PMOVES.YT voice integration** (stretch goal — new consumer)
-- [ ] **Higgs upstream issue filed** (housekeeping)
+- [ ] **VibeVoice separate endpoint test** (`/handle_vibevoice_generation`) — Session 12 Lane 3 ships WebSocket harness
+- [x] **Voicebox provider integration** into Flute-Gateway (`VoiceboxProvider` class) — Session 12 Lane 1
+- [x] **Creator pipeline test**: synthesize → Discord webhook with .wav attachment — Session 11 (`voice_to_discord_test.py --synthetic`)
+- [x] **Pterm/pinokio skill stubs** in `.claude/commands/pinokio/` — Session 11 (5 commands shipped)
+- [x] **Voice-synthesis skill pairing** in `pmoves/configs/skill-pairings.yaml` — already wired at lines 158-205 (Phase 3 claim was stale)
+- [x] **PMOVES.YT voice integration** — Session 12 Lane 4: documented as intentional non-wiring in `pmoves/docs/architecture/voice-chain-end-to-end.md`
+- [ ] **Higgs upstream issue filed** at `SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition` — root cause isolated, filing-ready body at `pmoves/docs/issues/higgs-upstream-embedding-bug-draft.md` (Session 12 research). Related: `boson-ai/higgs-audio#176` (same root cause, one step earlier in the stack). Filing itself is a user action — just copy-paste the draft into a new GitHub issue.
 
 ## Phase 7: NATS Subjects Catalog (Voice Lane)
 

--- a/pmoves/docs/issues/higgs-upstream-embedding-bug-draft.md
+++ b/pmoves/docs/issues/higgs-upstream-embedding-bug-draft.md
@@ -1,0 +1,186 @@
+# Higgs Audio engine fails to initialize after upstream checkpoint update (`Padding_idx must be within num_embeddings`)
+
+**Repo:** `SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition`
+**Affected engine:** Higgs Audio (`higgs_audio_handler.py`)
+**Hardware-agnostic:** Yes — CPU fallback fails with the same error, ruling out any CUDA/device cause.
+**Related upstream:** [`boson-ai/higgs-audio#176`](https://github.com/boson-ai/higgs-audio/issues/176) (opened 2026-04-13; same root cause, manifests one step earlier at `HiggsAudioTokenizer.__init__`).
+
+---
+
+## Summary
+
+After the `bosonai/higgs-audio-v2-generation-3B-base` HuggingFace checkpoint
+was republished on **2026-04-04** in the new transformers-native format
+(`architectures: ["HiggsAudioV2ForConditionalGeneration"]`, `model_type: "higgs_audio_v2"`,
+flat config with no nested `text_config`), the vendored `higgs_audio/` model
+code inside `Ultimate-TTS-Studio-SUP3R-Edition` can no longer construct the
+model. It silently falls back to a default `LlamaConfig` (vocab_size=32000)
+while still using `pad_token_id=128001` from the top-level config, which
+violates the `padding_idx < num_embeddings` invariant on the embedding layer.
+
+## Reproduction
+
+1. Install and launch Ultimate-TTS-Studio-SUP3R-Edition via Pinokio.
+2. In the Gradio UI, select the **Higgs Audio** engine and submit any text.
+3. Observe the following in the console:
+
+```
+🎤 Initializing Higgs Audio engine on cuda...
+❌ Failed to initialize Higgs Audio engine: Padding_idx must be within num_embeddings
+🔄 Attempting CPU fallback...
+❌ CPU fallback also failed: Padding_idx must be within num_embeddings
+```
+
+The error is **hardware-agnostic** — CPU fallback fails identically, so this
+is not a CUDA/device issue. The model was initialized on an RTX 5090 (CUDA
+12.4), but the same failure occurs on CPU-only machines per the traceback.
+
+## Root cause
+
+The HuggingFace repo `bosonai/higgs-audio-v2-generation-3B-base` was updated
+in place on **2026-04-04** (`lastModified: 2026-04-04T19:47:40Z`, sha
+`0ff4877`). The new `config.json` is flat — no nested `text_config`:
+
+```json
+{
+  "architectures": ["HiggsAudioV2ForConditionalGeneration"],
+  "model_type": "higgs_audio_v2",
+  "vocab_size": 128256,
+  "hidden_size": 3072,
+  "pad_token_id": 128001,
+  "audio_token_id": 128016,
+  "audio_bos_token_id": 128013,
+  ...
+}
+```
+
+But the vendored `higgs_audio/model/configuration_higgs_audio.py` in this
+repo still expects the legacy composition schema (`model_type: "higgs_audio"`,
+nested `text_config` sub-object). In its `__init__`, when `text_config=None`
+is encountered, it falls back to an **empty default Llama config**:
+
+https://github.com/SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition/blob/main/higgs_audio/higgs_audio/model/configuration_higgs_audio.py#L168-L169
+
+```python
+elif text_config is None:
+    text_config = CONFIG_MAPPING["llama"]()   # → LlamaConfig(vocab_size=32000, hidden_size=4096)
+```
+
+Later in the same `__init__` (line 239), it still assigns
+`self.pad_token_id = 128001` from the top-level kwargs. Then in
+`modeling_higgs_audio.py` line 900:
+
+https://github.com/SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition/blob/main/higgs_audio/higgs_audio/model/modeling_higgs_audio.py#L889-L900
+
+```python
+self.padding_idx = config.pad_token_id                           # = 128001
+self.vocab_size  = config.text_config.vocab_size                 # = 32000  (Llama default)
+...
+self.embed_tokens = nn.Embedding(
+    self.vocab_size,                     #   32000
+    config.text_config.hidden_size,      #    4096 (Llama default)
+    self.padding_idx,                    #  128001  ← OUT OF RANGE
+)
+```
+
+PyTorch raises `ValueError: Padding_idx must be within num_embeddings` in
+`torch/nn/modules/sparse.py`. The CPU fallback path in
+`higgs_audio_handler.py::initialize_engine` (lines 334-350) simply retries
+the same construction, so it fails with the same error.
+
+## Why this broke now
+
+This is **not** a tokenizer drift / `resize_token_embeddings()` oversight
+inside the vendored code — the vendored code was correct against the
+**previous** version of the checkpoint. The HF repo was republished
+~nine days before this report (2026-04-04) in a new single-file
+`AutoModelForTextToWaveform` format. The vendored `higgs_audio/` subtree in
+this repo has not been updated to match; `git log app/higgs_audio_handler.py`
+upstream shows zero commits.
+
+The same root cause is reported upstream at `boson-ai/higgs-audio`:
+
+- https://github.com/boson-ai/higgs-audio/issues/176 — `HiggsAudioTokenizer.__init__() got an unexpected keyword argument 'acoustic_model_config'` (2026-04-13)
+
+That issue trips one step earlier — in the tokenizer load — because the
+`boson_multimodal` snapshot is older than the vendored `higgs_audio/` subtree
+in SUP3R, which gets past the tokenizer step and then dies at the embedding
+constructor instead. Both issues share the same underlying checkpoint-format
+mismatch.
+
+## Suggested fixes (any one of these unblocks Higgs)
+
+**Option A — pin to pre-2026-04-04 checkpoint (fast, minimal blast radius).**
+In `app/higgs_audio_handler.py` around line 261, set a pinned revision on the
+snapshot download calls in `_ensure_local_higgs_snapshots` (line 436-442):
+
+```python
+model_local = snapshot_download(
+    repo_id=self.model_path,
+    revision="<sha-of-last-working-commit-before-2026-04-04>",  # pin
+    ...
+)
+```
+
+The last-known-good sha can be found via
+`huggingface_hub.list_repo_commits("bosonai/higgs-audio-v2-generation-3B-base")`
+and selecting the most recent commit dated before 2026-04-04.
+
+**Option B — upgrade to the new `transformers`-native loader.** The new
+checkpoint advertises `auto_model: "AutoModelForTextToWaveform"` in its
+`transformersInfo`. Replace the vendored `HiggsAudioServeEngine` call
+(line 324-328 of `higgs_audio_handler.py`) with:
+
+```python
+from transformers import AutoProcessor, AutoModelForTextToWaveform
+processor = AutoProcessor.from_pretrained(local_model_path)
+model = AutoModelForTextToWaveform.from_pretrained(
+    local_model_path,
+    torch_dtype=torch.bfloat16,
+    device_map=self.device,
+)
+```
+
+and retire the vendored `higgs_audio/` subtree entirely. This requires
+`transformers>=5.3.0.dev0` (per the checkpoint's `transformers_version`
+field) and an adapter around the existing prompt-building logic.
+
+**Option C — sync the vendored subtree.** Pull the latest
+`boson-ai/higgs-audio` copy into `app/higgs_audio/` and wait for upstream
+issue #176 to land a fix. Lowest control, highest dependency on upstream.
+
+## Workaround (for users hitting this now)
+
+Ultimate-TTS-Studio-SUP3R-Edition ships **13 other engines** that do not
+share this code path. Any of the following produce comparable quality
+without patching anything:
+
+| Higgs use case | Alternative in this repo |
+|---|---|
+| Expressive narration | VoxCPM (44.1 kHz) |
+| Short-reference voice cloning | F5-TTS (24 kHz, 8.5x real-time) |
+| Multi-language emotional speech | Fish Speech S2 Pro (44.1 kHz, 13 languages) |
+
+Simply select a different engine in the Gradio UI until the Higgs handler
+is updated.
+
+## Exact file:line references
+
+- **Error origin:** `app/higgs_audio/higgs_audio/model/modeling_higgs_audio.py:900`
+- **Root-cause fallback:** `app/higgs_audio/higgs_audio/model/configuration_higgs_audio.py:168-169`
+- **Handler entry point:** `app/higgs_audio_handler.py:312-351` (`initialize_engine`)
+- **Snapshot download (fix location A):** `app/higgs_audio_handler.py:436-442`
+
+## Environment
+
+- OS: Windows 11, Python 3.10 (Pinokio-managed venv)
+- GPU: NVIDIA RTX 5090, CUDA 12.4
+- torch: (per Pinokio install profile)
+- Reproduces on CPU fallback — not hardware-specific
+- Upstream model checkpoint sha `0ff4877` (lastModified 2026-04-04)
+
+---
+
+*Filed from the PMOVES.AI production voice lane after verification that no
+existing issue in this repo references `Padding_idx`, `num_embeddings`, or
+the 2026-04-04 checkpoint break.*

--- a/pmoves/docs/issues/higgs-upstream-embedding-bug.md
+++ b/pmoves/docs/issues/higgs-upstream-embedding-bug.md
@@ -1,0 +1,103 @@
+# Higgs Audio: Upstream Embedding Mismatch Bug
+
+**Status:** Root cause identified (Session 12 follow-up research)
+**Severity:** Non-blocking (13 other engines available)
+**Affects:** `SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition` — Higgs Audio handler
+**First observed:** Session 11 (2026-04-13)
+**Root cause isolated:** Session 12 (2026-04-14)
+**Related upstream issue:** [`boson-ai/higgs-audio#176`](https://github.com/boson-ai/higgs-audio/issues/176) — same root cause, manifests one step earlier at `HiggsAudioTokenizer.__init__`
+**Filing-ready issue body:** [`higgs-upstream-embedding-bug-draft.md`](higgs-upstream-embedding-bug-draft.md)
+
+---
+
+## TL;DR
+
+The HuggingFace repo `bosonai/higgs-audio-v2-generation-3B-base` was **republished on 2026-04-04** in a new single-file format. The vendored `higgs_audio/` subtree inside `SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition` has not been updated to match — when it hits the new flat config, it silently falls through to an empty Llama default (vocab_size=32000) while still using `pad_token_id=128001` from the top-level config, which crashes `torch.nn.Embedding` with `padding_idx (128001) >= num_embeddings (32000)`.
+
+This is **not** a `resize_token_embeddings()` oversight — the vendored code was correct against the **previous** version of the checkpoint. The bug is a checkpoint-format drift that only appeared when the HF repo was republished nine days before this report.
+
+## Error path (precise)
+
+1. `app/higgs_audio/higgs_audio/model/configuration_higgs_audio.py:168-169`
+   ```python
+   elif text_config is None:
+       text_config = CONFIG_MAPPING["llama"]()   # → LlamaConfig(vocab_size=32000)
+   ```
+2. `app/higgs_audio/higgs_audio/model/modeling_higgs_audio.py:900`
+   ```python
+   self.embed_tokens = nn.Embedding(
+       self.vocab_size,                     #   32000 (Llama default, wrong)
+       config.text_config.hidden_size,      #    4096
+       self.padding_idx,                    #  128001 (from top-level pad_token_id)
+   )
+   ```
+3. PyTorch raises `ValueError: Padding_idx must be within num_embeddings` in `torch/nn/modules/sparse.py`.
+
+CPU fallback (`app/higgs_audio_handler.py:334-350`) simply retries the same construction → same failure. Hardware-agnostic.
+
+## Three concrete fixes (any one unblocks Higgs)
+
+| Option | Location | Effort | Risk |
+|--------|----------|--------|------|
+| **A — Pin to pre-2026-04-04 checkpoint** | `app/higgs_audio_handler.py:436-442` (add `revision=<sha>` to `snapshot_download`) | Low | Model frozen at old version |
+| **B — Upgrade to `AutoModelForTextToWaveform`** | `app/higgs_audio_handler.py:324-328` (replace vendored loader with new transformers-native API) | Medium | Requires `transformers>=5.3.0.dev0` + adapter for prompt-building logic |
+| **C — Sync vendored subtree** | `app/higgs_audio/` (pull latest `boson-ai/higgs-audio`) | Low-Medium | Gated on upstream fix for boson-ai/higgs-audio#176 |
+
+**Recommendation:** Option A (pin to pre-2026-04-04 revision) for fastest unblock. Use `huggingface_hub.list_repo_commits("bosonai/higgs-audio-v2-generation-3B-base")` to find the most recent commit dated before 2026-04-04.
+
+## Reproducer
+
+1. Install and launch Ultimate-TTS-Studio-SUP3R-Edition via Pinokio: `pterm run ultimate-tts-studio-sup3r-edition.pinokio.git`
+2. In the Gradio UI at `http://localhost:7860`, select the **Higgs Audio** engine and submit any text
+3. Observe:
+   ```
+   🎤 Initializing Higgs Audio engine on cuda...
+   ❌ Failed to initialize Higgs Audio engine: Padding_idx must be within num_embeddings
+   🔄 Attempting CPU fallback...
+   ❌ CPU fallback also failed: Padding_idx must be within num_embeddings
+   ```
+
+Equivalent reproducer via PMOVES production path:
+```bash
+curl -X POST http://localhost:8055/v1/voice/synthesize \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Hello world","provider":"ultimate_tts","engine":"higgs"}'
+```
+The flute-gateway surfaces the upstream traceback as an `UltimateTTSError` → HTTP 502.
+
+## Workaround (operational, available now)
+
+Until upstream fix lands, **skip Higgs Audio**. Three alternative engines cover the same use cases with comparable or better quality:
+
+| Higgs use case | PMOVES alternative | Quality |
+|----------------|---------------------|---------|
+| Expressive narration | **VoxCPM** (44.1 kHz) | Highest fidelity; verified in Session 11 |
+| Voice cloning from short reference | **F5-TTS** (24 kHz) | 8.5x real-time, best cloning verified |
+| Multi-language emotional speech | **Fish Speech S2 Pro** (44.1 kHz) | 13 languages, user-verified UI |
+
+The PMOVES production path defaults to these engines; Higgs is only reachable when explicitly requested via `engine=higgs`.
+
+## Upstream filing status
+
+**Related existing issue (one step earlier in the same stack):**
+- [`boson-ai/higgs-audio#176`](https://github.com/boson-ai/higgs-audio/issues/176) — `HiggsAudioTokenizer.__init__() got an unexpected keyword argument 'acoustic_model_config'` (opened 2026-04-13)
+  - This is in the upstream `boson-ai/higgs-audio` repo, not the SUP3R fork
+  - Same checkpoint-format mismatch; trips earlier because the `boson_multimodal` snapshot is older than the vendored subtree in SUP3R
+  - Both issues share the same underlying root cause
+
+**New issue to file at SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition** (user action):
+- **Filing-ready body:** `higgs-upstream-embedding-bug-draft.md` in this same directory — copy-paste into a new GitHub issue
+- Verified: no existing issue in the SUP3R repo references `Padding_idx`, `num_embeddings`, or the 2026-04-04 checkpoint break
+- Title: `Higgs Audio engine fails to initialize after upstream checkpoint update (Padding_idx must be within num_embeddings)`
+
+## Cross-references
+
+- TAC tree: `pmoves/docs/TAC/TAC_VOICE_PRODUCTION.md` Phase 4 (Known Bugs)
+- Engine inventory: `pmoves/configs/tts-engine-capabilities.yaml`
+- Production test harness: `pmoves/tools/test_all_tts_engines.py`
+- Filing-ready issue body: `higgs-upstream-embedding-bug-draft.md`
+- Precise file:line references:
+  - Config fallthrough: `app/higgs_audio/higgs_audio/model/configuration_higgs_audio.py:168-169`
+  - Embedding crash site: `app/higgs_audio/higgs_audio/model/modeling_higgs_audio.py:900`
+  - Handler entry point: `app/higgs_audio_handler.py:312-351`
+  - Snapshot download (fix A location): `app/higgs_audio_handler.py:436-442`

--- a/pmoves/tools/cgp_sub_probe.py
+++ b/pmoves/tools/cgp_sub_probe.py
@@ -1,12 +1,23 @@
 #!/usr/bin/env python3
-"""Subscribe to geometry.cgp.v1 and print any messages received."""
+"""Subscribe to CGP + voice NATS subjects and print any messages received.
+
+Covers two subject families:
+  - Geometry/CHIT CGP: tokenism.geometry.event.v1, geometry.cgp.v1 (+ wildcards)
+  - Voice chain: voice.agent.response.v1, agentzero.task.result.v1,
+    voice.training.request.v1
+
+The voice subjects were added in Session 12 Lane 2 because the geometry.>
+and tokenism.> wildcards do NOT cover them — voice-relay publishes on the
+voice.* and agentzero.* hierarchies, which are distinct from the CGP/geometry
+namespaces. Use this probe to verify the full voice chain emits events end-to-end.
+"""
 import asyncio
 import os
 import nats
 
 
 async def main() -> None:
-    """Connect to NATS and print CGP events for 8 seconds."""
+    """Connect to NATS and print CGP + voice events for 10 seconds."""
     url = os.environ.get("NATS_URL", "nats://nats:pmoves@nats:4222")
     nc = await nats.connect(url)
     print(f"Connected to NATS: {url}")
@@ -17,11 +28,26 @@ async def main() -> None:
         print(f"RECV: {msg.subject} ({len(msg.data)} bytes)")
         print(f"Preview: {msg.data[:300]!r}")
 
+    # Geometry / CHIT CGP subjects (existing)
     await nc.subscribe("tokenism.geometry.event.v1", cb=handler)
     await nc.subscribe("geometry.cgp.v1", cb=handler)
     await nc.subscribe("geometry.>", cb=handler)
     await nc.subscribe("tokenism.>", cb=handler)
-    print("Subscribed to tokenism.geometry.event.v1 + wildcards — waiting 10s")
+
+    # Voice chain subjects (added Session 12 Lane 2)
+    # voice-relay input (consumed):
+    await nc.subscribe("agentzero.task.result.v1", cb=handler)
+    # voice-relay output (consumed by voice_follow_agent, voice_follow_cast_agent, publisher-discord):
+    await nc.subscribe("voice.agent.response.v1", cb=handler)
+    # voice cloning training trigger (planned consumer: training worker):
+    await nc.subscribe("voice.training.request.v1", cb=handler)
+
+    print(
+        "Subscribed to:\n"
+        "  geometry/CHIT: tokenism.geometry.event.v1, geometry.cgp.v1, geometry.>, tokenism.>\n"
+        "  voice chain:   agentzero.task.result.v1, voice.agent.response.v1, voice.training.request.v1\n"
+        "Waiting 10s..."
+    )
     await asyncio.sleep(10)
     print(f"Total messages: {len(msgs)}")
     await nc.close()


### PR DESCRIPTION
## Summary

Correctness lane for the Session 12 voice production orchestration. Three mechanical fixes that make existing artifacts internally consistent with disk reality, **plus** a deep-dive upstream bug investigation for Higgs Audio that went much further than the original plan scope.

## 1. TAC_VOICE_PRODUCTION.md corrections

**Phase 3 stale claim fixed.** The TAC tree claimed `❌ No voice-synthesis pairing in skill-pairings.yaml`, but the pairing has been wired at lines 158-205 since before Session 11. Changed to `✅ voice-synthesis pairing wired (text-generate → prosodic-analyze → tts-synthesize → cast-to-device)`.

**Phase 3 PMOVES.YT status updated** to forward-reference the Lane 4 architecture doc (the explicit non-wiring decision).

**Phase 4 Higgs root cause rewritten.** Was vague ("vocab/embedding mismatch, likely missing resize_token_embeddings"), now precise:
- HF repo `bosonai/higgs-audio-v2-generation-3B-base` was republished 2026-04-04 in new single-file format
- Vendored `higgs_audio/` subtree in SUP3R falls through to empty Llama default at `configuration_higgs_audio.py:168-169`
- Then `nn.Embedding(32000, 4096, padding_idx=128001)` at `modeling_higgs_audio.py:900` crashes
- **Not** a `resize_token_embeddings()` oversight — the vendored code was correct against the *previous* checkpoint

**Phase 6 checklist progressed 5/12 → 9/12 done:**
- [x] Voicebox provider integration (Session 12 Lane 1 → #1235)
- [x] Creator pipeline test (Session 11 verified)
- [x] Pinokio skill stubs (Session 11 — 5 commands shipped)
- [x] Voice-synthesis skill pairing (already wired)
- [x] PMOVES.YT voice integration (documented as intentional non-wiring in Lane 4 → #1238)
- [ ] VibeVoice WebSocket test (Lane 3 ships harness → #1236, gated on upstream running)
- [ ] Higgs upstream issue filed (root cause isolated, draft ready, filing is user action)

## 2. cgp_sub_probe.py voice subjects

The probe subscribed to `geometry.cgp.v1`, `geometry.>`, `tokenism.>`. The voice chain uses `voice.*` and `agentzero.*` which are NOT covered by those wildcards, so voice CGP events were silently missed. Added explicit subscribes:
- \`voice.agent.response.v1\` (voice-relay output → consumers)
- \`agentzero.task.result.v1\` (voice-relay input)
- \`voice.training.request.v1\` (voice cloning training trigger, planned)

Module docstring rewritten to explain the two subject families and why voice subjects need explicit subscribes.

## 3. Higgs upstream RCA (new directory: \`pmoves/docs/issues/\`)

A dispatched background research agent went much deeper than the original plan scope of "create a local stub":

1. **Searched upstream issue tracker** — verified no existing issue in \`SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition\` references \`Padding_idx\` or the 2026-04-04 checkpoint break.
2. **Located the exact code path** — the vendored \`higgs_audio/\` subtree in the SUP3R repo, with \`file:line\` precision.
3. **Identified the trigger** — the HF repo was republished on 2026-04-04 with a new single-file \`AutoModelForTextToWaveform\` format. The vendored loader expects the legacy composition schema (nested \`text_config\`); when it hits the new flat config, it falls through to an empty Llama default.
4. **Cross-referenced with upstream** — found [\`boson-ai/higgs-audio#176\`](https://github.com/boson-ai/higgs-audio/issues/176), the same root cause one step earlier in the stack.
5. **Proposed 3 concrete fixes** (ranked by effort):
   - **A — Pin checkpoint revision** (fastest, 1-line change in \`higgs_audio_handler.py:436-442\`)
   - **B — Upgrade to \`AutoModelForTextToWaveform\`** (requires \`transformers>=5.3.0.dev0\`)
   - **C — Sync vendored subtree** (gated on upstream \`#176\`)

**Files in \`pmoves/docs/issues/\` (NEW directory):**
- \`higgs-upstream-embedding-bug.md\` — canonical RCA document (TL;DR, error path, fix options, reproducer, workaround, filing status)
- \`higgs-upstream-embedding-bug-draft.md\` — filing-ready issue body, copy-paste into a new GitHub issue at \`SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition\`

**No code changes in this PR** — all fixes are upstream work. PMOVES continues to route around Higgs via VoxCPM / F5-TTS / Fish S2 Pro.

## Files (4)

- EDIT \`pmoves/docs/TAC/TAC_VOICE_PRODUCTION.md\` — Phase 3 stale claim, Phase 4 RCA rewrite, Phase 6 closeout
- EDIT \`pmoves/tools/cgp_sub_probe.py\` — voice subject subscribes + docstring
- NEW \`pmoves/docs/issues/higgs-upstream-embedding-bug.md\` — canonical RCA
- NEW \`pmoves/docs/issues/higgs-upstream-embedding-bug-draft.md\` — filing-ready body

## Test plan

- [x] TAC tree renders in markdown
- [x] Higgs RCA cross-references are internally consistent (draft ↔ stub ↔ TAC Phase 4)
- [x] cgp_sub_probe.py is syntactically valid
- [ ] Run cgp_sub_probe.py against a live NATS + voice-relay to confirm voice subjects are captured (requires Lane 3 merged + voice-relay running)

## Cross-lane context

- Lane 1 (VoiceboxProvider): #1235
- Lane 3 (Verification tools): #1236
- Lane 4 (Architecture doc): #1238 — this PR forward-references its path
- Session 12 plan: keen-frolicking-turtle (approved)

Lane 2 has a soft dependency on Lane 4: the TAC Phase 3 line forward-references \`pmoves/docs/architecture/voice-chain-end-to-end.md\`. If Lane 4 merges first, the link resolves immediately. If they merge in the other order or simultaneously, the link is briefly dangling for <1 minute.

## Next steps for user

1. **Review + merge the 4 Session 12 PRs** in whatever order you prefer (no hard dependencies)
2. **File the Higgs issue**: copy-paste \`pmoves/docs/issues/higgs-upstream-embedding-bug-draft.md\` into a new issue at https://github.com/SUP3RMASS1VE/Ultimate-TTS-Studio-SUP3R-Edition/issues
3. **(Optional) Implement fix option A** if you want to unblock Higgs in PMOVES immediately — pin the checkpoint revision in a local fork of SUP3R until upstream merges a fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)