### PR TITLE
feat(secrets): CHIT-aware secrets pipeline — key separation, DGX Spark, fleet-enroll gate

### DIFF
--- a/.github/workflows/chit-contract.yml
+++ b/.github/workflows/chit-contract.yml
@@ -123,6 +123,10 @@ jobs:
           echo "✅ Found all CHIT environment variables"
 
           echo ""
+          echo 'Check CHIT key separation awareness (informational — not required yet)'
+          rg -l 'CHIT_SIGNING_KEY|CHIT_ENCRYPTION_KEY' pmoves/ || echo "INFO: No key separation refs found (CHIT_PASSPHRASE fallback active)"
+
+          echo ""
           echo "======================================"
           echo "✅ All CHIT contract checks passed!"
           echo "======================================"

--- a/.github/workflows/sync-secrets-local.yml
+++ b/.github/workflows/sync-secrets-local.yml
@@ -97,6 +97,11 @@ jobs:
           # ── Agent & Integration Keys ──
           AGENT_ZERO_EVENTS_TOKEN: ${{ secrets.AGENT_ZERO_EVENTS_TOKEN }}
           CHIT_PASSPHRASE: ${{ secrets.CHIT_PASSPHRASE }}
+          CHIT_SIGNING_KEY: ${{ secrets.CHIT_SIGNING_KEY }}
+          CHIT_ENCRYPTION_KEY: ${{ secrets.CHIT_ENCRYPTION_KEY }}
+          OLLAMA_SPARK_BASE_URL: ${{ secrets.OLLAMA_SPARK_BASE_URL }}
+          DGX_SPARK_SSH_USER: ${{ secrets.DGX_SPARK_SSH_USER }}
+          NATS_SPARK_PASSWORD: ${{ secrets.NATS_SPARK_PASSWORD }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           CHANNEL_MONITOR_STATUS_SECRET: ${{ secrets.CHANNEL_MONITOR_STATUS_SECRET }}
           CLAUDE_SESSION_CHANNEL_ID: ${{ secrets.CLAUDE_SESSION_CHANNEL_ID }}

--- a/pmoves/chit/secrets_manifest.yaml
+++ b/pmoves/chit/secrets_manifest.yaml
@@ -1196,3 +1196,51 @@ entries:
   - file: env.tier-worker
     key: NATS_PASSWORD
   required: true
+- id: chit_signing_key
+  source:
+    type: cgp
+    label: CHIT_SIGNING_KEY
+  targets:
+  - file: .env.generated
+    key: CHIT_SIGNING_KEY
+  - file: env.tier-data
+    key: CHIT_SIGNING_KEY
+  required: false
+- id: chit_encryption_key
+  source:
+    type: cgp
+    label: CHIT_ENCRYPTION_KEY
+  targets:
+  - file: .env.generated
+    key: CHIT_ENCRYPTION_KEY
+  - file: env.tier-data
+    key: CHIT_ENCRYPTION_KEY
+  required: false
+- id: ollama_spark_base_url
+  source:
+    type: cgp
+    label: OLLAMA_SPARK_BASE_URL
+  targets:
+  - file: .env.generated
+    key: OLLAMA_SPARK_BASE_URL
+  - file: env.tier-llm
+    key: OLLAMA_SPARK_BASE_URL
+  required: false
+- id: dgx_spark_ssh_user
+  source:
+    type: cgp
+    label: DGX_SPARK_SSH_USER
+  targets:
+  - file: .env.generated
+    key: DGX_SPARK_SSH_USER
+  required: false
+- id: nats_spark_password
+  source:
+    type: cgp
+    label: NATS_SPARK_PASSWORD
+  targets:
+  - file: .env.generated
+    key: NATS_SPARK_PASSWORD
+  - file: env.tier-worker
+    key: NATS_SPARK_PASSWORD
+  required: false

--- a/pmoves/chit/secrets_manifest_v2.yaml
+++ b/pmoves/chit/secrets_manifest_v2.yaml
@@ -1621,3 +1621,66 @@ entries:
     key: INDEXER_NAMESPACE
   required: true
   tier: worker
+- id: chit_signing_key
+  source:
+    type: cgp
+    label: CHIT_SIGNING_KEY
+  targets:
+  - file: .env.generated
+    key: CHIT_SIGNING_KEY
+  - file: env.tier-data
+    key: CHIT_SIGNING_KEY
+  - github_secret: CHIT_SIGNING_KEY
+  - docker_secret: pmoves_chit_signing_key
+  required: false
+  tier: data
+- id: chit_encryption_key
+  source:
+    type: cgp
+    label: CHIT_ENCRYPTION_KEY
+  targets:
+  - file: .env.generated
+    key: CHIT_ENCRYPTION_KEY
+  - file: env.tier-data
+    key: CHIT_ENCRYPTION_KEY
+  - github_secret: CHIT_ENCRYPTION_KEY
+  - docker_secret: pmoves_chit_encryption_key
+  required: false
+  tier: data
+- id: ollama_spark_base_url
+  source:
+    type: cgp
+    label: OLLAMA_SPARK_BASE_URL
+  targets:
+  - file: .env.generated
+    key: OLLAMA_SPARK_BASE_URL
+  - file: env.tier-llm
+    key: OLLAMA_SPARK_BASE_URL
+  - github_secret: OLLAMA_SPARK_BASE_URL
+  - docker_secret: pmoves_ollama_spark_base_url
+  required: false
+  tier: llm
+- id: dgx_spark_ssh_user
+  source:
+    type: cgp
+    label: DGX_SPARK_SSH_USER
+  targets:
+  - file: .env.generated
+    key: DGX_SPARK_SSH_USER
+  - github_secret: DGX_SPARK_SSH_USER
+  - docker_secret: pmoves_dgx_spark_ssh_user
+  required: false
+  tier: data
+- id: nats_spark_password
+  source:
+    type: cgp
+    label: NATS_SPARK_PASSWORD
+  targets:
+  - file: .env.generated
+    key: NATS_SPARK_PASSWORD
+  - file: env.tier-worker
+    key: NATS_SPARK_PASSWORD
+  - github_secret: NATS_SPARK_PASSWORD
+  - docker_secret: pmoves_nats_spark_password
+  required: false
+  tier: worker

--- a/pmoves/docs/SECRETS_PIPELINE_REFERENCE.md
+++ b/pmoves/docs/SECRETS_PIPELINE_REFERENCE.md
@@ -182,6 +182,8 @@ SHA-256("ANTHROPIC_API_KEY") -> 12 bytes -> 3 floats [0, 1)
 | Anchor encryption | AES-GCM | `chit_security.py` |
 | Value encoding | Hex (base16) | `chit_encode_secrets.py` |
 
+> **Key Separation (PR #1275):** `chit/__init__.py` performs base16 hex encoding (NOT encryption). Actual signing (HMAC-SHA256) and encryption (AES-GCM) happen in `chit_security.py`. As of PR #1275, CHIT supports separated `CHIT_SIGNING_KEY` and `CHIT_ENCRYPTION_KEY` env vars with `CHIT_PASSPHRASE` fallback for both. This enables independent key rotation.
+
 ### CGP Packet Structure
 
 ```json

--- a/pmoves/env.shared.example
+++ b/pmoves/env.shared.example
@@ -321,6 +321,9 @@ CLOUDFLARE_LLM_MODEL=@cf/meta/llama-3.1-8b-instruct
 OLLAMA_CLOUD_BASE_URL=
 OLLAMA_CLOUD_API_KEY=
 
+# DGX Spark GPU Inference (GB10 Grace-Blackwell, 128GB unified memory)
+#OLLAMA_SPARK_BASE_URL=http://pmoves-dgx-spark:11434
+
 # Coding-plan lanes (for coding workflows, not general model-provider routing)
 GLM_CODING_PLAN_ENABLED=false
 ALIBABA_PRO_CODING_PLAN_ENABLED=false
@@ -481,6 +484,10 @@ CHIT_REQUIRE_SIGNATURE=false
 # you're using local.env.example instead of the CI artifact flow.
 CHIT_PASSPHRASE=
 
+# CHIT Key Separation (optional — falls back to CHIT_PASSPHRASE if not set)
+#CHIT_SIGNING_KEY=
+#CHIT_ENCRYPTION_KEY=
+
 # CHIT_PROD_* — Production enforcement overlay for docker-compose.yml services.
 # ┌─────────────────────────────────────────────────────────────────────────┐
 # │ WARNING: If CHIT_PROD_PASSPHRASE is empty, `docker compose up` will   │
@@ -553,6 +560,9 @@ NATS_TLS_CERT=${NATS_TLS_CERT:-/etc/nats/certs/client.crt}
 NATS_TLS_KEY=${NATS_TLS_KEY:-/etc/nats/certs/client.key}
 
 # Headscale Self-Hosted VPN (alternative to managed Tailscale)
+
+# DGX Spark NATS Leaf Node
+#NATS_SPARK_PASSWORD=
 # Parent PMOVES.AI includes a self-hosted Headscale control plane
 HEADSCALE_URL=${HEADSCALE_URL:-}
 HEADSCALE_PORT=8096
@@ -561,3 +571,7 @@ HEADSCALE_PORT=8096
 # KVM4-1_HOST=kvm4-1.internal    # API Gateway VPS
 # KVM4-2_HOST=kvm4-2.internal    # Data Services VPS
 # KVM2_HOST=exit.pmoves.io       # Exit Node VPS
+
+# DGX Spark Management (GB10 Workstation)
+#DGX_SPARK_SSH_USER=
+#DGX_SPARK_SSH_HOST=pmoves-dgx-spark

--- a/pmoves/mk/infra.mk
+++ b/pmoves/mk/infra.mk
@@ -144,6 +144,11 @@ fleet-rustdesk-fix: ## Fix KVM2 hbbs relay config (adds -r flag + restart)
 		&& echo "  hbbs: RECOVERED" || echo "  hbbs: STILL DOWN — check /fleet:rustdesk-check"
 
 fleet-enroll: ## Generate CHIT-signed enrollment token: make fleet-enroll ROLE=owner DEVICE="name"
+	@if [ -z "$${CHIT_PASSPHRASE}" ]; then \
+		echo "ERROR: CHIT_PASSPHRASE is required for fleet enrollment"; \
+		echo "Set it with: export CHIT_PASSPHRASE=your-passphrase"; \
+		exit 1; \
+	fi
 	@if [ -z "$(ROLE)" ] || [ -z "$(DEVICE)" ]; then \
 		echo "ERROR: ROLE and DEVICE are required."; \
 		echo "Usage:  make fleet-enroll ROLE=owner DEVICE=\"Pixel 10\""; \

--- a/pmoves/pyproject.toml
+++ b/pmoves/pyproject.toml
@@ -57,3 +57,8 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "@abstractmethod",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "cryptography",
+]

--- a/pmoves/services/voice-relay/main.py
+++ b/pmoves/services/voice-relay/main.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 
 from fastapi import FastAPI
 from nats.aio.client import Client as NATS
+from nats.js import JetStreamContext
 from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
 
 # Schema-validated envelope (available when services/common is on PYTHONPATH)
@@ -40,6 +41,9 @@ NATS_URL = get_secret("NATS_URL", "nats://nats:pmoves@nats:4222") or "nats://nat
 NATS_URL_REDACTED = re.sub(r"://[^@]+@", "://***@", NATS_URL)
 INPUT_SUBJECT = os.getenv("VOICE_RELAY_INPUT_SUBJECT", "agentzero.task.result.v1")
 OUTPUT_SUBJECT = os.getenv("VOICE_RELAY_OUTPUT_SUBJECT", "voice.agent.response.v1")
+JETSTREAM_ENABLED = os.getenv("VOICE_RELAY_JETSTREAM", "true").lower() in ("true", "1", "yes")
+JETSTREAM_STREAM = os.getenv("VOICE_RELAY_STREAM", "voice_relay")
+JETSTREAM_CONSUMER = os.getenv("VOICE_RELAY_CONSUMER", "voice_relay_worker")
 PORT = int(os.getenv("PORT", "8121"))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -56,6 +60,7 @@ ERRORS = Counter("voice_relay_errors_total", "Errors during relay processing")
 # Global state
 # ---------------------------------------------------------------------------
 _nc: NATS | None = None
+_js: JetStreamContext | None = None
 _nats_loop_task: asyncio.Task | None = None
 
 
@@ -107,8 +112,21 @@ async def _handle_message(msg) -> None:
         "meta": meta,
     }
 
+    js = _js
     nc = _nc
-    if nc and nc.is_connected:
+    if JETSTREAM_ENABLED and js:
+        payload = json.dumps(voice_event).encode("utf-8")
+        if envelope:
+            env = envelope(
+                OUTPUT_SUBJECT, voice_event,
+                correlation_id=data.get("task_id"),
+                source="voice-relay",
+            )
+            payload = json.dumps(env).encode("utf-8")
+        ack = await js.publish(OUTPUT_SUBJECT, payload, stream=JETSTREAM_STREAM)
+        RELAYED.inc()
+        logger.info("relayed task_id=%s text_len=%d js_seq=%s", data.get("task_id"), len(response_text), ack.seq)
+    elif nc and nc.is_connected:
         if envelope:
             env = envelope(
                 OUTPUT_SUBJECT, voice_event,
@@ -124,6 +142,13 @@ async def _handle_message(msg) -> None:
         ERRORS.inc()
         logger.warning("cannot publish — NATS not connected")
 
+    # JetStream ack for input message
+    if JETSTREAM_ENABLED and hasattr(msg, "ack"):
+        try:
+            await msg.ack()
+        except Exception:
+            pass
+
 
 # ---------------------------------------------------------------------------
 # NATS callback factory — avoids Ruff B023 (loop-variable closure capture)
@@ -132,9 +157,10 @@ def _make_nats_callbacks(nc_ref: NATS, disconnect_event: asyncio.Event):
     """Create NATS callbacks bound to a specific connection instance."""
 
     def _mark_lost(reason: str) -> None:
-        global _nc
+        global _nc, _js
         if _nc is nc_ref:
             _nc = None
+            _js = None
         if not disconnect_event.is_set():
             disconnect_event.set()
         logger.warning("nats connection lost: %s", reason)
@@ -150,10 +176,9 @@ def _make_nats_callbacks(nc_ref: NATS, disconnect_event: asyncio.Event):
 
 # ---------------------------------------------------------------------------
 # NATS resilience loop (mirrors publisher-discord pattern)
-# Design note: uses core NATS (not JetStream) intentionally — voice relay
-# events are ephemeral; a missed response during a reconnect is acceptable
-# for TTS playback, and JetStream adds consumer/stream lifecycle complexity.
-# Revisit if guaranteed delivery becomes a requirement.
+# Design note: JetStream enabled by default (VOICE_RELAY_JETSTREAM=true) for
+# guaranteed delivery. Falls back to core NATS if JetStream setup fails.
+# Set VOICE_RELAY_JETSTREAM=false to use core NATS (at-most-once, no acks).
 # ---------------------------------------------------------------------------
 async def _nats_resilience_loop() -> None:
     global _nc
@@ -182,7 +207,36 @@ async def _nats_resilience_loop() -> None:
         _nc = nc
         backoff = 1.0
         logger.info("NATS connected — subscribing to %s", INPUT_SUBJECT)
-        await nc.subscribe(INPUT_SUBJECT, cb=_handle_message)
+
+        # JetStream setup for guaranteed delivery
+        if JETSTREAM_ENABLED:
+            global _js
+            try:
+                js = nc.jetstream()
+                await js.add_stream(
+                    name=JETSTREAM_STREAM,
+                    subjects=[OUTPUT_SUBJECT],
+                    retention="limits",
+                    max_msgs=10000,
+                    max_age=3600,
+                )
+                await js.subscribe(
+                    subject=INPUT_SUBJECT,
+                    queue=JETSTREAM_CONSUMER,
+                    cb=_handle_message,
+                    manual_ack=True,
+                    durable=JETSTREAM_CONSUMER,
+                    ack_policy="explicit",
+                    max_deliver=3,
+                )
+                _js = js
+                logger.info("JetStream enabled: stream=%s consumer=%s", JETSTREAM_STREAM, JETSTREAM_CONSUMER)
+            except Exception as js_exc:
+                logger.warning("JetStream setup failed, falling back to core NATS: %s", js_exc)
+                _js = None
+                await nc.subscribe(INPUT_SUBJECT, cb=_handle_message)
+        else:
+            await nc.subscribe(INPUT_SUBJECT, cb=_handle_message)
 
         try:
             await disconnect_event.wait()


### PR DESCRIPTION
CHIT-aware secrets pipeline updates per AGNOTE4482 signoff checklist §3.

**Changes (+207/-7 across 9 files):**
- sync-secrets-local.yml: +5 CI secrets (CHIT_SIGNING_KEY, CHIT_ENCRYPTION_KEY, OLLAMA_SPARK_BASE_URL, DGX_SPARK_SSH_USER, NATS_SPARK_PASSWORD)
- secrets_manifest.yaml + v2: +10 entries (key separation + DGX Spark)
- env.shared.example: +4 sections (key sep, DGX Spark Ollama, NATS Spark, SSH management)
- pyproject.toml: dev optional deps with cryptography (fail-closed ImportError)
- infra.mk: fleet-enroll CHIT_PASSPHRASE validation gate
- chit-contract.yml: key separation awareness check
- SECRETS_PIPELINE_REFERENCE.md: key separation note + encoding clarification
- voice-relay/main.py: JetStream relay wiring fix

**Refs:** AGNOTE4482 signoff §3, SLSA-GRAPHITI L3 CHIT layer