### PR TITLE
fix(invidious): harden init + idempotent ENUM (PG14)

### DIFF
--- a/pmoves/services/invidious/config/sql/playlists.sql
+++ b/pmoves/services/invidious/config/sql/playlists.sql
@@ -1,13 +1,23 @@
 -- Type: public.privacy
+--
+-- PostgreSQL 14 does not support `CREATE TYPE ... AS ENUM ... IF NOT EXISTS`.
+-- Wrap the creation in a DO block that catches duplicate_object so the init
+-- script remains idempotent on rerun (e.g., when the postgres data dir is
+-- preserved but the entrypoint re-runs this file via `psql -f`).
 
--- DROP TYPE public.privacy;
-
-CREATE TYPE public.privacy AS ENUM
-(
-    'Public',
-    'Unlisted',
-    'Private'
-);
+DO $$
+BEGIN
+    CREATE TYPE public.privacy AS ENUM
+    (
+        'Public',
+        'Unlisted',
+        'Private'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN
+        NULL;
+END
+$$;
 
 -- Table: public.playlists
 

--- a/pmoves/services/invidious/init-invidious-db.sh
+++ b/pmoves/services/invidious/init-invidious-db.sh
@@ -34,14 +34,28 @@ SQL_FILES=(
 
 echo "[init-invidious-db] Loading schema into database: ${POSTGRES_DB:-invidious}"
 
+# Preflight: verify every SQL file exists before starting any psql. If any
+# are missing, fail fast — continuing on would leave the DB in a partial
+# state (some tables created, others not), which manifests as Invidious
+# runtime errors on unrelated queries and is hard to diagnose post-boot.
+missing=()
+for sql_file in "${SQL_FILES[@]}"; do
+  if [[ ! -f "${SQL_DIR}/${sql_file}" ]]; then
+    missing+=("${sql_file}")
+  fi
+done
+if (( ${#missing[@]} > 0 )); then
+  echo "[init-invidious-db] ERROR: ${#missing[@]} required SQL file(s) missing from ${SQL_DIR}:" >&2
+  for m in "${missing[@]}"; do echo "  - ${m}" >&2; done
+  echo "[init-invidious-db] Aborting init to prevent partial schema. Verify the bind-mount:" >&2
+  echo "  pmoves/services/invidious/config/sql/ → /config/sql/ in docker-compose.yml" >&2
+  exit 1
+fi
+
 for sql_file in "${SQL_FILES[@]}"; do
   sql_path="${SQL_DIR}/${sql_file}"
-  if [[ -f "${sql_path}" ]]; then
-    echo "[init-invidious-db] Applying ${sql_file}..."
-    psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -f "${sql_path}"
-  else
-    echo "[init-invidious-db] WARNING: ${sql_path} not found, skipping"
-  fi
+  echo "[init-invidious-db] Applying ${sql_file}..."
+  psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -f "${sql_path}"
 done
 
 echo "[init-invidious-db] Schema load complete."


### PR DESCRIPTION
## Summary

Addresses 4 unresolved review threads left on merged PR #1259 (`fix/invidious-restore-sql-init`):

| Thread | File | Severity | Issue |
|--------|------|:-:|-------|
| Codex | `init-invidious-db.sh:43` | **P1** | Warn-and-continue on missing SQL files leaves first-run bootstrap in "started but broken" state |
| CodeRabbit | `init-invidious-db.sh:44` | Major | Same (duplicate of Codex P1) |
| Codex | `playlists.sql:5` | P2 | `CREATE TYPE public.privacy AS ENUM` is not rerunnable |
| CodeRabbit | `playlists.sql:10` | Major | PostgreSQL 14 does NOT support `IF NOT EXISTS` in `CREATE TYPE AS ENUM` |

## Fix 1 — Init script fail-fast

Replaces per-file warn-and-skip with a **preflight loop** that checks all expected SQL files up front:

```bash
missing=()
for sql_file in "${SQL_FILES[@]}"; do
  if [[ ! -f "${SQL_DIR}/${sql_file}" ]]; then
    missing+=("${sql_file}")
  fi
done
if (( ${#missing[@]} > 0 )); then
  echo "[init-invidious-db] ERROR: ${#missing[@]} required SQL file(s) missing..." >&2
  # ... list + bind-mount hint ...
  exit 1
fi
```

If any files are missing:
- Print the list of missing filenames to stderr
- Point at the likely cause (bind-mount misconfiguration in `docker-compose.yml`)
- Exit 1 **before any psql runs** — prevents partial schema

## Fix 2 — Idempotent ENUM creation for PG14

Wraps `CREATE TYPE public.privacy AS ENUM` in a DO block that catches `duplicate_object`:

```sql
DO $$
BEGIN
    CREATE TYPE public.privacy AS ENUM
    (
        'Public',
        'Unlisted',
        'Private'
    );
EXCEPTION
    WHEN duplicate_object THEN
        NULL;
END
$$;
```

This is the **canonical PG14+ idempotency workaround** for `CREATE TYPE` — the statement itself does not support `IF NOT EXISTS` (confirmed via PostgreSQL 14 docs). The surrounding `CREATE TABLE IF NOT EXISTS public.playlists` already uses the ENUM as a column type (`privacy privacy`), so this change completes the idempotency story for the file end-to-end.

## Test Plan

- [x] Shell script logic verified manually (preflight loop structure)
- [ ] **Operator test (requires a dev container):** `docker compose run --rm invidious-db /config/init-invidious-db.sh` on fresh data dir → expect full schema load
- [ ] **Operator test:** rerun same command against populated DB → expect clean completion (no "type already exists" error)
- [ ] **Operator test:** deliberately remove one SQL file from bind-mount → expect init to exit 1 with list of missing files and bind-mount hint

## Context

Post-merge audit of Phase 9 wave (see `pmoves/docs/logs/post_merge_audit_2026-04-16.md`) — 4 of 6 unresolved threads on merged PRs landed here. The other 2 (hook exemption gap on #1256) are in separate PR #1267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
