### PR TITLE
fix(k8s): scope allow-ingress policy to pmoves-core pods

### DIFF
--- a/deploy/k8s/networkpolicies/allow-ingress.yaml
+++ b/deploy/k8s/networkpolicies/allow-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/part-of: pmoves-ai
+      app.kubernetes.io/name: pmoves-core
   policyTypes:
     - Ingress
   ingress:


### PR DESCRIPTION
## Summary
- extract the one safe follow-up from the merged `feat/rec11-13-k8s-tests-async` stash
- target the `allow-ingress` NetworkPolicy at `pmoves-core` pods instead of every pod in `pmoves-ai`
- keep the change atomic so it can merge independently of the stale test/mock leftovers in that stash

## Validation
- `git diff --check`
- confirmed `deploy/k8s/base/pmoves-core-deployment.yaml` labels pods with `app.kubernetes.io/name: pmoves-core`
