### PR TITLE
fix(ci): harden public image build workflow

### DIFF
--- a/.github/workflows/hardening-validation.yml
+++ b/.github/workflows/hardening-validation.yml
@@ -162,11 +162,11 @@ jobs:
           fi
 
   # ============================================================================
-  # Docker Security Checks (Cross-Platform)
+  # Docker Security Checks
   # ============================================================================
   docker-bench:
     name: Docker Bench Security
-    runs-on: [self-hosted, ai-lab]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
@@ -178,7 +178,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # ---- Cross-platform checks (Linux + Windows) ----
+      # ---- GitHub-hosted Linux runner checks ----
       - name: Check Docker daemon security config
         shell: bash
         run: |
@@ -252,7 +252,7 @@ jobs:
           fi
 
           echo ""
-          echo "=== Cross-Platform Checks Complete ==="
+          echo "=== Docker Security Checks Complete ==="
 
       - name: Validate compose hardening directives
         shell: bash

--- a/.github/workflows/hardening-validation.yml
+++ b/.github/workflows/hardening-validation.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run hardening validation
         id: hardening-check
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload hardening report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: hardening-report
           path: hardening-report.md
@@ -106,12 +106,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Check USER directive
         run: |
@@ -168,17 +168,15 @@ jobs:
     name: Docker Bench Security
     runs-on: [self-hosted, ai-lab]
     timeout-minutes: 15
-    env:
-      DOCKER_CONTENT_TRUST: 1
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # ---- Cross-platform checks (Linux + Windows) ----
       - name: Check Docker daemon security config
@@ -194,18 +192,25 @@ jobs:
           fi
           echo "✓ Docker daemon reachable"
 
-          # 2. Check content trust (image signing)
-          if docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -qi "content-trust"; then
-            echo "✓ Content trust enabled"
+          # 2. Check rootless/user namespace isolation posture
+          SECURITY_OPTIONS=$(docker info --format '{{json .SecurityOptions}}' 2>/dev/null || echo '[]')
+          if printf '%s' "$SECURITY_OPTIONS" | grep -qi 'name=rootless'; then
+            echo "✓ Rootless Docker enabled"
+          elif printf '%s' "$SECURITY_OPTIONS" | grep -qi 'name=userns'; then
+            echo "✓ User namespace remap enabled"
           else
-            echo "⚠ Content trust not enabled (set DOCKER_CONTENT_TRUST=1)"
+            echo "ℹ Rootless/userns-remap not detected (runner compatibility decision)"
           fi
 
-          # 3. Check default runtime
+          # 3. Image provenance policy lives in CI and deploy refs, not daemon flags
+          echo "ℹ Image signing is enforced via cosign in the GHCR publish workflow."
+          echo "ℹ Prefer digest-pinned image refs in deployment manifests when practical."
+
+          # 4. Check default runtime
           RUNTIME=$(docker info --format '{{.DefaultRuntime}}' 2>/dev/null || echo "unknown")
           echo "ℹ Default runtime: $RUNTIME"
 
-          # 4. Check live-restore (daemon resilience)
+          # 5. Check live-restore (daemon resilience)
           LIVE_RESTORE=$(docker info --format '{{.LiveRestoreEnabled}}' 2>/dev/null || echo "unknown")
           if [ "$LIVE_RESTORE" = "true" ]; then
             echo "✓ Live restore enabled"
@@ -213,7 +218,7 @@ jobs:
             echo "ℹ Live restore disabled (daemon config — not CI-fixable)"
           fi
 
-          # 5. Check no containers running as privileged
+          # 6. Check no containers running as privileged
           # Exclude BuildKit builders (always privileged by design) and CI runners
           PRIV_CONTAINERS=$(docker ps -q 2>/dev/null | xargs -r docker inspect --format '{{.Name}} {{.HostConfig.Privileged}}' 2>/dev/null | grep "true" | grep -v "buildx_buildkit_\|github-runner" || true)
           if [ -n "$PRIV_CONTAINERS" ]; then
@@ -331,12 +336,12 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Materialize compose env files from templates
         run: |
@@ -438,7 +443,7 @@ jobs:
           cat summary.md
 
       - name: Upload summary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: validation-summary
           path: summary.md

--- a/.github/workflows/integrations-ghcr.matrix.json
+++ b/.github/workflows/integrations-ghcr.matrix.json
@@ -111,7 +111,7 @@
     "name": "supaserch",
     "git_url": "https://github.com/POWERFULMOVES/PMOVES.AI.git",
     "ref": "main",
