### PR TITLE
fix(chit-encode): force UTF-8 stdin on Windows

### DIFF
--- a/pmoves/tools/chit_encode_hook.py
+++ b/pmoves/tools/chit_encode_hook.py
@@ -272,7 +272,12 @@ def main() -> int:
         text = data.get("content", data.get("text", ""))
         metadata = {k: v for k, v in data.items() if k not in ("content", "text")}
     else:
-        # Read from stdin
+        # Read from stdin — force UTF-8 on Windows where stdin defaults to cp1252
+        # and produces lone surrogates that break downstream hashing.
+        try:
+            sys.stdin.reconfigure(encoding="utf-8", errors="replace")
+        except AttributeError:
+            pass
         text = sys.stdin.read().strip()
         metadata = {}
 


### PR DESCRIPTION
## Summary
- `tools/chit_encode_hook.py` reads from stdin when neither `--text` nor `--input` is given. On Windows, `sys.stdin` defaults to cp1252 and decodes non-ASCII bytes with `surrogateescape`, producing lone surrogates that `hashlib.sha256(text.encode("utf-8"))` cannot re-encode — the encoder crashes with `UnicodeEncodeError` before emitting a CGP packet.
- Fix: `sys.stdin.reconfigure(encoding="utf-8", errors="replace")` before reading. Guarded with `try/except AttributeError` for older Python or non-standard streams.

## Why this matters
`/chit:review-sweep` pipes `pmoves/docs/logs/pr_monitor_learnings_latest.md` into this encoder. On a Windows node, that step silently failed (exit 1, no packet) whenever the learnings contained any non-ASCII character, which happens on nearly every real PR scan. This broke the pr-monitor → CGP → trail handshake at Step 2.

## Reproducer (before fix)
```bash
cd pmoves
py -3 tools/chit_encode_hook.py --pretty \
  < docs/logs/pr_monitor_learnings_latest.md > /tmp/out.cgp.json
# UnicodeEncodeError: 'utf-8' codec can't encode character '\udc8f' ...
```

## Test plan
- [x] Repro before fix: exit 1 + traceback on a Windows shell.
- [x] After fix: exit 0 and same `content_hash` as the `PYTHONIOENCODING=utf-8` workaround (`2e16e7b3fe83bb98` for the session's learnings), confirming behavior-neutral on already-clean input.
- [ ] Non-Windows: `reconfigure()` is a no-op when stdin is already UTF-8; nothing to verify beyond unchanged hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)