### PR TITLE
feat(pmoves-yt): Tailscale egress sidecar for YouTube 403 bypass (Phase 9Q)

### DIFF
--- a/.claude/context/runner-topology.md
+++ b/.claude/context/runner-topology.md
@@ -8,10 +8,19 @@
 |------|------|-------------|--------|
 | **Z890** | Dev + GPU (3090Ti) | All (local Docker Compose) | `self-hosted, ai-lab, gpu, cuda` |
 | **5090** | Primary GPU (pending) | Future inference | (pending) |
-| **KVM4-1** | API Gateway | TensorZero, Agent Zero, Hi-RAG, Archon, Gateway Agent | `self-hosted, vps, kvm4, production` |
+| **KVM4-1** | API Gateway + Tailscale Egress Exit Node (Phase 9Q) | TensorZero, Agent Zero, Hi-RAG, Archon, Gateway Agent; outbound exit for `pmoves-yt` stack | `self-hosted, vps, kvm4, production` |
 | **KVM4-2** | Data/Storage | Supabase, NATS, Qdrant, Neo4j, Meilisearch, MinIO, monitoring | `self-hosted, vps, kvm4, production` |
-| **KVM2** | Exit Node | nginx (SSL termination) | `self-hosted, vps, kvm2, backup` |
+| **KVM2** | Reverse Proxy / RustDesk Relay | nginx (SSL termination), RustDesk hbbs/hbbr | `self-hosted, vps, kvm2, backup` |
 | **Cloudflare** | Edge | DNS, CI Worker | — |
