### PR TITLE
docs(claude): fix submodule wipe recovery recipe

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -308,7 +308,9 @@ make -C pmoves worktree-sitrep-strict    # gate (non-zero exit on any dirty/conf
 #
 #   2. If HEAD has commits you want to keep, restore working tree from
 #      HEAD without touching HEAD itself:
-#        git -C <submodule> restore .
+#        # General form — handles all 3 wipe subtypes:
+#        #   ` M` worktree modifications, `D ` staged deletions, missing index file
+#        git -C <submodule> restore --source=HEAD --staged --worktree :/
 #
 #   3. If HEAD is also wrong, stash submodule commits before update:
 #        git -C <submodule> stash --include-untracked \
@@ -320,6 +322,11 @@ make -C pmoves worktree-sitrep-strict    # gate (non-zero exit on any dirty/conf
 # `git log` and `git rev-parse HEAD` inside the submodule before running
 # any submodule reset command. `restore` rewrites the working tree from
 # HEAD's tree; `update` resets HEAD to the superproject pointer.
+#
+# Wipe signature: if each wiped sub retains exactly ONE file
+# (`PMOVES.AI_INTEGRATION.md`), that matches the 2026-04-04/05 batch
+# pattern — predates all logged AI agent sessions. See memory
+# entry `project_submodule_wipe_forensic.md` for full forensic record.
 ```
 
 See `pmoves/docs/AGENTS/CODEX_CIPHER_MEMORY_IMPLEMENTATION_MAP.md` for the full worktree
@@ -585,6 +592,7 @@ encapsulate the correct stop/restart/env-injection flow.
 | Tailscale admin API calls | `make -C pmoves fleet-stale-audit` | `/fleet:stale-nodes` |
 | Tailscale ACL drift audit | `pmoves/docs/operations/FLEET_REMOTE_ACCESS_RUNBOOK.md` + `pmoves/configs/tailscale-acl-policy.json` | `/fleet:acl-audit` |
 | RustDesk enrollment / QR gen | `make -C pmoves fleet-enroll ROLE=... DEVICE=...` | `/fleet:enroll` |
+| Submodule working-tree wipe | `git -C <sub> restore --source=HEAD --staged --worktree :/` | — |
 
 | MinIO restart (object storage) | `make -C pmoves up-minio` | `/minio:status` |
 

--- a/pmoves/docs/AGENTS/OPERATOR_FACING_CLAUDE_MD_MIRRORS.md
+++ b/pmoves/docs/AGENTS/OPERATOR_FACING_CLAUDE_MD_MIRRORS.md
@@ -54,8 +54,14 @@ commits that were ahead of the gitlink locally.
 2. If HEAD has commits you want to keep, restore working tree from HEAD
    without touching HEAD itself:
    ```bash
-   git -C <submodule> restore .
+   # General form — handles all 3 wipe subtypes:
+   #   ` M` worktree modifications, `D ` staged deletions, missing index file
+   git -C <submodule> restore --source=HEAD --staged --worktree :/
    ```
+   The `:/` pathspec is git's root-magic signature: it scopes to every file
+   from the repo root, regardless of the caller's cwd. `--staged --worktree`
+   together rewrite both the index and the working tree from `--source=HEAD`,
+   which is what the three wipe subtypes require.
 
 3. If HEAD is also wrong, stash submodule commits before update:
    ```bash


### PR DESCRIPTION
## Summary

- **Fix incomplete `git restore .` recipe** → correct form is `restore --source=HEAD --staged --worktree :/` which handles all 3 wipe subtypes (` M` worktree modifications, `D ` staged deletions, missing index)
- **Add forensic callout** for the 2026-04-04/05 batch wipe signature (single-file retention pattern across 24 submodules)
- **Add Known Roads table entry** for submodule working-tree wipe recovery

## Context

Phase 5 submodule triage recovered 24 wiped submodules with HEAD preserved in every case. The existing recipe (`git -C <submodule> restore .`) was incomplete — it only handles ` M` worktree modifications but fails on `D ` staged deletions and missing index entries. The forensic investigation is closed; the wipe predates all logged AI agent sessions.

See memory entry `project_submodule_wipe_forensic.md` for the full forensic record.

## Test plan

- [ ] Verify markdown renders correctly in GitHub
- [ ] Confirm Known Roads table row aligns with existing columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation regarding Git submodule recovery procedures and operational guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->