### PR TITLE
fix(dgx-spark): correct obsolete gemma4:26b-a4b Ollama tag

### DIFF
--- a/pmoves/docs/operations/TOPOLOGY.md
+++ b/pmoves/docs/operations/TOPOLOGY.md
@@ -65,7 +65,7 @@ NVIDIA DGX Spark (GB10 Grace-Blackwell Superchip) on Tailscale. Purpose-built fo
 
 **Pending setup:**
 1. Tailscale join + tag assignment (`tag:spark`)
-2. Ollama install + `gemma4:31b`, `gemma4:26b-a4b`, `nemotron:49b` model pulls
+2. Ollama install + `gemma4:31b`, `gemma4:26b`, `nemotron:49b` model pulls
 3. Registration in `agent-teams.yaml` under `agents/gpu-inference` tier
 4. TensorZero `ollama_spark` provider points at `http://pmoves-dgx-spark:11434/v1`
 5. `spark_claw` agent profile activates after first heartbeat on `mesh.gpu.status.v1`

--- a/pmoves/mk/nvidia-dgx-spark.mk
+++ b/pmoves/mk/nvidia-dgx-spark.mk
@@ -27,8 +27,8 @@ spark-ollama-pull: ## Pull a model on DGX Spark: make spark-ollama-pull MODEL=ge
 	@test -n "$(MODEL)" || { echo "ERROR: MODEL required (e.g. MODEL=gemma4:31b)"; exit 1; }
 	@ssh -o ConnectTimeout=10 root@$(OLLAMA_SPARK_HOST) "ollama pull $(MODEL)" || { echo "spark: pull failed"; exit 1; }
 
-spark-gemma4-pull: ## Pull all 4 Gemma 4 variants on DGX Spark (E2B + E4B + 26B-A4B + 31B)
-	@ssh -o ConnectTimeout=10 root@$(OLLAMA_SPARK_HOST) "ollama pull gemma4:e2b && ollama pull gemma4:e4b && ollama pull gemma4:26b-a4b && ollama pull gemma4:31b" || { echo "spark: gemma4 pull failed"; exit 1; }
+spark-gemma4-pull: ## Pull all 4 Gemma 4 variants on DGX Spark (E2B + E4B + 26B + 31B)
+	@ssh -o ConnectTimeout=10 root@$(OLLAMA_SPARK_HOST) "ollama pull gemma4:e2b && ollama pull gemma4:e4b && ollama pull gemma4:26b && ollama pull gemma4:31b" || { echo "spark: gemma4 pull failed"; exit 1; }
 
 spark-health: ## Check DGX Spark Ollama HTTP endpoint via Tailscale
 	@curl -sf http://$(OLLAMA_SPARK_HOST):$(OLLAMA_SPARK_PORT)/api/tags >/dev/null 2>&1 && echo "spark: ready" || echo "spark: not ready (or unreachable)"


### PR DESCRIPTION
## Summary

Phase 8A-followup to #1237. Fixes two remaining artifacts that would break operator bring-up on the DGX Spark node after the Ollama tag correction.

- `pmoves/mk/nvidia-dgx-spark.mk` — `spark-gemma4-pull` would fail with `MANIFEST_UNKNOWN` on the third pull. Swap `gemma4:26b-a4b` → `gemma4:26b`.
- `pmoves/docs/operations/TOPOLOGY.md` — operator-facing pending-setup checklist referenced the broken tag.

Descriptive narrative mentions of "Gemma 4 26B-A4B" as a model architecture descriptor (26B total params, 4B active MoE) are preserved — only Ollama tag references are changed.

## Why

Lane 1 verification of #1237 discovered that the Ollama Docker Registry manifest API returns `MANIFEST_UNKNOWN` for `gemma4:26b-a4b` — the HTML library page shows quant variants that are not actually pullable. The canonical pullable tag is `gemma4:26b`.

#1237 fixed `gpu-models.yaml`, `flare-model-namespace.yaml`, `12_model_registry_seed.sql`, and `tensorzero.toml`. This PR finishes the job by fixing the two remaining operator-facing artifacts.

## Test plan

- [ ] `make -C pmoves help | grep spark-gemma4-pull` — target still listed
- [ ] Dry-run inspection: `grep -r "gemma4:26b-a4b" pmoves/ --include="*.mk" --include="*.md"` should return zero hits
- [ ] Unblocks Phase 6 fleet deploy on DGX Spark

Blocks: none (waiting on #1237 merge for consistency, but can merge in either order since they touch disjoint files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)