-    "context": "pmoves/services",
+    "context": "pmoves",
     "dockerfile": "pmoves/services/supaserch/Dockerfile",
     "image_name": "pmoves-supaserch",
     "build_args": "",

--- a/.github/workflows/integrations-ghcr.yml
+++ b/.github/workflows/integrations-ghcr.yml
@@ -122,7 +122,7 @@ jobs:
       names: ${{ steps.resolve.outputs.names }}
     steps:
       - name: Checkout (matrix config)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Resolve integration matrix
         id: resolve
@@ -157,9 +157,122 @@ jobs:
           print(f"Resolved {len(names)} integration lane(s) (target={target})")
           PY
 
+  build-validate-pr:
+    name: Validate ${{ matrix.name }} (PR)
+    needs: resolve-matrix
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        name: ${{ fromJSON(needs.resolve-matrix.outputs.names) }}
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df
+        with:
+          egress-policy: audit
+
+      - name: Checkout (stub)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Load integration config
+        id: cfg
+        run: |
+          set -euo pipefail
+          pybin="$(command -v python3 || command -v python || true)"
+          if [ -z "$pybin" ]; then
+            echo "::error::python3/python is required on runner for matrix config resolution."
+            exit 1
+          fi
+          "$pybin" - <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+          import uuid
+
+          name = os.environ["MATRIX_NAME"]
+          matrix_path = pathlib.Path(".github/workflows/integrations-ghcr.matrix.json")
+          entries = json.loads(matrix_path.read_text(encoding="utf-8"))
+          match = next((entry for entry in entries if entry.get("name") == name), None)
+          if not match:
+              print(f"::error::No config found for integration '{name}'", file=sys.stderr)
+              sys.exit(1)
+
+          output = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as fh:
+              for key, value in match.items():
+                  if value is None:
+                      value = ""
+                  if isinstance(value, bool):
+                      fh.write(f"{key}={'true' if value else 'false'}\n")
+                  else:
+                      text = str(value)
+                      if "\n" in text:
+                          delim = f"EOF_{key}_{uuid.uuid4().hex}"
+                          fh.write(f"{key}<<{delim}\n{text}\n{delim}\n")
+                      else:
+                          fh.write(f"{key}={text}\n")
+          PY
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
+
+      - name: Prepare integration source
+        run: |
+          set -euo pipefail
+          cfg_url='${{ steps.cfg.outputs.git_url }}'
+          cfg_ref='${{ steps.cfg.outputs.ref }}'
+          case "$cfg_url" in
+            https://github.com/*) ;;
+            *)
+              echo "::error::Unsupported git_url '$cfg_url' (only https://github.com/* is allowed)."
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$cfg_ref" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "::error::Unsupported git ref '$cfg_ref'."
+            exit 1
+          fi
+
+          if [ "$cfg_url" = "https://github.com/POWERFULMOVES/PMOVES.AI.git" ]; then
+            echo "Using checked-out PMOVES.AI workspace as integration source"
+            rm -rf integration-src
+            mkdir -p integration-src
+            git archive --format=tar HEAD | tar -x -C integration-src
+          else
+            git clone --depth=1 --branch "$cfg_ref" "$cfg_url" integration-src
+          fi
+
+      - name: Free disk space (runner)
+        run: |
+          set -euxo pipefail
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android || true
+          sudo rm -rf /usr/local/share/boost || true
+          df -h
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Build (PR validation, no push)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: integration-src/${{ steps.cfg.outputs.context }}
+          file: integration-src/${{ steps.cfg.outputs.dockerfile }}
+          push: false
+          build-args: |
+            PIP_CONSTRAINT=requirements.lock
+            ${{ steps.cfg.outputs.build_args }}
+          platforms: linux/amd64
+
   build-publish:
     name: Build ${{ matrix.name }}
     needs: resolve-matrix
+    if: ${{ github.event_name != 'pull_request' }}
     # Distribute across all available self-hosted Linux runners for parallel builds.
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 60
@@ -176,7 +289,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df
         with:
           egress-policy: audit
           allowed-endpoints: >
@@ -192,7 +305,7 @@ jobs:
             security.ubuntu.com:443
 
       - name: Checkout (stub)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Load integration config
         id: cfg
@@ -238,7 +351,7 @@ jobs:
       - name: Generate GitHub App token (for clone + GHCR)
         id: app_token
         continue-on-error: true
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_SEC }}
@@ -292,19 +405,19 @@ jobs:
           df -h
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
 
       - name: Log in to GHCR (App token preferred)
         id: login_ghcr_app
         if: ${{ steps.app_token.outputs.token != '' }}
         continue-on-error: true
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ${{ env.REGISTRY }}
           username: x-access-token
