### PR TITLE
feat(yt-cookies): Phase 9Q.2 PR 3 — cookie-writer sidecar + shared volume + runbook

### DIFF
--- a/pmoves/docker-compose.yt-cookies.yml
+++ b/pmoves/docker-compose.yt-cookies.yml
@@ -1,8 +1,20 @@
-# Phase 9Q.2: YouTube cookie refresh service overlay
+# Phase 9Q.2: YouTube cookie refresh services overlay
 # Usage: docker compose -f docker-compose.yml -f docker-compose.yt-cookies.yml --profile yt-cookies up -d
 #
-# Requires PR 1 (Supabase migration) to be applied first.
-# Operator must have run `make yt-cookies-auth` to store refresh token.
+# Prerequisites:
+#   1. Supabase migration 20260417000000 applied
+#   2. Operator ran `make yt-cookies-auth` (stored refresh token)
+#
+# Services:
+#   yt-cookie-refresher — weekly Playwright harvest, encrypts + stores in Supabase
+#   yt-cookie-writer    — NATS subscriber, decrypts + writes to shared volume
+#
+# The shared volume `yt-cookies-vol` is mounted by both the writer (rw) and
+# pmoves-yt (ro via override below). pmoves-yt's yt-dlp reads the cookiefile
+# per-request — no container restart needed when cookies update.
+
+volumes:
+  yt-cookies-vol:
 
 services:
   yt-cookie-refresher:
@@ -41,3 +53,43 @@ services:
         limits:
           cpus: '2.0'
           memory: 2G
