### PR TITLE
fix(services/common): use relative imports to fix absolute-path regressions (Phase 9M, supersedes #1250)

### DIFF
--- a/pmoves/services/common/config.py
+++ b/pmoves/services/common/config.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     from pydantic import BaseSettings  # type: ignore[no-redef]
 
-from services.common.env import get_secret
+from .env import get_secret
 
 
 def env_bool(name: str, default: bool = False) -> bool:

--- a/pmoves/services/common/nats_service_listener.py
+++ b/pmoves/services/common/nats_service_listener.py
@@ -44,7 +44,7 @@ import nats
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 
-from services.common.service_registry import (
+from .service_registry import (
     ServiceAnnouncement,
     ServiceInfo,
     ServiceTier,

--- a/pmoves/services/common/port_resolver.py
+++ b/pmoves/services/common/port_resolver.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     DEFAULT_PORTS = {}
 
-from services.common.topology import TopologyContext, TopologyMode, get_topology
+from .topology import TopologyContext, TopologyMode, get_topology
 
 
 # Docker DNS names for services (slug → container hostname)


### PR DESCRIPTION
## Summary

Phase 9M (2026-04-15): one-line-per-file fix for three absolute-path imports that were introduced by the P4 common-module extraction (PR #1225). These only resolve when `pmoves/services/` is in `sys.path` as a top-level `services` package — which is true inside service containers after `bootstrap_import_paths()` runs, but NOT when the module is loaded as `pmoves.services.common.X` from host Python (`brand_defaults.py`, `ensure_env_shared.py`, etc.) or in full-venv contexts where other P4 deps already imported successfully.

## Relationship to PR #1250 and commit 872bae0459

The bot commit `872bae0459` (`fix(common): guard all P4 module imports in __init__.py for CI environments`, merged earlier today) added a broad `try/except ImportError` wrapper around the entire P4 import block in `pmoves/services/common/__init__.py`. That masks this bug in CI-only venvs where nats-py/fastapi/structlog are missing (the whole block fails silently so `config.py` is never loaded and its bad absolute import never fires), BUT in a full-venv service container the other imports succeed, `config.py` loads, hits `from services.common.env import get_secret`, and crashes.

**PR #1250** (`fix(common): wrap P4 imports in try/except for CLI-only venvs`, currently CONFLICTING on origin/main) tried to fix the same thing by wrapping individual P4 imports in try/except instead of fixing the actual absolute-path bug. It was landed-to-main via the bot commit's different code path, and is now effectively obsolete.

**This PR** fixes the root cause: switch to relative imports. The rest of `services/common/` (telemetry.py, geometry_models.py, model_nexus.py, bootstrap.py) already uses `from .X import Y` — these three were the drift.

**Recommendation:** close PR #1250 as superseded after this lands. The broad try/except block that the bot commit added can be simplified to per-import try/except (or removed entirely) in a follow-up — once `config.py`'s bad import is fixed, nothing inside the P4 block should actually raise `ImportError` that isn't a real missing dependency.

## Files (3 × 1 line)

| File | Before | After |
|------|--------|-------|
| `pmoves/services/common/config.py:27` | `from services.common.env import get_secret` | `from .env import get_secret` |
| `pmoves/services/common/port_resolver.py:27` | `from services.common.topology import TopologyContext, TopologyMode, get_topology` | `from .topology import TopologyContext, TopologyMode, get_topology` |
| `pmoves/services/common/nats_service_listener.py:47` | `from services.common.service_registry import (...)` | `from .service_registry import (...)` |

## Test Plan

- [ ] `python -c \"from pmoves.services.common.config import env_bool\"` — succeeds in a full-venv context (previously raised `ModuleNotFoundError: No module named 'services'`)
- [ ] `make -C pmoves env-setup` — still works in CLI-only venvs (relative imports don't depend on sys.path tricks)
- [ ] `make -C pmoves up-supabase` — still works (was the original canary target)
- [ ] `cd pmoves && uv run pytest tests/` — full pytest suite on 3.11 still passes
- [ ] Service containers that depend on `services.common.config`, `services.common.port_resolver`, `services.common.nats_service_listener` still start cleanly (bootstrap_import_paths still adds `pmoves/services/` to sys.path for the public-import path, relative imports don't conflict with that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->