@@ -314,7 +427,7 @@ jobs:
         id: login_ghcr_pat
         if: ${{ steps.login_ghcr_app.outcome != 'success' && env.GHCR_USERNAME != '' && env.GHCR_PAT != '' }}
         continue-on-error: true
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.GHCR_USERNAME }}
@@ -324,7 +437,7 @@ jobs:
         id: login_ghcr_actions
         if: ${{ steps.login_ghcr_app.outcome != 'success' && steps.login_ghcr_pat.outcome != 'success' }}
         continue-on-error: true
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -337,8 +450,8 @@ jobs:
           exit 1
 
       - name: Optional login to Docker Hub
-        if: ${{ github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
-        uses: docker/login-action@v4
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_PASSWORD }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: docker.io
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -357,16 +470,6 @@ jobs:
           OWNER_LC="${{ github.repository_owner }}"
           OWNER_LC="${OWNER_LC,,}"
           echo "ghcr_ns=${OWNER_LC}" >> $GITHUB_OUTPUT
-
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "use_ghcr=false" >> $GITHUB_OUTPUT
-            echo "has_tags=false" >> $GITHUB_OUTPUT
-            echo "tags<<EOF" >> $GITHUB_OUTPUT
-            echo "" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-            echo "::notice::Pull request build detected; registry publish/sign/scan steps are skipped."
-            exit 0
-          fi
 
           DATE_TAG=$(date +%Y%m%d)
           SHA_SHORT=${GITHUB_SHA::7}
@@ -416,29 +519,14 @@ jobs:
           echo -e "$TAGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      # PRs validate Dockerfile/build correctness without publishing artifacts.
-      # Build native amd64 only — skip arm64 QEMU emulation to cut PR time ~50%.
-      - name: Build (PR validation, no push)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@v7
-        with:
-          context: integration-src/${{ steps.cfg.outputs.context }}
-          file: integration-src/${{ steps.cfg.outputs.dockerfile }}
-          push: false
-          build-args: |
-            PIP_CONSTRAINT=requirements.lock
-            ${{ steps.cfg.outputs.build_args }}
-          platforms: linux/amd64
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ steps.meta.outputs.ghcr_ns }}/${{ steps.cfg.outputs.image_name }}:buildcache
-
       - name: Build and push (multi-arch)
-        if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.has_tags == 'true' }}
+        if: ${{ steps.meta.outputs.has_tags == 'true' }}
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: integration-src/${{ steps.cfg.outputs.context }}
           file: integration-src/${{ steps.cfg.outputs.dockerfile }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           build-args: |
             PIP_CONSTRAINT=requirements.lock
             ${{ steps.cfg.outputs.build_args }}
@@ -448,7 +536,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ steps.meta.outputs.ghcr_ns }}/${{ steps.cfg.outputs.image_name }}:buildcache,mode=max
 
       - name: Cosign sign GHCR digest (keyless)
-        if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.has_tags == 'true' && steps.meta.outputs.use_ghcr == 'true' }}
+        if: ${{ steps.meta.outputs.has_tags == 'true' && steps.meta.outputs.use_ghcr == 'true' }}
         env:
           IMAGE_DIGEST_REF: ${{ env.REGISTRY }}/${{ steps.meta.outputs.ghcr_ns }}/${{ steps.cfg.outputs.image_name }}@${{ steps.build.outputs.digest }}
           COSIGN_EXPERIMENTAL: "1"
@@ -457,20 +545,20 @@ jobs:
           cosign sign --yes "$IMAGE_DIGEST_REF"
 
       - name: Install Syft (SBOM)
-        if: ${{ github.event_name != 'pull_request' && steps.cfg.outputs.generate_sbom == 'true' && steps.meta.outputs.has_tags == 'true' }}
-        uses: anchore/sbom-action/download-syft@v0.24.0
+        if: ${{ steps.cfg.outputs.generate_sbom == 'true' && steps.meta.outputs.has_tags == 'true' }}
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
 
       - name: Generate SBOMs (CycloneDX)
         id: sbom
-        if: ${{ github.event_name != 'pull_request' && steps.cfg.outputs.generate_sbom == 'true' && steps.meta.outputs.has_tags == 'true' }}
+        if: ${{ steps.cfg.outputs.generate_sbom == 'true' && steps.meta.outputs.has_tags == 'true' }}
         run: |
           set -euo pipefail
           syft packages "${{ steps.meta.outputs.primary_tag }}" -o cyclonedx-json > sbom.cdx.json
           echo "sbom_path=sbom.cdx.json" >> $GITHUB_OUTPUT
 
       - name: Upload SBOM artifact