+
+  yt-cookie-writer:
+    build:
+      context: ./services/yt-cookie-writer
+    # main.py now touches /tmp/healthy after NATS subscription is active,
+    # matching the Dockerfile healthcheck. This override keeps it consistent.
+    healthcheck:
+      test: ["CMD", "python", "-c", "from pathlib import Path; assert Path('/tmp/healthy').exists()"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    restart: unless-stopped
+    environment:
+      - NATS_URL=${NATS_URL:-nats://nats:pmoves@nats:4222}
+      - SUPABASE_URL=${SUPABASE_URL:-http://supabase-kong:8000}
+      - SERVICE_ROLE_KEY=${SERVICE_ROLE_KEY}
+      - VAULT_ENC_KEY=${VAULT_ENC_KEY:-}
+      - YT_COOKIE_OUTPUT_PATH=/cookies/yt-cookies.txt
+      - LOG_LEVEL=${YT_COOKIE_WRITER_LOG_LEVEL:-INFO}
+      - SSL_CERT_FILE=
+      - SSL_CERT_DIR=
+      - REQUESTS_CA_BUNDLE=
+    depends_on:
+      nats:
+        condition: service_healthy
+    volumes:
+      - yt-cookies-vol:/cookies
+    profiles: ["yt-cookies"]
+    networks: [pmoves_bus, pmoves_api]
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+
+  # Override pmoves-yt to mount the shared cookie volume (read-only)
+  pmoves-yt:
+    volumes:
+      - yt-cookies-vol:/app/config/cookies:ro

--- a/pmoves/docs/operations/YT_COOKIES_RUNBOOK.md
+++ b/pmoves/docs/operations/YT_COOKIES_RUNBOOK.md
@@ -1,0 +1,184 @@
+# YT Cookie Refresh Runbook
+
+**Phase:** 9Q.2
+**Last updated:** 2026-04-17
+
+## Overview
+
+Automated YouTube cookie harvesting replaces the manual
+`pmoves/config/cookies/darkxside.youtube.cookies.txt` workaround. Three
+services work together:
+
+1. **OAuth CLI** (`make yt-cookies-auth`) — one-time browser consent,
+   stores encrypted refresh token in Supabase
+2. **yt-cookie-refresher** (container) — weekly cron harvests fresh
+   cookies via Playwright Chromium, encrypts + stores in Supabase,
+   fires NATS event
+3. **yt-cookie-writer** (sidecar) — subscribes to NATS event, decrypts
+   cookies, writes Netscape file to shared volume that pmoves-yt reads
+
+## First-Time Setup
+
+### 1. Verify Google OAuth client credentials
+
+```bash
+make -C pmoves yt-cookies-check
+```
+
+These are the same `CHANNEL_MONITOR_GOOGLE_CLIENT_ID/SECRET` used by
+channel-monitor. If not configured, add them to `env.shared`.
+
+### 2. Apply Supabase migration
+
+```bash
+# Apply the schema (run once):
+docker exec pmoves-supabase-db-1 psql -U postgres -f \
+  /docker-entrypoint-initdb.d/20260417000000_yt_oauth_cookies.sql
+
+# Verify:
+docker exec pmoves-supabase-db-1 psql -U postgres -c \
+  "SELECT table_name FROM information_schema.tables WHERE table_schema='pmoves_core' AND table_name='yt_oauth_cookies';"
+```
+
+### 3. Run OAuth consent flow
+
+```bash
+make -C pmoves yt-cookies-auth
+```
+
+Opens a browser for Google OAuth2 consent. Sign in with the YouTube
+account that has access to target content (the darkxside account).
+Stores encrypted refresh token in Supabase.
+
+### 4. Start the cookie services
+
+```bash
+# Start refresher + writer sidecar:
+docker compose -f docker-compose.yml -f docker-compose.yt-cookies.yml \
+  --profile yt-cookies up -d
+```
+
+### 5. Trigger initial harvest
+
+```bash
+make -C pmoves yt-cookies-refresh
+```
+
+### 6. Verify end-to-end
+
+```bash
+# Check refresher status:
+curl -s http://localhost:8115/status | python -m json.tool
+
+# Check cookie file exists in pmoves-yt container:
+docker exec pmoves-pmoves-yt-1 ls -la /app/config/cookies/yt-cookies.txt
+
+# Test ingest with fresh cookies:
+curl -X POST http://localhost:8077/yt/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://youtube.com/watch?v=dQw4w9WgXcQ"}'
+```
+
+## Routine Operations
+
+### Manual refresh
+
+```bash
+make -C pmoves yt-cookies-refresh
+# Or directly:
+curl -X POST http://localhost:8115/refresh
+```
+
+### Check status
+
+```bash
+make -C pmoves yt-cookies-status
+```
+
+### Revoke credentials
+
+```bash
+make -C pmoves yt-cookies-revoke
+```
+
+Deletes Supabase row + revokes token at Google. Requires re-consent
+via `make yt-cookies-auth` before cookies can be refreshed again.
+
+## Troubleshooting
+
+### Refresher reports "invalid_grant"
+
+The Google refresh token has been revoked or expired. Re-run consent:
+```bash
+make -C pmoves yt-cookies-revoke
+make -C pmoves yt-cookies-auth
+make -C pmoves yt-cookies-refresh
+```
+
+### Cookie file not updating after NATS event
+
+1. Check writer sidecar logs: `docker logs pmoves-yt-cookie-writer-1`
+2. Verify NATS connectivity: `nats sub ingest.cookies.refreshed.v1`
+3. Check `VAULT_ENC_KEY` is consistent between refresher and writer
+4. Check shared volume mount exists in both containers
+
+### Playwright fails to launch
+
+The Playwright Chromium base image requires sufficient memory. The
+compose overlay sets a 2GB limit. If extraction fails with OOM:
+```yaml
+# In docker-compose.yt-cookies.yml, increase:
+deploy:
+  resources:
+    limits:
+      memory: 4G
+```
+
+### PO tokens not captured
+
+PO token capture requires YouTube to serve a video player response with
+`streamingData.adaptiveFormats[].poToken`. This depends on the account's
+standing and the video being accessible. Check:
+- The test video ID is accessible: `dQw4w9WgXcQ` (Rick Astley)
+- The OAuth account isn't flagged by YouTube
+
+## Architecture
+
+```
+┌─────────────────────────────┐
+│  make yt-cookies-auth       │ One-time: browser consent
+│  tools/yt_oauth_flow.py     │ → encrypted refresh_token in Supabase
+└──────────────┬──────────────┘
+               │
+┌──────────────▼──────────────┐
+│  yt-cookie-refresher :8115  │ Weekly cron (or POST /refresh)
+│  Playwright Chromium        │ → fresh cookies + PO token
+│  Fernet encrypt → Supabase  │ → NATS: ingest.cookies.refreshed.v1
+└──────────────┬──────────────┘
+               │
+┌──────────────▼──────────────┐
+│  yt-cookie-writer (sidecar) │ NATS subscriber
+│  Decrypt → write to volume  │ → /app/config/cookies/yt-cookies.txt
+└──────────────┬──────────────┘
+               │
+┌──────────────▼──────────────┐
+│  pmoves-yt :8077            │ yt-dlp reads cookiefile per-request
+│  (PMOVES.YT submodule)      │ No submodule changes needed
+└─────────────────────────────┘
+```
+
+## Related Files
+
+- `pmoves/tools/yt_oauth_flow.py` — OAuth CLI (auth/status/revoke)
+- `pmoves/mk/yt-cookies.mk` — Make targets
+- `pmoves/services/yt-cookie-refresher/` — Playwright harvester service
+- `pmoves/services/yt-cookie-writer/` — NATS cookie-file writer sidecar
+- `pmoves/docker-compose.yt-cookies.yml` — Compose overlay
+- `pmoves/supabase/migrations/20260417000000_yt_oauth_cookies.sql` — Schema
+- `pmoves/docs/operations/YT_EGRESS_RUNBOOK.md` — Network egress (Phase 9Q)
+
+## NATS Subjects
+
+| Subject | Publisher | Consumer |
+|---------|-----------|----------|
+| `ingest.cookies.refreshed.v1` | yt-cookie-refresher | yt-cookie-writer |

--- a/pmoves/docs/operations/YT_COOKIES_RUNBOOK.md
+++ b/pmoves/docs/operations/YT_COOKIES_RUNBOOK.md
@@ -17,7 +17,7 @@ services work together:
 3. **yt-cookie-writer** (sidecar) — subscribes to NATS event, decrypts
    cookies, writes Netscape file to shared volume that pmoves-yt reads
 
-## First-Time Setup
+## First-Time Setup (6 steps)
 
 ### 1. Verify Google OAuth client credentials
 
@@ -118,7 +118,10 @@ make -C pmoves yt-cookies-refresh
 ### Cookie file not updating after NATS event
 
 1. Check writer sidecar logs: `docker logs pmoves-yt-cookie-writer-1`
-2. Verify NATS connectivity: `nats sub ingest.cookies.refreshed.v1`
+2. Verify NATS connectivity (auth required — base nats service runs with `--auth nats:pmoves`):
+   ```bash
+   nats sub --server "nats://nats:pmoves@localhost:4222" ingest.cookies.refreshed.v1
+   ```
 3. Check `VAULT_ENC_KEY` is consistent between refresher and writer
 4. Check shared volume mount exists in both containers
 
@@ -144,7 +147,7 @@ standing and the video being accessible. Check:
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────┐
 │  make yt-cookies-auth       │ One-time: browser consent
 │  tools/yt_oauth_flow.py     │ → encrypted refresh_token in Supabase

--- a/pmoves/services/yt-cookie-writer/Dockerfile
+++ b/pmoves/services/yt-cookie-writer/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir httpx nats-py cryptography
+
+COPY main.py .
+
+RUN useradd -r -s /bin/false appuser
+USER appuser
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s \
+    CMD python -c "from pathlib import Path; assert Path('/tmp/healthy').exists()" || exit 1
+
+CMD ["python", "main.py"]

--- a/pmoves/services/yt-cookie-writer/main.py
+++ b/pmoves/services/yt-cookie-writer/main.py
@@ -18,10 +18,10 @@ import logging
 import os
 import signal
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+import httpx
 import nats
 
 try:
@@ -39,6 +39,7 @@ NATS_SUBJECT = "ingest.cookies.refreshed.v1"
 COOKIE_OUTPUT_PATH = os.environ.get("YT_COOKIE_OUTPUT_PATH", "/app/config/cookies/yt-cookies.txt")
 TABLE_PATH = "/rest/v1/yt_oauth_cookies"
 DEFAULT_USER_ID = "darkxside"
+VALID_STATUSES = {"success", "failed", "revoked"}
 
 
 def _get_fernet() -> Optional[Fernet]:
@@ -57,18 +58,31 @@ def _get_fernet() -> Optional[Fernet]:
 
 
 def _decrypt(value: str) -> str:
-    """Decrypt Fernet-encrypted value, or return as-is."""
+    """Decrypt Fernet-encrypted value. Raises RuntimeError on failure.
+
+    CRITICAL: must NOT fall back to ciphertext — writing encrypted bytes
+    as a cookie file corrupts yt-dlp's session and silently breaks the
+    YT pipeline. Fail loud so the operator can diagnose key mismatch.
+    """
     f = _get_fernet()
-    if f is None or not value:
+    if f is None:
+        raise RuntimeError("Fernet unavailable — VAULT_ENC_KEY missing or cryptography not installed")
+    if not value:
         return value
     try:
         return f.decrypt(value.encode()).decode()
-    except Exception:
-        return value
+    except Exception as e:
+        raise RuntimeError(f"Fernet decryption failed (VAULT_ENC_KEY mismatch?): {e}")
 
 
 def _supabase_url() -> str:
-    return os.environ.get("SUPABASE_URL", os.environ.get("SUPA_REST_URL", "http://supabase-kong:8000"))
+    url = os.environ.get("SUPABASE_URL", os.environ.get("SUPA_REST_URL", "http://supabase-kong:8000"))
+    # Strip trailing /rest/v1 to avoid duplicated path when combined with TABLE_PATH
+    for suffix in ("/rest/v1/", "/rest/v1"):
+        if url.endswith(suffix):
+            url = url[: -len(suffix)]
+            break
+    return url.rstrip("/")
 
 
 def _supabase_headers() -> dict:
@@ -81,15 +95,15 @@ def _supabase_headers() -> dict:
 
 
 async def fetch_and_write_cookies(user_id: str = DEFAULT_USER_ID) -> bool:
-    """Fetch encrypted cookies from Supabase, decrypt, write to disk.
+    """Fetch encrypted cookies from Supabase, decrypt, atomically write to disk.
 
-    Returns True on success.
+    Returns True on success. Uses async httpx + atomic write (tmp + rename)
+    so the yt-dlp per-request readers never see a torn cookie file.
     """
-    import httpx
-
     url = f"{_supabase_url()}{TABLE_PATH}?user_id=eq.{user_id}&select=encrypted_cookies"
     try:
-        resp = httpx.get(url, headers=_supabase_headers(), timeout=10)
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url, headers=_supabase_headers())
         rows = resp.json() if resp.status_code == 200 else []
     except Exception as e:
         logger.error(f"Failed to fetch cookies from Supabase: {e}")
@@ -99,36 +113,70 @@ async def fetch_and_write_cookies(user_id: str = DEFAULT_USER_ID) -> bool:
         logger.warning("No cookies in Supabase — waiting for first refresh")
         return False
 
-    cookies_str = _decrypt(rows[0]["encrypted_cookies"])
-    if not cookies_str:
-        logger.error("Failed to decrypt cookies (VAULT_ENC_KEY mismatch?)")
+    try:
+        cookies_str = _decrypt(rows[0]["encrypted_cookies"])
+    except RuntimeError as e:
+        logger.error(f"Decryption failed (will NOT write ciphertext to cookie file): {e}")
         return False
 
+    if not cookies_str:
+        logger.error("Decrypted cookie blob is empty — refusing to write")
+        return False
+
+    # Atomic write: tmp + rename. yt-dlp reads the cookiefile per-request so
+    # a non-atomic write (file truncated mid-rewrite) would produce torn reads.
     output = Path(COOKIE_OUTPUT_PATH)
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(cookies_str)
-    logger.info(f"Wrote {len(cookies_str)} bytes to {output}")
+    tmp = output.with_suffix(output.suffix + ".tmp")
+    try:
+        tmp.write_text(cookies_str)
+        tmp.replace(output)
+    except OSError as e:
+        logger.error(f"Cookie write failed: {e}")
+        tmp.unlink(missing_ok=True)
+        return False
+
+    logger.info(f"Wrote {len(cookies_str)} bytes to {output} (atomic)")
     return True
 
 
 async def _on_message(msg):
-    """Handle ingest.cookies.refreshed.v1 NATS messages."""
+    """Handle ingest.cookies.refreshed.v1 NATS messages.
+
+    Validates payload shape + user_id match before acting. Silently defaulting
+    user_id would apply the wrong account's cookies in a multi-user setup.
+    """
     try:
         data = json.loads(msg.data.decode())
-        status = data.get("status", "unknown")
-        user_id = data.get("user_id", DEFAULT_USER_ID)
-        logger.info(f"Received {NATS_SUBJECT}: status={status}, user={user_id}")
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        logger.warning(f"Malformed NATS payload on {NATS_SUBJECT}: {e}")
+        return
 
-        if status == "success":
-            ok = await fetch_and_write_cookies(user_id)
-            if ok:
-                logger.info("Cookie file updated — pmoves-yt will pick up on next request")
-            else:
-                logger.warning("Cookie write failed — existing file left in place")
+    if not isinstance(data, dict):
+        logger.warning(f"NATS payload is not an object: {type(data).__name__}")
+        return
+
+    status = data.get("status")
+    if status not in VALID_STATUSES:
+        logger.warning(f"NATS payload has invalid status={status!r}, expected one of {VALID_STATUSES}")
+        return
+
+    # Require explicit user_id — no silent default. If absent, skip the write.
+    user_id = data.get("user_id")
+    if not user_id or not isinstance(user_id, str):
+        logger.warning("NATS payload missing/invalid user_id — skipping")
+        return
+
+    logger.info(f"Received {NATS_SUBJECT}: status={status}, user={user_id}")
+
+    if status == "success":
+        ok = await fetch_and_write_cookies(user_id)
+        if ok:
+            logger.info("Cookie file updated — pmoves-yt will pick up on next request")
         else:
-            logger.warning(f"Refresh reported status={status}, skipping write")
-    except Exception as e:
-        logger.exception(f"Error processing {NATS_SUBJECT}: {e}")
+            logger.warning("Cookie write failed — existing file left in place")
+    else:
+        logger.warning(f"Refresh reported status={status}, skipping write")
 
 
 async def run() -> None:
@@ -140,9 +188,15 @@ async def run() -> None:
     await nc.subscribe(NATS_SUBJECT, cb=_on_message)
     logger.info(f"Subscribed to {NATS_SUBJECT}")
 
-    # On startup, try to write existing cookies (if any)
+    # On startup, try to write existing cookies (catch-up after container restart)
     logger.info("Checking for existing cookies on startup...")
     await fetch_and_write_cookies()
+
+    # Touch liveness marker so the Docker healthcheck knows we reached steady state
+    try:
+        Path("/tmp/healthy").touch()
+    except OSError:
+        pass
 
     # Wait for signal
     stop = asyncio.Event()

--- a/pmoves/services/yt-cookie-writer/main.py
+++ b/pmoves/services/yt-cookie-writer/main.py
@@ -1,0 +1,168 @@
+"""yt-cookie-writer — Phase 9Q.2 PR 3.
+
+NATS sidecar that subscribes to ingest.cookies.refreshed.v1, fetches
+encrypted cookies from Supabase, decrypts with Fernet (VAULT_ENC_KEY),
+and writes Netscape-format cookie file to the shared volume that
+pmoves-yt mounts at /app/config/cookies/.
+
+pmoves-yt's yt-dlp reads the cookiefile per-request — no restart needed.
+This sidecar is the bridge between the refresher service and the YT
+pipeline, keeping PMOVES.YT submodule untouched.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import signal
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import nats
+
+try:
+    from cryptography.fernet import Fernet
+except ImportError:
+    Fernet = None  # type: ignore[assignment,misc]
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("yt-cookie-writer")
+
+NATS_SUBJECT = "ingest.cookies.refreshed.v1"
+COOKIE_OUTPUT_PATH = os.environ.get("YT_COOKIE_OUTPUT_PATH", "/app/config/cookies/yt-cookies.txt")
+TABLE_PATH = "/rest/v1/yt_oauth_cookies"
+DEFAULT_USER_ID = "darkxside"
+
+
+def _get_fernet() -> Optional[Fernet]:
+    """Build Fernet from VAULT_ENC_KEY."""
+    if Fernet is None:
+        return None
+    key_hex = os.environ.get("VAULT_ENC_KEY", "").strip()
+    if not key_hex:
+        return None
+    try:
+        key_bytes = bytes.fromhex(key_hex)
+        key_bytes = (key_bytes + b"\x00" * 32)[:32]
+        return Fernet(base64.urlsafe_b64encode(key_bytes))
+    except Exception:
+        return None
+
+
+def _decrypt(value: str) -> str:
+    """Decrypt Fernet-encrypted value, or return as-is."""
+    f = _get_fernet()
+    if f is None or not value:
+        return value
+    try:
+        return f.decrypt(value.encode()).decode()
+    except Exception:
+        return value
+
+
+def _supabase_url() -> str:
+    return os.environ.get("SUPABASE_URL", os.environ.get("SUPA_REST_URL", "http://supabase-kong:8000"))
+
+
+def _supabase_headers() -> dict:
+    key = os.environ.get("SERVICE_ROLE_KEY", "")
+    return {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+
+
+async def fetch_and_write_cookies(user_id: str = DEFAULT_USER_ID) -> bool:
+    """Fetch encrypted cookies from Supabase, decrypt, write to disk.
+
+    Returns True on success.
+    """
+    import httpx
+
+    url = f"{_supabase_url()}{TABLE_PATH}?user_id=eq.{user_id}&select=encrypted_cookies"
+    try:
+        resp = httpx.get(url, headers=_supabase_headers(), timeout=10)
+        rows = resp.json() if resp.status_code == 200 else []
+    except Exception as e:
+        logger.error(f"Failed to fetch cookies from Supabase: {e}")
+        return False
+
+    if not rows or not rows[0].get("encrypted_cookies"):
+        logger.warning("No cookies in Supabase — waiting for first refresh")
+        return False
+
+    cookies_str = _decrypt(rows[0]["encrypted_cookies"])
+    if not cookies_str:
+        logger.error("Failed to decrypt cookies (VAULT_ENC_KEY mismatch?)")
+        return False
+
+    output = Path(COOKIE_OUTPUT_PATH)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(cookies_str)
+    logger.info(f"Wrote {len(cookies_str)} bytes to {output}")
+    return True
+
+
+async def _on_message(msg):
+    """Handle ingest.cookies.refreshed.v1 NATS messages."""
+    try:
+        data = json.loads(msg.data.decode())
+        status = data.get("status", "unknown")
+        user_id = data.get("user_id", DEFAULT_USER_ID)
+        logger.info(f"Received {NATS_SUBJECT}: status={status}, user={user_id}")
+
+        if status == "success":
+            ok = await fetch_and_write_cookies(user_id)
+            if ok:
+                logger.info("Cookie file updated — pmoves-yt will pick up on next request")
+            else:
+                logger.warning("Cookie write failed — existing file left in place")
+        else:
+            logger.warning(f"Refresh reported status={status}, skipping write")
+    except Exception as e:
+        logger.exception(f"Error processing {NATS_SUBJECT}: {e}")
+
+
+async def run() -> None:
+    """Main event loop — connect to NATS, subscribe, wait."""
+    nats_url = os.environ.get("NATS_URL", "nats://nats:pmoves@nats:4222")
+    logger.info(f"Connecting to NATS at {nats_url}")
+
+    nc = await nats.connect(nats_url)
+    await nc.subscribe(NATS_SUBJECT, cb=_on_message)
+    logger.info(f"Subscribed to {NATS_SUBJECT}")
+
+    # On startup, try to write existing cookies (if any)
+    logger.info("Checking for existing cookies on startup...")
+    await fetch_and_write_cookies()
+
+    # Wait for signal
+    stop = asyncio.Event()
+
+    def _signal_handler():
+        stop.set()
+
+    loop = asyncio.get_event_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _signal_handler)
+        except NotImplementedError:
+            pass  # Windows
+
+    logger.info("yt-cookie-writer running — waiting for NATS events")
+    await stop.wait()
+
+    await nc.drain()
+    logger.info("Shutdown complete")
+
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

- Final piece of the YouTube cookie automation pipeline (Phase 9Q.2)
- NATS sidecar subscribes to `ingest.cookies.refreshed.v1`, decrypts + writes cookies to shared Docker volume
- pmoves-yt mounts volume read-only — yt-dlp reads cookiefile per-request, no restart needed
- Zero PMOVES.YT submodule changes

## New Files (4)

- **`pmoves/services/yt-cookie-writer/main.py`** — NATS subscriber: fetch encrypted cookies from Supabase, Fernet-decrypt, write Netscape file. On startup, catch-up writes existing cookies.
- **`pmoves/services/yt-cookie-writer/Dockerfile`** — python:3.11-slim, non-root (appuser)
- **`pmoves/docker-compose.yt-cookies.yml`** — UPDATED: adds writer sidecar + `yt-cookies-vol` shared volume + pmoves-yt read-only volume override
- **`pmoves/docs/operations/YT_COOKIES_RUNBOOK.md`** — Full operator walkthrough: first-time setup (5 steps), routine ops, troubleshooting, architecture diagram

## End-to-End Flow

```
make yt-cookies-auth → encrypted refresh_token in Supabase
  ↓
yt-cookie-refresher (weekly cron) → Playwright harvest → encrypted cookies in Supabase
  ↓
NATS: ingest.cookies.refreshed.v1
  ↓
yt-cookie-writer → decrypt → /cookies/yt-cookies.txt (shared volume)
  ↓
pmoves-yt → yt-dlp reads cookiefile per-request (no restart)
```

## Depends On

- PR #1270 (Supabase schema + OAuth CLI)
- PR #1273 (yt-cookie-refresher Playwright service)

## Test plan

- [ ] Writer container starts and subscribes to NATS
- [ ] On startup, writer checks Supabase for existing cookies (catch-up)
- [ ] After refresher fires `ingest.cookies.refreshed.v1`, writer writes cookie file within 30s
- [ ] `docker exec pmoves-pmoves-yt-1 ls -la /app/config/cookies/yt-cookies.txt` shows fresh file
- [ ] `docker exec pmoves-pmoves-yt-1 head -3 /app/config/cookies/yt-cookies.txt` shows Netscape header
- [ ] Test ingest succeeds with fresh cookies

## Phase 9Q.2 Complete

| PR | Scope | Status |
|----|-------|--------|
| PR 1 (#1270) | OAuth scaffold + Supabase schema + CLI | Ready |
| PR 2 (#1273) | yt-cookie-refresher (Playwright harvester) | Ready |
| **PR 3 (this)** | yt-cookie-writer sidecar + runbook | Ready |

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated YouTube cookie refresh system with scheduled refresh cycles and on-demand capability
  * Docker Compose overlay configuration providing dedicated services for cookie management with integrated health checks and monitoring

* **Documentation**
  * Operational runbook for YouTube cookie management including initial setup steps, routine maintenance procedures, troubleshooting guides, and system architecture diagrams

<!-- end of auto-generated comment: release notes by coderabbit.ai -->