+
+**Phase 9Q — YT egress routing (2026-04-16, PR #1262):** `pmoves-yt`,
+`bgutil-pot-provider`, `invidious-companion`, and `invidious` route all
+outbound HTTP/HTTPS through a Tailscale sidecar (`tailscale-yt-egress`)
+configured with `--exit-node=pmoves-kvm4-1`. See
+`pmoves/docs/operations/YT_EGRESS_RUNBOOK.md` for activation/rollback.
+The egress path is transparent to event consumers — no new NATS subjects
+are introduced. See `.claude/context/nats-subjects.md` for the subject
+catalog; `ingest.*.v1` flows through normally when egress is active.
 
 ## Route: Public → Services
 

--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -961,6 +961,9 @@ chitSafePaths:
   - "pr-kits"
   # Context docs that need fleet/config renames (approved per issue #1173)
   - ".claude/context/nats-subjects.md"
+  # Runner topology context — mirror surface for fleet role changes
+  # (Phase 9Q, 2026-04-16: KVM4-1 role expansion for YT egress — PR #1262)
+  - ".claude/context/runner-topology.md"
 
 # ---------------------------------------------------------------------------
 # PMOVES.AI - GIT SUBMODULES

--- a/.claude/hooks/damage-control/patterns.yaml
+++ b/.claude/hooks/damage-control/patterns.yaml
@@ -952,6 +952,11 @@ chitSafePaths:
   # (Phase 9P, 2026-04-16: SQL schema for Invidious DB + init-invidious-db.sh)
   - "pmoves/services/invidious/"
   - "services/invidious/"
+  # YT egress compose — Tailscale sidecar routing YT-facing services through
+  # KVM4-1 exit node (Phase 9Q, 2026-04-16: YouTube residential-IP 403 bypass)
+  - "docker-compose.yt-egress"
+  # YT egress Make target lib
+  - "mk/egress.mk"
   # PR-kit compose files — integration starter templates
   - "pr-kits"
   # Context docs that need fleet/config renames (approved per issue #1173)

--- a/pmoves/Makefile
+++ b/pmoves/Makefile
@@ -159,6 +159,7 @@ include mk/nvidia-dgx-spark.mk
 include mk/amd-rdna4.mk
 include mk/hf.mk
 include mk/provider.mk
+include mk/egress.mk
 
 .PHONY: update-service-docs
 update-service-docs: ## Regenerate service update notes from git metadata

--- a/pmoves/docker-compose.yt-egress.yml
+++ b/pmoves/docker-compose.yt-egress.yml
@@ -1,0 +1,118 @@
+# docker-compose.yt-egress.yml — PMOVES.YT outbound via Tailscale exit node
+# ============================================================================
+# Phase 9Q (2026-04-16)
+#
+# Purpose
+# -------
+# Routes all YouTube-facing services (pmoves-yt, bgutil-pot-provider,
+# invidious-companion, invidious) through the KVM4-1 Tailscale exit node
+# (31.97.42.207, Hostinger datacenter) to bypass YouTube's residential-IP
+# anti-bot 403s. Home residential fingerprints are invisible to YouTube once
+# every yt-dlp request + PO token fetch + companion stream resolves through
+# the datacenter IP.
+#
+# KVM4-1 was approved as a Tailscale exit node on 2026-04-12 by 4090-CLAUDE
+# (see pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md:475). Earlier scripts in
+# deploy/provision/kvm2-exit-node.sh target KVM2 and are superseded by the
+# KVM4-1 setup.
+#
+# Usage
+# -----
+#   make -C pmoves up-yt-egress       # Activate sidecar, restart YT stack through proxy
+#   make -C pmoves yt-egress-verify   # Compare host IP vs container egress IP
+#   make -C pmoves down-yt-egress     # Stop sidecar, YT reverts to residential IP
+#
+# Architecture
+# ------------
+# The sidecar runs tailscale/tailscale:latest in userspace mode (no TUN
+# device needed) with TS_EXTRA_ARGS=--exit-node=pmoves-kvm4-1. Tailscale
+# exposes two proxy listeners inside the pmoves_app network:
+#   - SOCKS5 on :1055 (for clients that prefer SOCKS5)
+#   - HTTP CONNECT on :1080 (used by yt-dlp/urllib via HTTP_PROXY env)
+#
+# The four service overrides below set HTTP_PROXY/HTTPS_PROXY to the
+# sidecar's HTTP listener. yt-dlp auto-respects these via Python urllib, so
+# no submodule code change is required. Internal Docker DNS targets
+# (minio, nats, supabase, etc.) are listed in NO_PROXY so internal traffic
+# stays on pmoves_app.
+
+services:
+  tailscale-yt-egress:
+    image: tailscale/tailscale:latest
+    container_name: pmoves-tailscale-yt-egress
+    hostname: pmoves-yt-egress
+    restart: unless-stopped
+    environment:
+      - TS_AUTHKEY=${TAILSCALE_AUTHKEY}
+      - TS_USERSPACE=true
+      - TS_HOSTNAME=pmoves-yt-egress
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_ACCEPT_DNS=true
+      # Route all outbound through KVM4-1. --exit-node-allow-lan-access lets
+      # the sidecar still reach pmoves_app services directly (otherwise all
+      # traffic would tunnel, including internal DNS).
+      - TS_EXTRA_ARGS=--exit-node=pmoves-kvm4-1 --exit-node-allow-lan-access
+      # SOCKS5 + HTTP CONNECT proxy listeners (both bound to 0.0.0.0 so peers
+      # on pmoves_app can reach them).
+      - TS_SOCKS5_SERVER=0.0.0.0:1055
+      - TS_OUTBOUND_HTTP_PROXY_LISTEN=0.0.0.0:1080
+    volumes:
+      - tailscale-yt-egress-state:/var/lib/tailscale
+    networks:
+      - pmoves_app
+    cap_add:
+      - NET_ADMIN  # required for userspace proxy listeners
+    healthcheck:
+      test: ["CMD", "tailscale", "status", "--peers=false"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+
+  # --- Service overrides --------------------------------------------------
+  # Each override only sets the proxy env vars + depends_on for ordering.
+  # The rest of the service definition stays in docker-compose.yml.
+
+  pmoves-yt:
+    environment:
+      - HTTP_PROXY=http://tailscale-yt-egress:1080
+      - HTTPS_PROXY=http://tailscale-yt-egress:1080
+      - NO_PROXY=localhost,127.0.0.1,minio,nats,supabase-kong,supabase-postgrest,invidious,invidious-companion,invidious-db,channel-monitor,hi-rag-gateway-v2,bgutil-pot-provider,ffmpeg-whisper,extract-worker,tailscale-yt-egress
+    depends_on:
+      tailscale-yt-egress:
+        condition: service_healthy
+
+  bgutil-pot-provider:
+    environment:
+      - HTTP_PROXY=http://tailscale-yt-egress:1080
+      - HTTPS_PROXY=http://tailscale-yt-egress:1080
+      - NO_PROXY=localhost,127.0.0.1,minio,nats,tailscale-yt-egress
+    depends_on:
+      tailscale-yt-egress:
+        condition: service_healthy
+
+  invidious-companion:
+    environment:
+      - HTTP_PROXY=http://tailscale-yt-egress:1080
+      - HTTPS_PROXY=http://tailscale-yt-egress:1080
+      - NO_PROXY=localhost,127.0.0.1,invidious,invidious-db,tailscale-yt-egress
+    depends_on:
+      tailscale-yt-egress:
+        condition: service_healthy
+
+  invidious:
+    environment:
+      - HTTP_PROXY=http://tailscale-yt-egress:1080
+      - HTTPS_PROXY=http://tailscale-yt-egress:1080
+      - NO_PROXY=localhost,127.0.0.1,invidious-db,invidious-companion,tailscale-yt-egress
+    depends_on:
+      tailscale-yt-egress:
+        condition: service_healthy
+
+volumes:
+  tailscale-yt-egress-state:

--- a/pmoves/docker-compose.yt-egress.yml
+++ b/pmoves/docker-compose.yt-egress.yml
@@ -6,15 +6,15 @@
 # -------
 # Routes all YouTube-facing services (pmoves-yt, bgutil-pot-provider,
 # invidious-companion, invidious) through the KVM4-1 Tailscale exit node
-# (31.97.42.207, Hostinger datacenter) to bypass YouTube's residential-IP
+# (pmoves-kvm4-1, Hostinger datacenter) to bypass YouTube's residential-IP
 # anti-bot 403s. Home residential fingerprints are invisible to YouTube once
 # every yt-dlp request + PO token fetch + companion stream resolves through
-# the datacenter IP.
+# the datacenter egress.
 #
 # KVM4-1 was approved as a Tailscale exit node on 2026-04-12 by 4090-CLAUDE
-# (see pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md:475). Earlier scripts in
-# deploy/provision/kvm2-exit-node.sh target KVM2 and are superseded by the
-# KVM4-1 setup.
+# (see pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md, 2026-04-12 RELEASE entry).
+# Earlier scripts in deploy/provision/kvm2-exit-node.sh target KVM2 and are
+# superseded by the KVM4-1 setup.
 #
 # Usage
 # -----
@@ -43,7 +43,11 @@ services:
     hostname: pmoves-yt-egress
     restart: unless-stopped
     environment:
-      - TS_AUTHKEY=${TAILSCALE_AUTHKEY}
+      # Fail at compose parse time if TAILSCALE_AUTHKEY is unset — the
+      # userspace Tailscale container silently fails to join the tailnet
+      # with an empty authkey, which leaves the proxy listening but with
+      # no actual exit-node tunnel. This guard forces the error upstream.
+      - TS_AUTHKEY=${TAILSCALE_AUTHKEY:?TAILSCALE_AUTHKEY must be set for yt-egress (run make -C pmoves secrets-funnel)}
       - TS_USERSPACE=true
       - TS_HOSTNAME=pmoves-yt-egress
       - TS_STATE_DIR=/var/lib/tailscale

--- a/pmoves/docs/operations/TOPOLOGY.md
+++ b/pmoves/docs/operations/TOPOLOGY.md
@@ -17,7 +17,7 @@
 | R9700 Workstation (Linux) | LAN | `ts:<rdna4>` | pmoves-rdna4 | Heavyweight ROCm Inference (Gemma 4 31B/26B-A4B via llama.cpp) | `self-hosted, ai-lab, gpu, rocm, rdna4` (pending) | 9850X3D / 32GB + 2x R9700 (64GB VRAM total) | electricity |
 | Jetson Orin #1 | LAN (RustDesk + SSH) | `ts:<nano>` | pmoves-nano (rename to pmoves-nano-1 pending) | Edge Inference (Nemotron/NemoClaw), Claws | — | Orin (sm_87) | electricity |
 | Jetson Orin #2 | LAN (RustDesk + SSH) | TBD | TBD | Edge Inference (Nemotron/NemoClaw), Claws | — | Orin (sm_87) | electricity |
-| KVM4-1 | — | 31.97.42.207 | pmoves-kvm4-1 | API Gateway + Tailscale Egress Exit Node (Phase 9Q) | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
+| KVM4-1 | — | `ts:<kvm4-1>` | pmoves-kvm4-1 | API Gateway + Tailscale Egress Exit Node (Phase 9Q) | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
 | KVM4-2 | — | — | pmoves-kvm4-2 | Data / Storage | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
 | KVM2 | — | — | pmoves-kvm2 | Reverse Proxy (nginx SSL) / RustDesk Relay | `self-hosted, vps, kvm2, backup` | 4C / 8GB | $10/mo |
 | Cloudflare Edge | — | — | — | DNS, Worker routing | — | Edge | Free plan |

--- a/pmoves/docs/operations/TOPOLOGY.md
+++ b/pmoves/docs/operations/TOPOLOGY.md
@@ -17,9 +17,9 @@
 | R9700 Workstation (Linux) | LAN | `ts:<rdna4>` | pmoves-rdna4 | Heavyweight ROCm Inference (Gemma 4 31B/26B-A4B via llama.cpp) | `self-hosted, ai-lab, gpu, rocm, rdna4` (pending) | 9850X3D / 32GB + 2x R9700 (64GB VRAM total) | electricity |
 | Jetson Orin #1 | LAN (RustDesk + SSH) | `ts:<nano>` | pmoves-nano (rename to pmoves-nano-1 pending) | Edge Inference (Nemotron/NemoClaw), Claws | — | Orin (sm_87) | electricity |
 | Jetson Orin #2 | LAN (RustDesk + SSH) | TBD | TBD | Edge Inference (Nemotron/NemoClaw), Claws | — | Orin (sm_87) | electricity |
-| KVM4-1 | — | — | pmoves-kvm4-1 | API Gateway | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
+| KVM4-1 | — | 31.97.42.207 | pmoves-kvm4-1 | API Gateway + Tailscale Egress Exit Node (Phase 9Q) | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
 | KVM4-2 | — | — | pmoves-kvm4-2 | Data / Storage | `self-hosted, vps, kvm4, production` | 8C / 16GB | $10/mo |
-| KVM2 | — | — | pmoves-kvm2 | Exit Node / Proxy | `self-hosted, vps, kvm2, backup` | 4C / 8GB | $10/mo |
+| KVM2 | — | — | pmoves-kvm2 | Reverse Proxy (nginx SSL) / RustDesk Relay | `self-hosted, vps, kvm2, backup` | 4C / 8GB | $10/mo |
 | Cloudflare Edge | — | — | — | DNS, Worker routing | — | Edge | Free plan |
 | GitHub Cloud | — | — | — | Lightweight CI | `ubuntu-latest` | 2C / 7GB | $0.008/min |
 
@@ -147,7 +147,13 @@ Services deployed via `docker-compose.vps.override.yml`:
 | Loki | 3100 | `/ready` | monitoring |
 | MinIO | 9000 (API) / 9001 (Console) | `/minio/health/live` | — |
 
-### KVM2 — Exit Node / Reverse Proxy / RustDesk Relay
+### KVM2 — Reverse Proxy / RustDesk Relay
+
+> Note (Phase 9Q, 2026-04-16): KVM2 provides nginx SSL ingress (reverse
+> proxy for public endpoints) and RustDesk relay. The egress exit node for
+> outbound traffic (e.g., PMOVES.YT routing around YouTube residential-IP
+> blocks) is **KVM4-1**, not KVM2. The `deploy/provision/kvm2-exit-node.sh`
+> script is an older draft never activated in production.
 
 | Service | Port | Health | Notes |
 |---------|------|--------|-------|

--- a/pmoves/docs/operations/YT_EGRESS_RUNBOOK.md
+++ b/pmoves/docs/operations/YT_EGRESS_RUNBOOK.md
@@ -1,0 +1,214 @@
+# YT Egress Routing Runbook
+
+**Phase:** 9Q
+**Last updated:** 2026-04-16
+**Exit node:** `pmoves-kvm4-1` (Hostinger datacenter IP `31.97.42.207`)
+
+## When to Activate
+
+Turn the egress sidecar on when PMOVES.YT starts returning HTTP 403s on
+public YouTube videos that should be accessible. Symptoms:
+
+- `curl -X POST http://localhost:8077/yt/ingest ...` returns
+  `Failed to download via Invidious companion: 403 Client Error`
+- `docker logs pmoves-pmoves-yt-1` shows YouTube 403 responses with
+  `&c=WEB` in the signed playback URLs
+- `ingest.transcript.ready.v1` events stop firing for channel-monitor
+  submissions
+- Downstream pipeline (Hi-RAG v2 knowledge freshness, Publisher-Discord
+  notifications, conch-consciousness-analysis skill) goes quiet
+
+YouTube rotates anti-bot rules periodically. The residential IP
+fingerprint blocks are "set and forget" — once the home IP enters a
+blocklist, every request from it gets 403'd regardless of yt-dlp client
+strategy, PO tokens, or cookie freshness. Egress routing moves the
+outbound surface to Hostinger's datacenter range, which YouTube treats
+differently.
+
+## Preflight
+
+Before activation, confirm KVM4-1 is advertising as exit node:
+
+```bash
+make -C pmoves yt-egress-preflight
+```
+
+Expected output:
+```
+[yt-egress] Preflight: checking KVM4-1 Tailscale status...
+[yt-egress] KVM4-1 reachable on tailnet.
+```
+
+If the preflight fails:
+
+1. SSH to KVM4-1 and confirm exit-node advertisement:
+   ```bash
+   ssh kvm4-1 "tailscale status --peers=false && tailscale status | grep 'exit node'"
+   ```
+2. If not advertising, re-apply:
+   ```bash
+   ssh kvm4-1 "sudo tailscale set --advertise-exit-node"
+   ```
+3. In Tailscale admin UI, approve KVM4-1 as an exit node
+   (Admin Console → Machines → pmoves-kvm4-1 → Edit route settings
+   → "Use as exit node").
+4. KVM4-1 setup history: see
+   `pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md:475` (2026-04-12 by
+   4090-CLAUDE).
+
+The older `deploy/provision/kvm2-exit-node.sh` script targets KVM2 and
+was never activated for the YT egress path. It's kept for historical
+reference; KVM4-1 is the production exit node.
+
+## Activation
+
+```bash
+make -C pmoves up-yt-egress
+```
+
+This:
+1. Starts `tailscale-yt-egress` sidecar (userspace Tailscale joining the
+   tailnet, auth via existing `TAILSCALE_AUTHKEY` in `env.shared`).
+2. Waits 20 seconds for exit-node handshake to complete.
+3. Recreates `pmoves-yt`, `bgutil-pot-provider`, `invidious-companion`,
+   `invidious` with `HTTP_PROXY=http://tailscale-yt-egress:1080` set.
+4. Runs verification (see next section).
+
+## Verification
+
+```bash
+make -C pmoves yt-egress-verify
+```
+
+Expected output:
+
+```
+--- Host IP (residential baseline) ---
+<your residential IP, e.g. 71.190.90.179>
+
+--- PMOVES.YT container egress IP (expected: 31.97.42.207 or Hostinger range) ---
+31.97.42.207
+
+--- Test ingest (dQw4w9WgXcQ, short known-good video) ---
+{"ok": true, "ingest_id": "..."}
+```
+
+If the test ingest returns `{"detail": "Failed to download..."}`:
+- Wait 60 seconds and retry (sidecar may still be establishing route)
+- Check sidecar logs: `docker logs pmoves-tailscale-yt-egress`
+- Check that bgutil + companion also got the proxy env:
+  `docker exec pmoves-pmoves-yt-1 env | grep -i proxy`
+- If the IP still shows residential, the sidecar tailnet join likely
+  failed — check `TAILSCALE_AUTHKEY` validity in `env.shared`.
+
+## Deactivation (rollback)
+
+```bash
+make -C pmoves down-yt-egress
+```
+
+Stops the sidecar and recreates the 4 services without proxy env. PMOVES.YT
+reverts to residential IP egress. Use when:
+
+- Investigating whether the sidecar itself is causing issues
+- KVM4-1 is offline/under-maintenance and YT egress needs to fall back
+- After YouTube re-allows the home IP (rare but possible)
+
+## Status Check
+
+```bash
+make -C pmoves yt-egress-status
+```
+
+Shows:
+- Tailscale sidecar status (peers, exit-node state)
+- Running state of the 5 affected containers (sidecar + 4 YT services)
+
+## Troubleshooting
+
+### Sidecar stuck at "joining tailnet"
+
+```bash
+docker logs pmoves-tailscale-yt-egress
+```
+
+Common causes:
+- `TAILSCALE_AUTHKEY` in `env.shared` has expired. Regenerate via
+  Tailscale admin UI and run `make -C pmoves env-setup` to propagate.
+- Network firewall blocking port 41641 UDP (Tailscale DERP). Usually
+  OK because Tailscale falls back to TCP relay, but verify with
+  `tailscale netcheck` from any other PMOVES node.
+
+### Exit node marked "not advertising" after it was working
+
+Tailscale tagged auth keys can expire. Check via Tailscale admin UI:
+- Machine `pmoves-kvm4-1` → Details
+- "Key expiry" should be disabled for tagged/shared nodes
+- If expired, re-auth with fresh key via the kvm4-1 setup procedure
+
+### YT still 403s even with sidecar active
+
+Three possible causes:
+1. **YouTube blocks Hostinger range too.** Unlikely but possible during
+   aggressive anti-bot sweeps. Test by pulling a recent known-public
+   video via `curl` from the container. If that also 403s, the IP itself
+   is blocked.
+2. **Cookies are expired.** See the cookies section below (Phase 9Q.2
+   addresses this properly).
+3. **Invidious companion is down.** Tier 2 fallback is critical when
+   Tier 1 yt-dlp hits 403s. Check
+   `docker ps --filter "name=invidious-companion"` and restart via
+   `docker compose up -d --force-recreate invidious-companion` if needed.
+
+### All traffic going through proxy (not just YouTube)
+
+By design — the sidecar catches all outbound HTTP/HTTPS from the 4 YT
+services. `NO_PROXY` carves out internal Docker DNS targets (minio, nats,
+supabase-kong, etc.) so service-to-service traffic stays on
+`pmoves_app`. If a target is missed and traffic breaks, extend `NO_PROXY`
+in `docker-compose.yt-egress.yml` for the affected service.
+
+## Cookies Workflow (Phase 9Q.2 — forward reference)
+
+The current `pmoves/config/cookies/darkxside.youtube.cookies.txt` file is
+a **manual workaround** — operator exports browser cookies once, copies
+to disk, hopes they don't expire. This is brittle.
+
+The real process (not yet built) uses Google OAuth2 + Playwright headless
+Chromium to automatically harvest fresh cookies weekly, store them
+encrypted in MinIO, and surface them to `pmoves-yt` via a NATS event
+(`yt.cookies.refreshed.v1`). Tracked as Phase 9Q.2 (task #44).
+
+Until that ships, refresh the cookies file manually on expiry:
+
+```bash
+# On any machine with a logged-in YouTube session:
+yt-dlp --cookies-from-browser chrome \
+  --cookies darkxside.youtube.cookies.txt \
+  https://www.youtube.com/
+# Copy file to PMOVES host:
+scp darkxside.youtube.cookies.txt pmoves:pmoves/config/cookies/
+# Restart pmoves-yt to pick up (no compose rebuild needed):
+make -C pmoves up-pmoves-yt
+```
+
+## Related Files
+
+- `pmoves/docker-compose.yt-egress.yml` — sidecar + proxy overrides
+- `pmoves/mk/egress.mk` — Make targets
+- `pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md:475` — KVM4-1 exit node setup
+- `pmoves/docs/operations/FLEET_REMOTE_ACCESS_RUNBOOK.md` — tailnet topology
+- `pmoves/docs/operations/TAILSCALE_NODE_HYGIENE.md` — stale node cleanup
+- `PMOVES.YT/pmoves_yt_service/yt.py` — 3-tier YT fallback implementation
+
+## NATS Subjects Affected
+
+When egress is active and a video successfully ingests, these subjects
+fire normally:
+- `ingest.file.added.v1`
+- `ingest.transcript.ready.v1`
+- `ingest.summary.ready.v1`
+- `ingest.chapters.ready.v1`
+
+No new subjects introduced by Phase 9Q. Egress is a transport-layer
+concern, invisible to event consumers.

--- a/pmoves/docs/operations/YT_EGRESS_RUNBOOK.md
+++ b/pmoves/docs/operations/YT_EGRESS_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 **Phase:** 9Q
 **Last updated:** 2026-04-16
-**Exit node:** `pmoves-kvm4-1` (Hostinger datacenter IP `31.97.42.207`)
+**Exit node:** `pmoves-kvm4-1` (Hostinger datacenter — resolve via Tailscale MagicDNS)
 
 ## When to Activate
 
@@ -34,9 +34,9 @@ make -C pmoves yt-egress-preflight
 ```
 
 Expected output:
-```
-[yt-egress] Preflight: checking KVM4-1 Tailscale status...
-[yt-egress] KVM4-1 reachable on tailnet.
+```text
+[yt-egress] Preflight: checking pmoves-kvm4-1 Tailscale exit-node advertisement...
+[yt-egress] pmoves-kvm4-1 is advertising as exit node.
 ```
 
 If the preflight fails:
@@ -82,16 +82,19 @@ make -C pmoves yt-egress-verify
 
 Expected output:
 
-```
+```text
 --- Host IP (residential baseline) ---
-<your residential IP, e.g. 71.190.90.179>
+<residential-ip-redacted>
 
---- PMOVES.YT container egress IP (expected: 31.97.42.207 or Hostinger range) ---
-31.97.42.207
+--- PMOVES.YT container egress IP (expected: pmoves-kvm4-1 / Hostinger range) ---
+<hostinger-datacenter-ip-redacted>
 
 --- Test ingest (dQw4w9WgXcQ, short known-good video) ---
 {"ok": true, "ingest_id": "..."}
 ```
+
+Host and container IPs must differ. The Makefile target fails with a clear
+error if they match (proxy inactive) or if the container is not running.
 
 If the test ingest returns `{"detail": "Failed to download..."}`:
 - Wait 60 seconds and retry (sidecar may still be establishing route)
@@ -188,8 +191,8 @@ yt-dlp --cookies-from-browser chrome \
   https://www.youtube.com/
 # Copy file to PMOVES host:
 scp darkxside.youtube.cookies.txt pmoves:pmoves/config/cookies/
-# Restart pmoves-yt to pick up (no compose rebuild needed):
-make -C pmoves up-pmoves-yt
+# Restart YT stack to pick up (no compose rebuild needed):
+make -C pmoves up-yt
 ```
 
 ## Related Files

--- a/pmoves/env.shared.example
+++ b/pmoves/env.shared.example
@@ -408,6 +408,13 @@ INVIDIOUS_COMPANION_URL=http://localhost:8282
 YT_PLAYER_CLIENT=
 YT_PO_TOKEN_CONTEXT=
 
+# PMOVES.YT PO token flag (Phase 9Q, 2026-04-16)
+# Enables yt-dlp to USE the PO tokens that bgutil-pot-provider and
+# invidious-companion are generating. Was silently false in prior defaults —
+# yt-dlp ran without tokens even though the supporting services worked. Set
+# to true so tokens flow end-to-end.
+YT_ENABLE_PO_TOKEN=true
+
 # Jellyfin - Media server integration
 # Numeric user/group override for jellyfin-ext in docker-compose.external.yml.
 # Keep `0:0` for maximum compatibility, or set to host media UID:GID when needed.

--- a/pmoves/mk/egress.mk
+++ b/pmoves/mk/egress.mk
@@ -3,17 +3,22 @@
 #
 # Make targets that toggle outbound routing of pmoves-yt, bgutil-pot-provider,
 # invidious-companion, and invidious through the KVM4-1 Tailscale exit node
-# (31.97.42.207, Hostinger datacenter). Bypasses YouTube residential-IP 403s.
+# (pmoves-kvm4-1, Hostinger datacenter). Bypasses YouTube residential-IP 403s.
 #
 # See pmoves/docs/operations/YT_EGRESS_RUNBOOK.md for full operator guide.
 
 YT_EGRESS_COMPOSE := docker-compose.yt-egress.yml
 YT_EGRESS_SERVICES := pmoves-yt bgutil-pot-provider invidious-companion invidious
-KVM4_1_EXIT_IP := 31.97.42.207
+YT_EGRESS_EXIT_HOST := pmoves-kvm4-1
 
 .PHONY: up-yt-egress down-yt-egress yt-egress-preflight yt-egress-status yt-egress-verify
 
 up-yt-egress: ensure-env-shared yt-egress-preflight ## Route YT services through KVM4-1 exit node
+	@if [ -z "$${TAILSCALE_AUTHKEY:-}" ]; then \
+		echo "ERROR: TAILSCALE_AUTHKEY not set in env.shared — egress sidecar cannot join tailnet." >&2; \
+		echo "Fix: run 'make -C pmoves secrets-funnel' or set TAILSCALE_AUTHKEY manually." >&2; \
+		exit 1; \
+	fi
 	@echo "[yt-egress] Starting Tailscale sidecar (tailscale-yt-egress)..."
 	@$(DC) -f docker-compose.yml -f $(YT_EGRESS_COMPOSE) up -d tailscale-yt-egress
 	@echo "[yt-egress] Waiting 20s for tailnet join + exit-node handshake..."
@@ -31,17 +36,25 @@ down-yt-egress: ## Stop egress sidecar, revert YT services to residential IP
 	@$(DC) up -d --force-recreate $(YT_EGRESS_SERVICES)
 	@echo "[yt-egress] Deactivation complete. Services now egress via host IP."
 
-yt-egress-preflight: ## Verify KVM4-1 exit node is reachable before activating
-	@echo "[yt-egress] Preflight: checking KVM4-1 Tailscale status..."
+yt-egress-preflight: ## Verify KVM4-1 is advertising exit node before activating
+	@echo "[yt-egress] Preflight: checking $(YT_EGRESS_EXIT_HOST) Tailscale exit-node advertisement..."
 	@if command -v tailscale >/dev/null 2>&1; then \
-		tailscale status 2>/dev/null | grep -E "pmoves-kvm4-1.*(active|idle)" >/dev/null && \
-			echo "[yt-egress] KVM4-1 reachable on tailnet." || \
-			{ echo "ERROR: pmoves-kvm4-1 not active in tailnet."; \
-			  echo "Fix: ssh kvm4-1 'sudo tailscale set --advertise-exit-node' and approve in Tailscale admin UI."; \
-			  echo "See pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md:475 for setup history."; \
-			  exit 1; }; \
+		status_json=$$(tailscale status --json 2>/dev/null); \
+		if [ -z "$$status_json" ]; then \
+			echo "ERROR: tailscale CLI installed but not connected to tailnet." >&2; \
+			exit 1; \
+		fi; \
+		if echo "$$status_json" | grep -q '"ExitNodeOption": *true' && \
+		   echo "$$status_json" | grep -B2 '"ExitNodeOption": *true' | grep -q '$(YT_EGRESS_EXIT_HOST)'; then \
+			echo "[yt-egress] $(YT_EGRESS_EXIT_HOST) is advertising as exit node."; \
+		else \
+			echo "ERROR: $(YT_EGRESS_EXIT_HOST) not advertising exit-node option." >&2; \
+			echo "Fix: ssh $(YT_EGRESS_EXIT_HOST) 'sudo tailscale set --advertise-exit-node' and approve in Tailscale admin UI." >&2; \
+			echo "See pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md (2026-04-12 4090-CLAUDE entry) for setup history." >&2; \
+			exit 1; \
+		fi; \
 	else \
-		echo "[yt-egress] (host tailscale CLI not available; skipping preflight — sidecar will still attempt connection)"; \
+		echo "[yt-egress] (host tailscale CLI not available; preflight skipped — sidecar will attempt connection)"; \
 	fi
 
 yt-egress-status: ## Show Tailscale sidecar status + current YT egress IPs
@@ -55,17 +68,32 @@ yt-egress-status: ## Show Tailscale sidecar status + current YT egress IPs
 		--filter "name=tailscale-yt-egress" \
 		--format "table {{.Names}}\t{{.Status}}" 2>&1 | head -10
 
-yt-egress-verify: ## Compare host IP vs PMOVES.YT egress IP + test-ingest reference video
-	@echo "--- Host IP (residential baseline) ---"
-	@curl -s --max-time 5 https://api.ipify.org 2>/dev/null \
-		|| echo "(could not reach api.ipify.org from host)"; echo
-	@echo "--- PMOVES.YT container egress IP (expected: $(KVM4_1_EXIT_IP) or Hostinger range) ---"
-	@docker exec pmoves-pmoves-yt-1 sh -c 'wget -qO- --timeout=10 https://api.ipify.org 2>/dev/null' 2>&1 \
-		|| echo "(pmoves-yt IP check failed — still starting up? try again in 30s)"
-	@echo
-	@echo "--- Test ingest (dQw4w9WgXcQ, short known-good video) ---"
-	@curl -s --max-time 30 -X POST http://localhost:8077/yt/ingest \
+yt-egress-verify: ## Compare host IP vs PMOVES.YT egress IP + test-ingest reference video (fails on error)
+	@set -e; \
+	yt_container=$$($(DC) -f docker-compose.yml -f $(YT_EGRESS_COMPOSE) ps -q pmoves-yt 2>/dev/null | head -1); \
+	if [ -z "$$yt_container" ]; then \
+		echo "ERROR: pmoves-yt container not running. Activate first via 'make -C pmoves up-yt-egress'." >&2; \
+		exit 1; \
+	fi; \
+	echo "--- Host IP (residential baseline) ---"; \
+	host_ip=$$(curl -sf --max-time 5 https://api.ipify.org); \
+	echo "$$host_ip"; \
+	echo; \
+	echo "--- PMOVES.YT container egress IP (expected: $(YT_EGRESS_EXIT_HOST) / Hostinger range) ---"; \
+	container_ip=$$(docker exec $$yt_container sh -c 'wget -qO- --timeout=10 https://api.ipify.org 2>/dev/null'); \
+	if [ -z "$$container_ip" ]; then \
+		echo "ERROR: pmoves-yt IP check failed — container reachable but no egress IP returned." >&2; \
+		exit 1; \
+	fi; \
+	echo "$$container_ip"; \
+	if [ "$$host_ip" = "$$container_ip" ]; then \
+		echo "ERROR: container IP matches host IP — egress proxy is NOT active." >&2; \
+		exit 1; \
+	fi; \
+	echo; \
+	echo "--- Test ingest (dQw4w9WgXcQ, short known-good video) ---"; \
+	response=$$(curl -sf --max-time 30 -X POST http://localhost:8077/yt/ingest \
 		-H 'Content-Type: application/json' \
-		-d '{"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}' \
-		2>/dev/null | head -c 500
-	@echo
+		-d '{"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}'); \
+	echo "$$response" | head -c 500; \
+	echo

--- a/pmoves/mk/egress.mk
+++ b/pmoves/mk/egress.mk
@@ -1,0 +1,71 @@
+# mk/egress.mk — YT egress routing via Tailscale exit node (Phase 9Q)
+# ===========================================================================
+#
+# Make targets that toggle outbound routing of pmoves-yt, bgutil-pot-provider,
+# invidious-companion, and invidious through the KVM4-1 Tailscale exit node
+# (31.97.42.207, Hostinger datacenter). Bypasses YouTube residential-IP 403s.
+#
+# See pmoves/docs/operations/YT_EGRESS_RUNBOOK.md for full operator guide.
+
+YT_EGRESS_COMPOSE := docker-compose.yt-egress.yml
+YT_EGRESS_SERVICES := pmoves-yt bgutil-pot-provider invidious-companion invidious
+KVM4_1_EXIT_IP := 31.97.42.207
+
+.PHONY: up-yt-egress down-yt-egress yt-egress-preflight yt-egress-status yt-egress-verify
+
+up-yt-egress: ensure-env-shared yt-egress-preflight ## Route YT services through KVM4-1 exit node
+	@echo "[yt-egress] Starting Tailscale sidecar (tailscale-yt-egress)..."
+	@$(DC) -f docker-compose.yml -f $(YT_EGRESS_COMPOSE) up -d tailscale-yt-egress
+	@echo "[yt-egress] Waiting 20s for tailnet join + exit-node handshake..."
+	@sleep 20
+	@echo "[yt-egress] Recreating YT-facing services with proxy env..."
+	@$(DC) -f docker-compose.yml -f $(YT_EGRESS_COMPOSE) up -d --force-recreate $(YT_EGRESS_SERVICES)
+	@echo "[yt-egress] Activation complete. Verifying..."
+	@$(MAKE) --no-print-directory yt-egress-verify
+
+down-yt-egress: ## Stop egress sidecar, revert YT services to residential IP
+	@echo "[yt-egress] Stopping sidecar..."
+	@$(DC) -f $(YT_EGRESS_COMPOSE) stop tailscale-yt-egress 2>/dev/null || true
+	@$(DC) -f $(YT_EGRESS_COMPOSE) rm -f tailscale-yt-egress 2>/dev/null || true
+	@echo "[yt-egress] Recreating YT services without proxy env..."
+	@$(DC) up -d --force-recreate $(YT_EGRESS_SERVICES)
+	@echo "[yt-egress] Deactivation complete. Services now egress via host IP."
+
+yt-egress-preflight: ## Verify KVM4-1 exit node is reachable before activating
+	@echo "[yt-egress] Preflight: checking KVM4-1 Tailscale status..."
+	@if command -v tailscale >/dev/null 2>&1; then \
+		tailscale status 2>/dev/null | grep -E "pmoves-kvm4-1.*(active|idle)" >/dev/null && \
+			echo "[yt-egress] KVM4-1 reachable on tailnet." || \
+			{ echo "ERROR: pmoves-kvm4-1 not active in tailnet."; \
+			  echo "Fix: ssh kvm4-1 'sudo tailscale set --advertise-exit-node' and approve in Tailscale admin UI."; \
+			  echo "See pmoves/docs/AGENTS/AGNOTE4482PHI.t1.md:475 for setup history."; \
+			  exit 1; }; \
+	else \
+		echo "[yt-egress] (host tailscale CLI not available; skipping preflight — sidecar will still attempt connection)"; \
+	fi
+
+yt-egress-status: ## Show Tailscale sidecar status + current YT egress IPs
+	@echo "--- Tailscale sidecar status ---"
+	@docker exec pmoves-tailscale-yt-egress tailscale status --peers=false 2>/dev/null \
+		|| echo "[yt-egress] Sidecar not running."
+	@echo
+	@echo "--- YT service container states ---"
+	@docker ps --filter "name=pmoves-yt" --filter "name=bgutil-pot-provider" \
+		--filter "name=invidious-companion" --filter "name=invidious" \
+		--filter "name=tailscale-yt-egress" \
+		--format "table {{.Names}}\t{{.Status}}" 2>&1 | head -10
+
+yt-egress-verify: ## Compare host IP vs PMOVES.YT egress IP + test-ingest reference video
+	@echo "--- Host IP (residential baseline) ---"
+	@curl -s --max-time 5 https://api.ipify.org 2>/dev/null \
+		|| echo "(could not reach api.ipify.org from host)"; echo
+	@echo "--- PMOVES.YT container egress IP (expected: $(KVM4_1_EXIT_IP) or Hostinger range) ---"
+	@docker exec pmoves-pmoves-yt-1 sh -c 'wget -qO- --timeout=10 https://api.ipify.org 2>/dev/null' 2>&1 \
+		|| echo "(pmoves-yt IP check failed — still starting up? try again in 30s)"
+	@echo
+	@echo "--- Test ingest (dQw4w9WgXcQ, short known-good video) ---"
+	@curl -s --max-time 30 -X POST http://localhost:8077/yt/ingest \
+		-H 'Content-Type: application/json' \
+		-d '{"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}' \
+		2>/dev/null | head -c 500
+	@echo


### PR DESCRIPTION
## Summary

Routes all YouTube-facing services (pmoves-yt, bgutil-pot-provider, invidious-companion, invidious) through the **KVM4-1 Tailscale exit node** (`pmoves-kvm4-1` Hostinger datacenter) to bypass YouTube's residential-IP anti-bot 403s.

## Why

PMOVES.YT is a **critical upstream dependency** for the ingestion pipeline. Silent 403s propagate as quiet failures in:
- `ffmpeg-whisper`, `extract-worker`, `langextract`, `notebook-sync`
- Hi-RAG v2 knowledge freshness (new videos never reach Qdrant)
- `publisher-discord` notifications (NATS `ingest.*` subjects stop firing)
- `conch-consciousness-analysis` skill pipeline (full chain blocked)

Root cause: YouTube periodically blacklists residential IP ranges. Once blacklisted, every request from the home IP 403s regardless of yt-dlp client, PO tokens, or cookies. The 3-tier fallback chain (yt-dlp → Invidious Companion → Invidious API) all egresses from the same residential IP.

Additionally, background investigation found **`YT_ENABLE_PO_TOKEN` has been silently FALSE by default** despite bgutil-pot-provider and invidious-companion actively generating tokens. This PR flips it to `true` alongside the egress routing.

## Changes (7 files, +425/-3)

| File | Type | Purpose |
|------|------|---------|
| `pmoves/docker-compose.yt-egress.yml` | NEW | Tailscale userspace sidecar + proxy overrides for 4 services |
| `pmoves/mk/egress.mk` | NEW | 5 Make targets for egress lifecycle + verification |
| `pmoves/docs/operations/YT_EGRESS_RUNBOOK.md` | NEW | Operator runbook: activation, verification, troubleshooting |
| `pmoves/Makefile` | MODIFIED | `include mk/egress.mk` |
| `pmoves/env.shared.example` | MODIFIED | Add `YT_ENABLE_PO_TOKEN=true` with comment explaining silent misconfig |
| `pmoves/docs/operations/TOPOLOGY.md` | MODIFIED | Correct KVM2/KVM4-1 roles (KVM4-1 is the egress exit node, not KVM2) |
| `.claude/hooks/damage-control/patterns.yaml` | MODIFIED | Allow-list `docker-compose.yt-egress` + `mk/egress.mk` |

## Architecture

Tailscale sidecar (`tailscale/tailscale:latest`) runs in userspace mode (no TUN device) with `TS_EXTRA_ARGS=--exit-node=pmoves-kvm4-1 --exit-node-allow-lan-access`. Exposes two proxy listeners on `pmoves_app`:
- **SOCKS5 on :1055** (for clients that prefer SOCKS5)
- **HTTP CONNECT on :1080** (used by yt-dlp via Python urllib auto-reading `HTTP_PROXY` env)

No code changes to PMOVES.YT submodule required — yt-dlp auto-respects `HTTP_PROXY`/`HTTPS_PROXY` env vars.

## Operator Actions Needed (Post-Merge)

```bash
# 1. Preflight (verifies KVM4-1 is reachable + advertising)
make -C pmoves yt-egress-preflight

# 2. Activate
make -C pmoves up-yt-egress

# 3. Verify IP change (should show Hostinger range for PMOVES.YT container)
make -C pmoves yt-egress-verify

# 4. Test Cole Medin 2hr Archon video (the Phase 9C blocker)
curl -X POST http://localhost:8077/yt/ingest \
  -H 'Content-Type: application/json' \
  -d '{\"url\": \"https://www.youtube.com/watch?v=srx9iwnjK2M\"}'
```

Rollback: `make -C pmoves down-yt-egress` reverts to residential egress.

## Out of Scope (Deferred)

- **Cookie refresh workflow (Phase 9Q.2 — task #44)**: replaces manual `darkxside.youtube.cookies.txt` with OAuth2 + Playwright harvester + Fernet-encrypted storage + NATS event on refresh. Scoped in plan, ~3-4 days of work.
- Explicit `YT_PROXY` env var in PMOVES.YT submodule — not needed (urllib auto-reads `HTTP_PROXY`)
- External downloader (`aria2c`) fallback — future resilience enhancement
- VPS-hosted pmoves-yt-vps instance — reserved for escalation if sidecar proves unreliable under load

## Task List Impact

After merge:
- Close **#36 Phase 9J** (YT 403 client-switch) as SUPERSEDED
- Unblock **#29 Phase 9C** (Cole Medin channel ingestion)
- Unblock **#30 Phase 9D** (Archon video-driven TAC review, blocked on #29)
- **#44 Phase 9Q.2** continues as follow-up

## Test Plan

- [ ] `make -C pmoves yt-egress-preflight` succeeds (KVM4-1 reachable)
- [ ] `make -C pmoves up-yt-egress` completes without errors
- [ ] `make -C pmoves yt-egress-verify` shows PMOVES.YT egress IP = `<exit-node-ip-redacted>`
- [ ] Cole Medin video (`srx9iwnjK2M`) ingests successfully (returns `{ok: true}`)
- [ ] `ingest.transcript.ready.v1` NATS event fires within ~10min for a 2hr video
- [ ] Hi-RAG query \"Archon architecture\" returns chunks from the video
- [ ] `make -C pmoves down-yt-egress` reverts PMOVES.YT to residential IP
- [ ] No regression: other services (hi-rag, extract-worker, etc.) still reach internal targets (NO_PROXY carve-out works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added YouTube egress routing through Tailscale exit node, enabling service-level proxy configuration for improved network isolation.
  * Introduced `YT_ENABLE_PO_TOKEN` environment variable to enable YouTube token handling via provider services.

* **Documentation**
  * Added operational runbook documenting egress activation, verification, deactivation, and troubleshooting procedures.
  * Updated infrastructure topology documentation reflecting revised node roles and egress responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->