### PR TITLE
fix(vector): add --config flag so Vector loads mounted YAML config

### DIFF
--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -1051,6 +1051,7 @@ services:
   supabase-vector:
     <<: *tier-supabase-hardened
     image: timberio/vector:0.28.1-alpine
+    command: ["--config", "/etc/vector/vector.yml"]
     restart: unless-stopped
     profiles:
     - supabase-local


### PR DESCRIPTION
## Summary
- Adds `command: ["--config", "/etc/vector/vector.yml"]` to `supabase-vector` service
- Vector 0.28.1 defaults to `/etc/vector/vector.toml` but we mount `vector.yml` — without this flag, Vector ignores our config and falls back to its built-in demo

## Context
Discovered during substrate repair session (mirror agent). The container starts without errors but emits "We're gonna need a bigger boat" fixture messages instead of processing actual logs. The YAML config (260+ lines from PMOVES-supabase) was never being loaded.

**Note:** `docker-compose.core.yml` (overlay) also needs this line but is protected by damage-control hook. Will be picked up when overlays are regenerated from the monolith via `split_compose.py`.

## Test plan
- [ ] `make -C pmoves up-supabase` — Vector container starts with custom config
- [ ] `docker logs supabase-vector` shows actual log sources, not demo fixture messages
- [ ] Vector API (`http://localhost:9001/health`) returns healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)