-        if: ${{ github.event_name != 'pull_request' && steps.cfg.outputs.generate_sbom == 'true' && steps.meta.outputs.has_tags == 'true' }}
-        uses: actions/upload-artifact@v7
+        if: ${{ steps.cfg.outputs.generate_sbom == 'true' && steps.meta.outputs.has_tags == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ matrix.name }}-sbom
           path: ${{ steps.sbom.outputs.sbom_path }}
@@ -486,14 +574,14 @@ jobs:
           df -h
 
       - name: Pull image for Trivy (private GHCR)
-        if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.has_tags == 'true' }}
+        if: ${{ steps.meta.outputs.has_tags == 'true' }}
         run: |
           set -euo pipefail
           docker pull "${{ steps.meta.outputs.primary_tag }}"
 
       - name: Trivy vulnerability scan (HIGH/CRITICAL)
-        if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.has_tags == 'true' }}
-        uses: aquasecurity/trivy-action@0.35.0
+        if: ${{ steps.meta.outputs.has_tags == 'true' }}
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           # Gate on HIGH/CRITICAL with fixes available (vendor/unfixed CVEs are still surfaced by the next step).
           # This avoids blocking nightly builds on upstream issues we can't remediate immediately, while keeping
@@ -509,8 +597,8 @@ jobs:
           timeout: '10m0s'
 
       - name: Trivy vulnerability scan report (includes unfixed)
-        if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.has_tags == 'true' }}
-        uses: aquasecurity/trivy-action@0.35.0
+        if: ${{ steps.meta.outputs.has_tags == 'true' }}
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: ${{ steps.meta.outputs.primary_tag }}
           format: table
@@ -525,14 +613,14 @@ jobs:
           timeout: '10m0s'
 
       - name: Upload Trivy report artifact
-        if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.has_tags == 'true' }}
-        uses: actions/upload-artifact@v7
+        if: ${{ steps.meta.outputs.has_tags == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ matrix.name }}-trivy
           path: trivy-${{ matrix.name }}.txt
 
       - name: Cosign verify GHCR digest (keyless)
-        if: ${{ github.event_name != 'pull_request' && steps.meta.outputs.has_tags == 'true' && steps.meta.outputs.use_ghcr == 'true' }}
+        if: ${{ steps.meta.outputs.has_tags == 'true' && steps.meta.outputs.use_ghcr == 'true' }}
         env:
           IMAGE_DIGEST_REF: ${{ env.REGISTRY }}/${{ steps.meta.outputs.ghcr_ns }}/${{ steps.cfg.outputs.image_name }}@${{ steps.build.outputs.digest }}
           COSIGN_EXPERIMENTAL: "1"

--- a/pmoves/docs/operations/DOCKER_DAEMON_HARDENING.md
+++ b/pmoves/docs/operations/DOCKER_DAEMON_HARDENING.md
@@ -3,40 +3,54 @@
 Operational recommendations for Docker daemon configuration on PMOVES.AI hosts.
 These settings are daemon-level and cannot be enforced by CI — they require host admin action.
 
-## Content Trust (Image Signing)
+## Image Provenance And Hardened Bases
 
-**CIS Benchmark:** 4.5 — "Enable Content trust for Docker"
+Docker Content Trust is no longer the primary recommendation for PMOVES images.
+Use immutable image digests plus Sigstore/cosign verification for PMOVES-built images,
+and prefer Docker Hardened Images or similarly minimized bases for runtime workloads.
 
-Content trust ensures that only signed images are pulled from registries.
+### Recommended Baseline
 
-### Enable Globally
+- Pin production image references by digest where operationally practical:
+  `image@sha256:...`
+- Verify PMOVES-built images with Sigstore/cosign before promotion.
+- Keep builder and runtime stages separate so compilers and package managers do not
+  ship in the final runtime image.
+- Prefer hardened/minimal runtime bases and non-root users.
 
-Add to `/etc/docker/daemon.json` (Linux) or Docker Desktop settings:
+### PMOVES CI Coverage
 
-```json
-{
-  "content-trust": {
-    "mode": "enforce"
-  }
-}
-```
+The `integrations-ghcr.yml` workflow signs GHCR-published images with cosign and
+verifies the resulting digest after push. This is the repo's primary provenance
+control for PMOVES-built images.
 
-Or set the environment variable for all Docker CLI sessions:
+### Hardened Images And Packages
 
