### PR TITLE
fix(tensorzero): repair gateway crash loop (DashScope env + multimodal_large)

### DIFF
--- a/pmoves/tensorzero/config/tensorzero.toml
+++ b/pmoves/tensorzero/config/tensorzero.toml
@@ -1079,11 +1079,15 @@ weight = 0.0
 [functions.multimodal_large]
 type = "chat"
 
-# Gemma 4 26B-A4B — local Ollama fallback (safe rollout, weight=0)
+# Gemma 4 26B-A4B — local Ollama DEFAULT route.
+# NOTE: This variant has no explicit weight, so it defaults to positive.
+# multimodal_large is a brand-new function (Phase 7); TensorZero requires at
+# least one positive-weight variant or it refuses to start the gateway.
+# 26B-A4B is the smallest local Gemma 4 option (~15GB VRAM via Q4_K_M),
+# making it the most defensible default across the fleet.
 [functions.multimodal_large.variants.gemma_4_26b_a4b]
 type = "chat_completion"
 model = "gemma_4_26b_a4b_local"
-weight = 0.0
 
 # Gemma 4 31B — local Ollama fallback (safe rollout, weight=0)
 [functions.multimodal_large.variants.gemma_4_31b]

--- a/pmoves/tensorzero/config/tensorzero.toml
+++ b/pmoves/tensorzero/config/tensorzero.toml
@@ -304,6 +304,9 @@ model_name = "qwen3-coder-next:80b"
 api_key_location = "none"
 
 # --- Qwen3-Coder 480B (Alibaba Cloud DashScope — 35B active MoE, cloud-only) ---
+# Env var: ALIBABA_PRO_CODING_PLAN is the PMOVES canonical name for this secret
+# (also used by chat_alibaba_qwen at line 209 for the same DashScope endpoint,
+# and plumbed through docker-compose.yml with a `:-local-disabled` fallback).
 [models.coding_qwen3_coder_480b_cloud]
 routing = ["alibaba_dashscope"]
 
@@ -311,7 +314,7 @@ routing = ["alibaba_dashscope"]
 type = "openai"
 api_base = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 model_name = "qwen3-coder"
-api_key_location = "env::DASHSCOPE_API_KEY"
+api_key_location = "env::ALIBABA_PRO_CODING_PLAN"
 
 # --- Gemma 3n E4B (Multimodal edge — ~3.5GB VRAM) ---
 [models.gemma_3n_e4b_local]


### PR DESCRIPTION
## Summary

Repair 2 latent TensorZero Gateway crash-loop bugs that were discovered during Phase 9 recovery. TZ gateway had been crash-looping locally (restart every ~60s), blocking all LLM routing for the platform. These two commits are minimal, targeted, and brought TZ back to `(healthy)` state.

## Bug #1 — DashScope env var alignment (commit `14838891b4`)

`coding_qwen3_coder_480b_cloud` model block (added during Phase 1 onboarding) referenced `env::DASHSCOPE_API_KEY`, but PMOVES's canonical name for this secret is `ALIBABA_PRO_CODING_PLAN`:

- `docker-compose.yml:2973` plumbs `ALIBABA_PRO_CODING_PLAN` with `:-local-disabled` fallback
- `env.shared.example:326` defines `ALIBABA_PRO_CODING_PLAN`
- `tensorzero.toml:209` (`chat_alibaba_qwen`) already uses `ALIBABA_PRO_CODING_PLAN` for the **exact same DashScope endpoint** (`dashscope-intl.aliyuncs.com`)

With `DASHSCOPE_API_KEY` unset, TensorZero refused to load the ENTIRE config:

```
ERROR: API key missing for provider OpenAI: Environment variable `DASHSCOPE_API_KEY` is missing
ERROR: models.coding_qwen3_coder_480b_cloud.providers.alibaba_dashscope
ERROR: Failed to load config
```

Fix: align the new block to the existing convention. Since both blocks point at the same API endpoint, they **must** share one API key by construction.

## Bug #2 — `multimodal_large` function needs positive-weight variant (commit `654e475c8b`)

After bug #1 was fixed, TZ crash-looped with a new error:

```
ERROR: Static weights config for function 'multimodal_large' has no candidate variants with positive weight and no fallback variants. At least one is required.
```

The `multimodal_large` function was added in Phase 7 (Gemma 4 onboarding) with **all 6 variants at `weight = 0.0`** per the PMOVES "safe rollout" convention. But this convention assumes a pre-existing positive-weight variant exists — `multimodal_large` is a brand-new function, so every variant is new, leaving TZ with no positive-weight route.

In the rest of `tensorzero.toml`, variants **without** an explicit `weight =` line default to positive (see `functions.agent_zero` lines 615-697 — the older variants have no weight at all).

Fix: Remove the explicit `weight = 0.0` from `gemma_4_26b_a4b` (local Ollama) so it defaults to positive. The other 5 variants (31b local, spark×2, rocm×2) remain at `weight = 0.0` for safe rollout. Rationale for picking 26B-A4B local:

- Smallest local Gemma 4 (~15GB VRAM via Q4_K_M), most likely to fit any Z890-class node
- Local Ollama is the most broadly-available backend (Spark + R9700 still pending hardware)
- Zero marginal cost for default routing

Added a 5-line comment block explaining why this variant has no weight line, to prevent a future maintainer from "cleaning up the inconsistency" and crash-looping TZ again.

## Discovered during

Phase 9 recovery cycle — during Phase 9C Cole Medin video ingestion, `/yt/ingest` returned a MinIO connection error. Investigating MinIO revealed it had been down 5 days, and investigating the broader container health revealed TZ was ALSO crash-looping (plus all 3 GHA runners, separate issue). This PR tackles the TZ root cause; MinIO was restored via the `make up-minio` Known Road.

## Verification

- Local TZ restart after bug #1 fix: `Restarting (1) 9 seconds ago` → surfaced bug #2
- Local TZ restart after bug #2 fix: `Up 7 seconds (healthy)` ✓
- TZ logs show clean startup — configuration loaded, ClickHouse observability enabled, no errors
- The 6 variants in `multimodal_large` still total 0 weight + 1 default — behavior matches other functions with implicit-default variants

## Out of scope

- GHA runner crash loop (separate root cause: `POST /actions/runner-registration` returning 404 — likely expired registration tokens)
- Broader compose service health sweep (18 containers down, several latent 2-week exits)
- PMOVES-supabase submodule drift (5 commits behind Hardened, surfaced by the same Phase 9 cycle — tracked separately)

## Test plan

- [x] Local TZ reaches `(healthy)` state and stays up
- [ ] CI: CodeRabbit + CodeQL + CHIT Contract Check pass
- [ ] Once merged: downstream Hi-RAG queries + LLM calls through port 3030 work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable name for Alibaba DashScope API credentials.
  * Modified model variant selection weighting for Gemma 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->