-```bash
-# Add to /etc/environment or shell profile
-export DOCKER_CONTENT_TRUST=1
-```
+When adopting Docker Hardened Images:
 
-### CI Coverage
+- Pin the hardened base image by digest, not tag.
+- Align package installation with the hardened base's documented package manager.
+  For current Docker Hardened Images guidance, that means following the base-specific
+  flow rather than assuming Debian/Ubuntu `apt` semantics will carry over.
+- Treat hardened-package adoption as an image-by-image migration so builds stay
+  reproducible and scanners keep clean signal.
 
-The `hardening-validation.yml` workflow sets `DOCKER_CONTENT_TRUST=1` at the
-job level for the Docker Bench job. This ensures CI itself practices content
-trust during image pulls.
+### Legacy Note
 
-**Note:** SHA-pinned images (`image@sha256:...`) bypass content trust entirely —
-they are already verified by digest, which is a stronger guarantee than signature
-verification alone.
+Docker's Content Trust documentation is still useful historical context, but it is
+not the forward-looking control PMOVES should optimize around. Prefer digest pinning,
+cosign signatures, and registry attestations instead.
+
+## Self-Hosted GitHub Actions Runners
+
+For this repo's public PR surface:
+
+- Run untrusted pull request image validation on GitHub-hosted runners.
+- Reserve self-hosted runners for trusted `push` and `workflow_dispatch` paths.
+- Prefer dedicated runner labels/groups for image builds over broad generic
+  self-hosted pools.
+- Use ephemeral runners where feasible; otherwise schedule aggressive image/container
+  cleanup and review daemon exposure regularly.
 
 ## Live Restore
 
@@ -106,5 +120,8 @@ docker system prune -f --filter "until=72h"
 
 - [CIS Docker Benchmark v2.0.0](https://www.cisecurity.org/benchmark/docker)
 - [Docker Content Trust documentation](https://docs.docker.com/engine/security/trust/)
+- [Docker Hardened Images: image digests](https://docs.docker.com/dhi/core-concepts/digests/)
+- [Docker Hardened Images: code signing](https://docs.docker.com/dhi/core-concepts/signatures/)
+- [Docker Hardened Images: hardened packages](https://docs.docker.com/dhi/how-to/hardened-packages/)
 - [Docker Live Restore](https://docs.docker.com/engine/containers/live-restore/)
 - PMOVES.AI Known Roads: `make -C pmoves docker-prune` / `make -C pmoves docker-prune-all`

--- a/pmoves/services/agent-zero/requirements.lock
+++ b/pmoves/services/agent-zero/requirements.lock
@@ -3485,9 +3485,9 @@ primp==0.15.0 \
     --hash=sha256:c18b45c23f94016215f62d2334552224236217aaeb716871ce0e4dcfa08eb161 \
     --hash=sha256:e985a9cba2e3f96a323722e5440aa9eccaac3178e74b884778e926b5249df080
     # via duckduckgo-search
-prometheus-client==0.24.1 \
-    --hash=sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055 \
-    --hash=sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9
+prometheus-client==0.25.0 \
+    --hash=sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28 \
+    --hash=sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1
     # via
     #   opentelemetry-exporter-prometheus
     #   pydocket


### PR DESCRIPTION
## Summary
- move public PR image validation for `integrations-ghcr.yml` onto GitHub-hosted runners
- keep privileged publish/sign/push steps on trusted self-hosted push and manual runs only
- pin third-party actions by full commit SHA in the touched workflows and refresh Docker hardening guidance away from Docker Content Trust toward digest + cosign provenance

## Why
The repo is public, and the previous GHCR workflow combined `pull_request` handling with generic self-hosted runners plus publish-oriented permissions and auth setup. This splits the trust boundary so untrusted PR builds stay read-only and GitHub-hosted.

## Validation
- `git diff --check`
- YAML parse check for `.github/workflows/integrations-ghcr.yml`
- YAML parse check for `.github/workflows/hardening-validation.yml`

## Notes
- I reviewed open PRs before cutting this lane; none of the live open PRs owned `integrations-ghcr.yml`, `DOCKER_DAEMON_HARDENING.md`, or `Dockerfile.multiarch`, so this is intentionally a dedicated follow-up.
- I did not fold the deeper Dockerfile hardened-base migration into this PR. That should stay a separate image-by-image lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker daemon hardening guidance to emphasize digest-based image pinning and Sigstore verification over legacy content trust methods.
  * Added best practices for runner configuration and security across CI environments.

* **Chores**
  * Enhanced CI/CD pipeline security through stricter action dependency pinning.
  * Improved Docker build validation and automated image signing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->