### PR TITLE
fix(ci-runners): load env.shared as fallback in local_cert_runners.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,12 @@ NUL
 .worktrees/
 .claude/worktrees/
 
+
+# Root artifacts (docx conversion, PDFs, temp files)
+Wrote
+Simulation*.md
+Simulation*.pdf
+Simulation*.docx
+Holographic*.md
+PMOVES.AI Provisioning Bundle*.pdf
+.coverage

--- a/CATACLYSM_STUDIOS_INC/L2-DESIGN/charters/Infra_Cloud_Guild_Charter_v0.1.md
+++ b/CATACLYSM_STUDIOS_INC/L2-DESIGN/charters/Infra_Cloud_Guild_Charter_v0.1.md
@@ -1,0 +1,40 @@
+# Mission
+
+Operate a resident‑run cloud for AI services (OCR/RAG, media,
+assistants) using home nodes; convert demand from local businesses and
+creators into paid workloads and fair rewards.
+
+# Services (Initial)
+
+- Document OCR + RAG search for local businesses.
+
+- Media transcode + publish to community channels (Jellyfin/YouTube).
+
+- AI office hours for residents and vendors (automation, marketing,
+  finances).
+
+# Operator Pathway
+
+- Tier‑0 Learner → Tier‑1 Operator → Tier‑2 Lead (training + QA gates).
+
+- Hardware profiles: CPU‑only, GPU‑capable, storage‑heavy; containerized
+  stack (Docker Compose).
+
+- Security: per‑service sandboxing; vetted data handling; backups and
+  incident response.
+
+# Scoring & Rewards
+
+- Score = Uptime% × (GPU_hrs + CPU_hrs + Storage_GB) × QA_factor.
+
+- Epoch rewards: \$WORK (reputation) + \$CRED (spend credits); bonus
+  \$CAT when KPIs exceed targets.
+
+- Publishing: weekly operator leaderboard and payout report.
+
+# Budget Rails & KPIs
+
+- Budget: 45% of DAO inflows distributed across guilds by KPI.
+
+- KPIs: successful jobs, latency, QA pass‑rate, customer satisfaction,
+  revenue per node.

--- a/CATACLYSM_STUDIOS_INC/L2-DESIGN/charters/RPE_Topic_Synthesis_Appendix_v0.1.md
+++ b/CATACLYSM_STUDIOS_INC/L2-DESIGN/charters/RPE_Topic_Synthesis_Appendix_v0.1.md
@@ -1,0 +1,275 @@
+We applied lightweight embeddings + soft clustering to your research
+corpus (MD/DOCX/HTML). Clusters below reflect dominant themes to inform
+the proposal.
+
+![](media/image1.png){width="6.5in" height="3.65625in"}
+
+Figure: Topic coverage across the corpus.
+
+## Cluster 0
+
+Top terms: 000, roi, community, investment, months, payback, 11, token,
+local, 25
+
+• \*\*Young Adults\*\*: Technology leverage + social impact focus
+through digital collectives and urban agriculture\[\^11\]\[\^12\]
+\[Community Wealth Building Through Diverse Resident.md\]
+
+• Start with \*\*Young Adults\*\* and \*\*Community College Students\*\*
+who have high digital fluency and can become peer mentors for other
+groups.\[\^11\]\[\^25\] \[Community Wealth Building Through Diverse
+Resident.md\]
+
+• - Shared creative studio with AI tools and revenue sharing tokens\
+- Capitalizes on tech fluency and social media expertise\
+- High scalability serving local businesses and events\[\^11\]\[\^12\]
+\[Community Wealth Building Through Diverse Resident.md\]
+
+• \*\*Young Adults\*\* - \*\*Digital Content Creator Collective\*\*
+(7,992% ROI) \[Community Wealth Building Through Diverse Resident.md\]
+
+• \*\*Focus on local networks\*\* - build trust and adoption
+gradually\[\^6\]\[\^8\]\[\^20\]\
+4. \[5-Year Business Projections\_ AI + Tokenomics Model.md\]
+
+• \### \*\*Deliverables:\*\*\
+- A \*\*system blueprint\*\* covering architecture, technical design,
+and implementation details. \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+## Cluster 1
+
+Top terms: ai, contract, frontend, backend, blockchain, user, contracts,
+api, smart, voting
+
+• The architecture would remain the same, just the RPC endpoints and
+contract addresses change. \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• After deducting the appropriate voting power (simulated by
+\`lockTokens\`), the contract adds the \*raw vote count\* to the
+proposal's total. \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• Upon submission, the frontend calls \`createProposal\` on the DAO
+contract (user signs the tx). \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• The Node server might expose endpoints that the AI calls when it has
+results (e.g. \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• For example, if the user asked a question, the planner might route the
+answer to the TTS engine (H). \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• The member or an AI agent can then also initiate a corresponding group
+buy order: the frontend calls the backend \`POST /api/orders\` or
+directly the \`createGroupBuy\` on the smart contract.
+\[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+## Cluster 2
+
+Top terms: https, com, www, org, pdf, 10, article, php, index, view
+
+• \[\^38\]: https://risetpress.com/index.php/jcsse/article/view/592
+\[Community Wealth Building Through Diverse Resident.md\]
+
+• \[\^33\]: https://econjournals.com/index.php/ijeep/article/view/15699
+\[5-Year Business Projections\_ AI + Tokenomics Model.md\]
+
+• \[\^11\]:
+https://rayyanjurnal.com/index.php/jamparing/article/view/4993
+\[Containerized Micro Business Model\_ Docker-Like Sc.md\]
+
+• \[\^5\]:
+https://wsj.westscience-press.com/index.php/wsee/article/view/448
+\[5-Year Business Projections\_ AI + Tokenomics Model.md\]
+
+• \[\^9\]: https://ijc.ilearning.co/index.php/ATM/article/view/2363
+\[5-Year Business Projections\_ AI + Tokenomics Model.md\]
+
+• \[\^12\]:
+https://epress.lib.uts.edu.au/journals/index.php/cjlg/article/download/2413/2649
+\[Community Wealth Building Through Diverse Resident.md\]
+
+## Cluster 3
+
+Top terms: ai, files, file, https, supabase, code, like, text, web, com
+
+• For example, a \`security.yml\` might define:\
+\`\`\`yaml\
+services:\
+tls-proxy:\
+image: nginx:latest\
+ports:\
+- \"443:443\"\
+volumes:\
+- ./ssl:/etc/ssl \# mount your SSL certs\
+environment:... \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• The communication between services is secured -- e.g., the Supabase
+REST endpoint is HTTPS with an API key required, and we may run an Nginx
+reverse proxy to terminate TLS for local services that don't support it
+natively (\[POWERFULMOVES v2.... \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• For example, after performing speech-to-text (STT) on audio input, the
+Jetson could send an HTTP request with a JSON payload to the Supabase
+REST endpoint, which writes to a table (\[Integrating Supabase Database
+with POWERFULMOVES A.md\](fil... \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• As the project grows, we will continue to refine each module (for
+example, upgrading AI models for better reasoning efficiency -- already
+version 2.0 shows \*\*3.9× efficiency and 72% latency improvement\*\*
+over the initial version (\[POWERFULMO... \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• In our architecture, this is handled via the \*\*Hardware-Aware
+Router\*\* (the "Input Router" B in Perception layer, and the "Compute
+Router" in the v2 diagram) which decides where to send tasks
+(\[POWERFULMOVES v2.0\_ Next-Generation Modular AI...
+\[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• def forward(self, x):\
+for \_ in range(self.max_depth):\
+x = self.recurrent_block(x)\
+if self.iteration_controller.should_halt(x):\
+break \# exit early if result is confident\
+return x\
+\`\`\`\
+\*... \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+## Cluster 4
+
+Top terms: file, model, text, ai, md, supabase, database, 20,
+architecture, community
+
+• On Jetson, an \*\*EfficientNet-B0\*\* or similar lightweight model
+runs at modest FPS for object recognition (\[Integrating Supabase
+Database with POWERFULMOVES
+A.md\](file://file-R4SKbWQxEDLRFL5CpyApNM#:\~:text=)), while the Windows
+PC can run a ... \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• For example, when the Jetson Nano processes audio via speech-to-text,
+it could send the transcribed text and some metadata to a
+\`sensor_data\` or \`transcripts\` table in Supabase via a REST endpoint
+(\[Integrating Supabase Database with POWERF... \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• Devices communicate with the database and backend over HTTPS with API
+keys (\[Integrating Supabase Database with POWERFULMOVES
+A.md\](file://file-R4SKbWQxEDLRFL5CpyApNM#:\~:text=)).
+\[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• We also utilize hardware security modules where possible (TPM 2.0 on
+the Windows PC for storing keys) (\[PMOVES_Core Architecture
+Layers.md\](file://file-EBcmZsLhM9bRqYWuQQAU51#:\~:text=,0%20storage%20on%20Windows)).
+\[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• void loop() {\
+// Example: insert a temperature reading\
+int status = db.insert(\"sensor_data\",
+\"{\\\"device_id\\\":\\\"esp32-01\\\",\\\"temp\\\":25.4}\");\
+delay(1000);\
+}\
+\`\`\`\
+\*ESP32 sending data to Supabase (pseudo-code) (\[Integrating Supabase
+Data... \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• The Jetson's STT engine transcribes this to text "check if we need
+more rice" (\[Integrating Supabase Database with POWERFULMOVES
+A.md\](file://file-R4SKbWQxEDLRFL5CpyApNM#:\~:text=)).
+\[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+## Cluster 5
+
+Top terms: ai, design, food, group, solidity, diagram, file, buying,
+\_orderid, contract
+
+• Below is the simplified Solidity code for the group buying mechanism,
+with annotations explaining each part: \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• Below is an illustrative Solidity snippet for the governance contract:
+\[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• \*\*Architecture Layers:\*\* The AI's internal design can be
+visualized in the following diagram: \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• - \*\*Task Planner / Orchestrator:\*\* This component (G in the first
+AI diagram) decides what to do with the output of the reasoning engine.
+\[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• (In many cases, the frontend can interact directly with the
+blockchain, but the backend is useful for off-chain services or as a
+trusted relay for certain operations.) \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• Below is a conceptual diagram of the key components and their
+interactions: \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+## Cluster 6
+
+Top terms: community, local, models, enterprises, wealth, token,
+service, building, businesses, cooperative
+
+• When residents develop enterprises that serve their community, money
+circulates \*\*2-4 times more\*\* than traditional employment
+models.\[\^4\]\[\^5\]\[\^6\]\[\^7\] \[Community Wealth Building Through
+Diverse Resident.md\]
+
+• 14% for traditional employment\[\^4\]\[\^20\]\
+- \*\*Money velocity\*\*: 3.2 annual circulation cycles\
+- \*\*Community retention rate\*\*: 85% average across all enterprise
+models\
+- \*\*Local supplier development\*\*: 40% increase in
+community-to-community tr... \[Community Wealth Building Through Diverse
+Resident.md\]
+
+• Your vision perfectly aligns with \*\*micro-franchising\*\* and
+\*\*platform cooperativism\*\* models that create replicable, scalable
+business \"containers\" owned by community
+members\[\^1\]\[\^2\]\[\^3\]\[\^4\]. \[Docker-Style Scalable Community
+Business Container.md\]
+
+• \*\*Distribution & Reward:\*\* Members receive their rice when it's
+delivered. \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• Each successful container becomes a template for deployment in other
+communities, creating a \*\*federated network of community-owned
+enterprises\*\*. \[Docker-Style Scalable Community Business
+Container.md\]
+
+• \# Containerized Micro Business Model: Docker-Like Scaling for
+Community Enterprises \[Containerized Micro Business Model\_ Docker-Like
+Sc.md\]
+
+## Cluster 7
+
+Top terms: ai, data, contract, use, entropy, backend, jetson, local,
+order, token
+
+• This contract ensures transparency in pooling funds and only executes
+the payment when the threshold is reached. \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• A supply limit variable is present in the smart contract to enable
+closing the initial offering after 360 days if the supply limit is not
+reached. \[Agent Zero Project Paper.html\]
+
+• The Node backend picks this up and marks order #5 as "completed" in
+the DB. \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• Throughout this process, the AI agent might assist (perhaps announcing
+via speakers "The rice order has been fully funded and is being
+processed!" when it detects the event, or updating a screen in a
+community center). \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]
+
+• Since funds are held in the contract until execution, the code must be
+carefully reviewed for re-entrancy (here we use a simple call and
+immediately mark completion, minimizing risk). \[POWERFULMOVES_and
+TOKENOMICS_DETAILS.md\]
+
+• Suppose it finds the inventory is below a threshold -- this
+information (perhaps already present in the knowledge graph from IoT
+weight sensors) leads the AI to decide that a new group-buy should be
+proposed. \[POWERFULMOVES_and TOKENOMICS_DETAILS.md\]

--- a/CATACLYSM_STUDIOS_INC/L2-DESIGN/constitution/Cataclysm_DAO_Constitution_v0.1.md
+++ b/CATACLYSM_STUDIOS_INC/L2-DESIGN/constitution/Cataclysm_DAO_Constitution_v0.1.md
@@ -1,0 +1,51 @@
+# Purpose
+
+Empower Fordham Hill and neighboring communities with a resident‑owned,
+AI‑enabled economy that circulates value locally and builds durable,
+creative livelihoods.
+
+# Houses & Voting
+
+- Token House (Capital): holders of \$CAT vote on strategy, treasury
+  caps, partnerships, risk policies.
+
+- Citizen House (Contributors): residents with \$WORK (reputation SBT)
+  vote on priorities, grants, vendor lists, day‑to‑day.
+
+- Bicameral Rule: proposals pass when both houses meet quorum and
+  approval thresholds.
+
+# Proposal Types & Thresholds
+
+- A‑Type (Strategy/Treasury \> \$25k): 7‑day vote; quorum 20% Token +
+  25% Citizen; pass at 60% each.
+
+- B‑Type (Programs/Budgets ≤ \$25k): 5‑day vote; quorum 15% Token + 20%
+  Citizen; pass at 55% each.
+
+- C‑Type (Grants ≤ \$10k; Listings): 3‑day vote; quorum 10% Token + 15%
+  Citizen; pass at 50% each.
+
+# Delegation & Roles
+
+- Delegation: both houses support delegated voting; delegates must
+  publish a platform and quarterly reports.
+
+- Stewards: 1--3 per guild; accountable to quarterly KPIs and budget
+  rails; recallable by C‑Type vote.
+
+# Treasury & Controls
+
+- Safe multisig: 3‑of‑5 signers (1 board, 2 stewards, 2 community).
+
+- Epoch rewards: transparent schedules for \$WORK and \$CRED; monthly
+  financials published.
+
+- Emergency brake: circuit‑breaker pause by 4‑of‑5 signers; requires
+  A‑Type ratification within 7 days.
+
+# Amendments & Audits
+
+- Amendments: A‑Type with 2‑week comment period.
+
+- Annual external audits for treasury and security; public reports.

--- a/CATACLYSM_STUDIOS_INC/L2-DESIGN/proposals/Cataclysm_Studios_DAO_Fordham_Hill_Proposal_v0.1.md
+++ b/CATACLYSM_STUDIOS_INC/L2-DESIGN/proposals/Cataclysm_Studios_DAO_Fordham_Hill_Proposal_v0.1.md
@@ -1,0 +1,96 @@
+*A resident‑owned, AI‑powered cooperative model that outperforms
+traditional project delivery on revenue, jobs, and local wealth
+retention.*
+
+# Executive Summary
+
+- Objective: Present a community‑owned alternative that complements
+  ACE's traditional plan with faster pilots, stronger participation, and
+  transparent economics.
+
+- Approach: Parent DAO with three guilds (Infra & Cloud, Creator, Wealth
+  & Learning), two‑house governance (capital + contributors), and a
+  stable community credit rails for pre‑orders and services.
+
+- Result (5‑year view): Tokenomics model yields \~3.25× revenue and
+  \~4.4× profit vs. traditional, with more jobs and households served
+  (illustrative figures below).
+
+![](media/image1.png){width="6.5in" height="3.65625in"}
+
+Figure: Fordham Hill 5‑year revenue & profit comparison --- Tokenomics
+vs. traditional.
+
+# Structure at a Glance
+
+- Parent DAO (Cataclysm Studios DAO): constitution, treasury, brand,
+  risk & compliance.
+
+- Infra & Cloud Guild (resident‑run nodes): OCR/RAG, media
+  transcode/publish, AI assistants; proof‑of‑service rewards;
+  marketplace for local workloads.
+
+- Creator Guild: music/AI video/art pods; on‑chain revenue splits;
+  events & merch fueled by pre‑orders.
+
+- Wealth & Learning Guild: micro‑business incubator (pre‑order tokens),
+  AI upskilling, financial literacy, local vendor onboarding.
+
+# Token Suite & Governance
+
+- \$CAT --- Governance (ERC‑20): elect stewards, approve budgets,
+  strategy votes.
+
+- \$WORK --- Reputation (SBT): non‑transferable 'proof of work' for
+  residents/operators; unlocks roles and citizen‑house voting weight.
+
+- \$CRED --- Community Credits (stable, spend‑limited): earned by
+  residents; redeemed with approved vendors/services; keeps value
+  circulating locally.
+
+- Two‑House Voting: Token House (\$CAT) + Citizen House (\$WORK). A
+  decision passes when both approve (e.g., 50%+ and 60%+).
+
+# 90‑Day Rollout
+
+- Days 0--14: Spin up Safe (multisig), Snapshot, draft 2‑page
+  constitution + guild charters; recruit 5--10 node operators.
+
+- Days 15--45: Turn on 3 paid services (OCR/RAG, media transcodes, AI
+  office hours); launch Creator Pod #1 (single + AI video).
+
+- Days 46--90: Publish first KPI report; Seed Grants #1 for youth/vendor
+  pilots; onboard 10 more nodes; ratify initial \$CAT distribution.
+
+# KPIs & Transparency
+
+- Infra: jobs served, uptime, GPU/CPU hours, QA pass‑rate; weekly
+  operator rewards report.
+
+- Creator: releases/quarter, streams/views, merch gross, collaborator
+  payouts.
+
+- Wealth & Learning: residents trained, preorder volume, vendor count,
+  household savings.
+
+- Treasury: monthly inflows/outflows; epoch reward schedules; public
+  dashboards.
+
+![](media/image2.png){width="6.5in" height="3.65625in"}
+
+Figure: Topic coverage across your research corpus (clusters found via
+lightweight embeddings).
+
+# Calls to Action (Meeting Ask)
+
+- Approve 90‑day pilot with a minimal budget and milestone gates
+  (board).
+
+- Nominate 3 resident stewards (one per guild) and 2 business advisors
+  (board & residents).
+
+- Green‑light Home‑Node Program (5--10 nodes) and Creator Pod #1
+  (residents & creators).
+
+- Authorize community credits pilot (\$CRED) for pre‑orders with 3 local
+  vendors (businesses).

--- a/CATACLYSM_STUDIOS_INC/L5-LEGENDARY/dao-audit/Organizational Audit & Recommendations/Google Drive Deep Dive & Accuracy Check.md
+++ b/CATACLYSM_STUDIOS_INC/L5-LEGENDARY/dao-audit/Organizational Audit & Recommendations/Google Drive Deep Dive & Accuracy Check.md
@@ -1,0 +1,566 @@
+# Comprehensive Governance, Economic, and Technical Audit of the Cataclysm Studios DAO Ecosystem
+
+The transition of Cataclysm Studios from a traditional S-corp into a
+decentralized autonomous organization (DAO) represents a complex
+convergence of legal innovation, economic redesign, and technical
+infrastructure hardening. This report provides an exhaustive deep dive
+into the current organizational state of the project, an accuracy review
+of its foundational analysis documents, and strategic recommendations
+for achieving long-term sustainability and regulatory compliance. The
+shift toward a resident-owned, AI-powered cooperative model requires not
+only the deployment of smart contracts but also the creation of a robust
+\"legal wrapper\" and a highly organized information governance
+framework to manage institutional partnerships and community trust \[,
+S_W45, S_W23\].
+
+## Information Governance and Workspace Organization Audit
+
+The digital workspace of Cataclysm Studios, currently hosted on Google
+Drive, serves as the primary repository for intellectual property,
+strategic planning, and legal documentation. A systematic review of this
+environment reveals a high concentration of visionary material but
+identifies significant risks regarding document fragmentation,
+versioning inconsistency, and the existence of duplicate files that
+could impede a formal legal or technical audit\].
+
+### Current State and Redundancy Analysis
+
+An audit of the existing file structure indicates that critical
+components of the \"DAO Readiness\" are often nested within larger,
+multi-purpose documents rather than standing as independent, easily
+accessible records. For instance, search results for \"Constitution\"
+and \"Proposal\" initially failed because these frameworks are embedded
+within pitch decks such as the Fordham Hill Board Decks. Furthermore,
+the repository contains duplicate versions of primary strategic assets,
+which creates a \"source of truth\" conflict for stakeholders.
+
+  -------------------------------------------------------------------------
+  Document Title            Identified Versions     Status/Risk
+  ------------------------- ----------------------- -----------------------
+  Fordham_Hill_Board_Deck   v0.2 (2 copies), v0.5   Redundancy risk; v0.5
+                                                    should be the master
+
+  PMOVES DAO                Created 2026-01-07      Placeholder file; needs
+                                                    content population
+
+                            Tokenomics &            Created 2026-01-29
+                            Cooperative Model       
+
+  Grant Application Master  Master Suite            Fragmented across chat
+                                                    logs and markdown files
+
+  Identity & Access         2026 Version            Technical baseline;
+  Strategy                                          needs alignment with
+                                                    DAO LLC OpAgreement
+  -------------------------------------------------------------------------
+
+The presence of identical copies of version 0.2 of the Board Deck,
+alongside a newer version 0.5, suggests that the current organizational
+culture has yet to adopt a centralized version control system. For a
+DAO, where the \"governance-by-code\" philosophy extends to
+documentation, this lack of clarity can lead to \"governance debt,\"
+where members vote on outdated information or legal counsel reviews the
+wrong iteration of a constitution\].
+
+### Proposed Optimized Organization Framework
+
+To mitigate these risks, the organization must move toward a thematic,
+permission-tiered structure. This is not merely a matter of convenience;
+it is a prerequisite for the SOC 2 Type II audits and legal reviews
+planned for 2026. The proposed structure below categorizes assets by
+their functional role in the DAO's lifecycle, ensuring that legal
+personhood, economic logic, and technical code are clearly demarcated.
+
+  -----------------------------------------------------------------------
+  Proposed Folder         Core Contents           Strategic Rationale
+  ----------------------- ----------------------- -----------------------
+  **01 Governance &       Ratified Constitution,  Establishes the \"Rule
+  Constitution**          Guild Charters, Voting  of Law\" for the
+                          Records                 community \[, S_W4\]
+
+  **02 Legal &            Wyoming DAO LLC         Protects individual
+  Compliance**            Filings, Benefit LLC    members from personal
+                          Paperwork, IP           liability
+                          Assignments             
+
+  **03 Tokenomics &       \$CAT/\$WORK/\$CRED     Documents the
+  Economics**             models, Shape           value-flow and
+                          Attribution protocols   incentive alignment
+
+  **04 Technical          Zero-retention          Proves the technical
+  Infrastructure**        blueprints, IAM         guarantees of privacy
+                          strategy, Repository    
+                          links                   
+
+  **05 Strategy &         Grant Application       Guides external
+  Proposals**             Master, Pilot Roadmap,  fundraising and
+                          Vision Decks            community expansion
+
+  **06 Community          Residents Decks,        Bridges the gap between
+  Outreach**              Training Toolkits,      technology and adoption
+                          Local Vendor MOUs       
+  -----------------------------------------------------------------------
+
+Adopting this structure will facilitate the \"Grant Sprint\" planned for
+early 2026 by providing a single point of entry for grant-makers (such
+as the NSF or UN) to review technical and social impact claims.
+Moreover, it supports the \"Offline Pack\" logic identified in the
+workspace, ensuring that even in low-connectivity disaster zones (like
+the St. Maarten use case), the community has access to its foundational
+governance laws \[, S_W77\].
+
+## Accuracy Audit of the DAO Governance & Readiness Analysis
+
+The \"DAO Governance & Readiness Analysis for Cataclysm Studios\" serves
+as the primary diagnostic tool for the project's transition. A deep-dive
+review of this document against the broader workspace snippets reveals
+that while the document is highly accurate in its structural assessment,
+it contains omissions regarding recent technical developments and
+specific financial metrics found in more recent files.
+
+### Verification of Governance and Institutional Findings
+
+\`\` accurately identifies the bicameral voting system and the role of
+the \$CAT and \$WORK tokens as a mechanism to balance capital and labor
+\[, S_W2, S_W53\]. It correctly highlights that the project is in a
+state of transition from an S-corp to a Wyoming DAO LLC and a Benefit
+LLC \[, S_W45\]. However, the document notes that the \"other guild
+charters\" (Creator and Wealth & Learning) are \"to be added\".
+
+In reality, the workspace already contains detailed mandates for these
+guilds that extend beyond the summary in \`\`. For example, the Wealth &
+Learning guild is already defined as a \"micro-business incubator\" with
+specific KPIs related to AI upskilling and vendor onboarding. The
+Creator guild\'s charter is already linked to the cultural identity of
+\"DARKXSIDE\" and the management of \"Creator Pods\". The readiness
+document should be updated to reflect that these charters are in v0.1
+draft form rather than simply missing.
+
+### Financial and Filing Accuracy
+
+One critical area where requires more granularity is in the legal filing
+costs and the specific mechanism of the asset transfer. mentions that
+legal entity setup is incomplete. More recent data in the \"PMOVES
+restructure chat\" provides exact figures and timelines that should be
+integrated into the readiness analysis to provide a more \"audit-ready\"
+view.
+
+  -----------------------------------------------------------------------
+  Data Point              Description in          Verified Reality in
+                                                  Snippets
+  ----------------------- ----------------------- -----------------------
+  Wyoming DAO LLC Cost    Not Specified           \$100 filing fee; \$60
+                                                  annual fee
+
+  Benefit LLC Location    Not Specified           NY or Delaware
+
+  Benefit LLC Filing Fee  Not Specified           \$200 -- \$500
+
+  Asset Transfer Method   Legal review needed     F-reorganization
+                                                  planned to avoid
+                                                  capital gains
+
+  \$CAT Distribution      Described in general    Specific 40/25/20/10/5
+                                                  split is confirmed
+  -----------------------------------------------------------------------
+
+The omission of these specific costs and the \"F-reorganization\"
+strategy in \`\` is a significant oversight for a document intended for
+\"Readiness Analysis.\" These details are vital for the 90-day execution
+plan, particularly in Phase 1 (Weeks 1-2) where the legal foundation is
+laid.
+
+### Technical and Security Accuracy
+
+correctly aligns with the \"PMOVES.AI Identity & Access Strategy 2026\"
+regarding the use of WorkOS and the zero-retention architecture \[,
+S_W34, S_W62\]. It accurately reflects the 3-of-5 Gnosis Safe multisig
+requirement and the \"Emergency Brake\" circuit breaker mechanism \[,
+S_W28, S_W30\]. One point of clarification for the readiness doc is the
+status of the \"SOC 2 Type II audit.\" While mentions audits generally,
+the project specifically targets Months 5-8 for this certification,
+which is a major milestone for humanitarian sector compliance.
+
+## The Bicameral Governance Model: A Sociological and Economic Analysis
+
+The governance model proposed by Cataclysm Studios is a sophisticated
+response to the \"Whale Problem\" that plagues many decentralized
+systems. By separating voting power into a Token House and a Citizen
+House, the project creates a \"Proof of Effort\" check on the \"Proof of
+Stake\". This design ensures that those who contribute physical labor
+and local infrastructure (node operators) have a meaningful veto over
+the high-level capital-driven decisions.
+
+### The Token House (\$CAT): Strategic Sovereignty
+
+The Token House, utilizing the \$CAT governance token, acts as the
+DAO\'s \"Senate.\" It is composed of stakeholders who have a long-term
+financial interest in the success of the ecosystem. The 100 million
+\$CAT tokens are distributed to ensure that no single entity can
+unilaterally control the project while providing enough liquidity to
+incentivize strategic partners.
+
+The rights of \$CAT holders are strictly defined around strategic and
+financial oversight:
+
+- **Budgetary Approval:** All allocations exceeding \$25,000 must pass a
+  Type B or A vote in the Token House \[, S_W22, S_W23\].
+
+- **Treasury Management:** The multi-sig treasury (Safe) is accountable
+  to \$CAT holders for major asset movements and emergency actions.
+
+- **Partnership Ratification:** Decisions to bring on global partners
+  like the UN or OID Inc. require the endorsement of capital
+  stakeholders to ensure alignment with the DAO\'s long-term
+  sustainability.
+
+By using quadratic voting and vote-escrow mechanics, the \$CAT system
+discourages short-term speculation. This is particularly relevant for
+the project\'s aim of raising \$500,000 to \$1M in its first year
+through a mix of grants and strategic pre-sales.
+
+### The Citizen House (\$WORK): Operational Meritocracy
+
+The Citizen House is governed by the \$WORK token, which is
+non-transferable and soulbound to the contributor\'s identity. This
+chamber acts as the \"House of Representatives,\" representing the
+residents and operators who keep the mesh network running on the ground
+at sites like Fordham Hill.
+
+The earning mechanics for \$WORK are designed to reflect the \"Entropy
+Reduction\" theory mentioned in the strategic audit---where value is
+defined by actions that bring order and clarity to the community.
+
+- **Proof of Service:** Running a node for 30 days earns 100 \$WORK,
+  creating a direct link between infrastructure uptime and governance
+  influence.
+
+- **High-Stakes Deployment:** Deploying an OpenMANET node in a disaster
+  zone (such as the St. Maarten recovery project) grants 500 \$WORK,
+  reflecting the higher risk and value of that labor.
+
+- **Operational Roles:** Reaching 2,000 \$WORK is the required threshold
+  to run for a Steward position, ensuring that only experienced
+  contributors lead the guilds.
+
+This bicameral split addresses the \"Free Rider\" problem. In
+traditional corporations, labor is a cost to be minimized. In the
+Cataclysm DAO, labor is the mechanism through which governance power is
+earned, making the community \"owners\" of the infrastructure they
+operate.
+
+## Advanced Tokenomics: The Tri-Token Suite and the Shape Attribution Protocol
+
+The project\'s economic model is built on the \"Iceberg Model,\" which
+distinguishes between the visible technical assets (the 10G lab, the
+global KVM backbone) and the invisible value generated by community
+interactions and AI-driven \"entropy reduction\". The tri-token suite
+(\$CAT, \$WORK, \$CRED) is the engine that captures this value and
+prevents it from being extracted by external shareholders.
+
+### The Shape Attribution Protocol
+
+The most innovative aspect of the Cataclysm economy is the \"Shape
+Attribution Protocol.\" This system moves away from \"labor-centric\"
+economics toward a mathematical model of value based on entropy.
+
+- **Mechanism:** Contributions are evaluated based on how much they
+  \"reduce entropy\" (i.e., solve problems, provide clarity, or increase
+  the order of the system).
+
+- **Implementation:** A resident processing local business data through
+  a node is reducing entropy for that business. The system
+  mathematically assigns credit for this order-creation, which is then
+  paid out in \$CRED or \$WORK.
+
+- **Implication:** This prevents the \"speculative bubble\" effect often
+  seen in crypto. If a token\'s value is tied to the actual reduction of
+  entropy (useful work) rather than mere hype, the economy remains
+  grounded in reality.
+
+### \$CRED: The Local Economic Engine
+
+\$CRED is designed as a stable, spend-limited local currency. It is not
+intended to trade on open exchanges but to circulate within
+micro-economies like Fordham Hill to increase local purchasing power.
+
+  -----------------------------------------------------------------------
+  Feature                 \$CRED Functionality    Strategic Purpose
+  ----------------------- ----------------------- -----------------------
+  **Peg**                 1:1 with USD (backed by Ensures price stability
+                          USDC)                   for residents\]
+
+  **Backing**             Fully collateralized in Mitigates the risk of
+                          DAO Treasury            currency collapse
+
+  **Spend-Limits**        Only redeemable at      Forces value to
+                          approved vendors        circulate locally
+                                                  (3.32x multiplier)
+
+  **Earnings**            100 \$CRED/month for    Provides a predictable
+                          node operation          \"UBI-like\" reward for
+                                                  labor
+  -----------------------------------------------------------------------
+
+The five-year projection for Fordham Hill illustrates the power of this
+model. By using \$CRED and a \"Bulk-Purchase-Delivery Container,\" the
+project aims to save residents 25% on groceries while generating \$43.2
+million in local economic impact. This is a 4.4x increase in profit
+retention compared to traditional management models where maintenance
+fees and vendor profits leak out of the community.
+
+## Legal Restructuring: Navigating the \"Dual-Entity\" Paradigm
+
+The transition from Cataclysm Studios Inc. (an S-corp) to a Wyoming DAO
+LLC and a Benefit LLC is a proactive strategy to balance decentralized
+governance with the \"real-world\" requirements of liability protection
+and institutional contracting.
+
+### The Wyoming DAO LLC: The Sovereign Core
+
+The choice of Wyoming for the DAO LLC is strategically sound due to the
+state\'s pioneering legal recognition of DAOs as a specific type of LLC.
+
+- **IP and Brand Sovereignty:** The Wyoming DAO LLC will be the ultimate
+  owner of the PMOVES.AI codebase, the CHIT patents, and the Cataclysm
+  brand. This ensures that the \"Technical Soul\" of the project is
+  owned by the community, not a group of founders.
+
+- **Liability Shield:** Without a legal entity, DAO members could be
+  viewed as a \"general partnership,\" exposing them to personal
+  liability for the DAO\'s actions. The LLC structure provides the
+  \"corporate veil\" necessary for residents to safely host nodes in
+  their homes\].
+
+- **Operating Agreement as Code:** The 2024 update to Wyoming\'s law
+  allows for the DAO\'s smart contracts and Snapshot voting rules to be
+  directly referenced in its legal Operating Agreement\].
+
+### The PMOVES Operations Benefit LLC: The Institutional Interface
+
+The Benefit LLC acts as the \"operational arm\" that is 100% owned by
+the DAO. This separation is crucial for high-stakes partnerships with
+the UN or the World Bank.
+
+- **Grants and Contracts:** Institutional grant-makers often require a
+  \"Social Enterprise\" or \"Benefit Corporation\" status to satisfy
+  their own compliance mandates. The Benefit LLC serves this purpose
+  while funneling 100% of profits back to the DAO treasury.
+
+- **Employment and Physical Ops:** The Benefit LLC handles the \"messy\"
+  reality of hiring staff, signing leases for lab space, and paying
+  taxes in jurisdictions like New York.
+
+- **The F-Reorganization:** This tax strategy is planned to facilitate
+  the transition from the old S-corp. If successful, it allows for a
+  tax-free transfer of assets to the new entities, preserving capital
+  for the 2026 pilot deployments.
+
+One significant legal \"Red Flag\" identified in the analysis is the
+status of the \$CAT token as a potential security. The project has
+correctly budgeted for a specialized token lawyer in Month 2 of the 2026
+plan to address this. Given the utility-heavy nature of \$CAT
+(governance and access control) and the absence of dividend rights, the
+project is positioning the token as a utility instrument, which a formal
+legal opinion will need to solidify \[, S_W3, S_W13\].
+
+## Technical Architecture and the Zero-Retention Framework
+
+The PMOVES.AI engine is the \"Technical Soul\" of the Cataclysm
+ecosystem. Its primary technical differentiator is \"Provably Private
+Compute\" (PPC), which replaces the \"trust-us\" promises of centralized
+AI with a technical guarantee of data destruction.
+
+### The Zero-Retention Stack
+
+The project utilizes a multi-layered stack to ensure that sensitive user
+data is never stored on disk. This is a critical requirement for the UN
+and medical mission use cases where data breaches could have
+life-or-death consequences.
+
+- **Firecracker MicroVMs:** Each user request is processed in an
+  ephemeral, hardware-isolated sandbox. These are \"Firecracker\" VMs
+  that are created and destroyed for every single transaction.
+
+- **Venice.ai Integration:** For high-performance inference that exceeds
+  local edge node capacity, the system offloads to Venice.ai, which
+  provides private, uncensored access to large models.
+
+- **E2B Sandboxing:** Tool execution by AI agents (such as code
+  interpretation or data processing) occurs within isolated E2B
+  sandboxes. This prevents \"hallucinations\" or malicious code from
+  affecting the host node.
+
+- **NATS Messaging Bus:** The entire system is orchestrated through a
+  NATS \"JetStream\" backbone, which allows for horizontal scaling and
+  fault isolation between different microservices like Agent Zero and
+  Archon.
+
+### Identity and Access Management (IAM) 2026
+
+The IAM strategy for 2026 emphasizes a \"Buy\" approach using WorkOS to
+manage the dual identities of B2C and B2B users.
+
+- **Zero-Trust Networking:** The system uses a self-hosted Headscale
+  control plane and WireGuard tunnels. This eliminates the risk of
+  third-party vendors (like Tailscale or Cloudflare) having access to
+  the encryption keys.
+
+- **Progressive Disclosure:** To prevent \"Context Pollution\" for AI
+  agents, the system uses a \"Progressive Disclosure\" model. Agents
+  only retrieve specific \"pivot files\" (SKILL.md) when needed,
+  ensuring data is not unnecessarily exposed across the entire mesh.
+
+- **Hierarchical Agent Roles:** Safety is maintained through a hierarchy
+  of models. \"Haiku\" acts as a low-latency \"Auditor\" to check
+  commands for safety before the more powerful \"Opus\" model executes
+  them.
+
+This technical depth is what allows the project to claim it is building
+\"provably private\" infrastructure. The pmoves-ppc-audit toolkit is
+intended to be open-sourced so that third parties can verify these
+claims independently---a key success metric for the Month 1-4 validation
+phase.
+
+## Strategic Roadmap and 2026 Funding Strategy
+
+The project\'s success hinges on a 12-month grant period divided into
+three concurrent workstreams: legal foundation, technical validation,
+and pilot community deployments.
+
+### 90-Day Execution Roadmap: Fordham Hill Pilot
+
+The immediate focus is the 90-day rollout at Fordham Hill, which serves
+as the \"crucible\" for the entire DAO model.
+
+  ---------------------------------------------------------------------------
+  Phase             Duration          Key Milestones    Status/Deliverables
+  ----------------- ----------------- ----------------- ---------------------
+  **Phase 1**       Days 0--14        Multi-sig (Safe)  Constitution
+                                      setup; Snapshot   ratified; 5-10
+                                      deployment        operators recruited
+
+  **Phase 2**       Days 15--45       Activation of AI  Revenue generation
+                                      services (OCR,    begins; Creator Pod
+                                      Transcoding)      #1 launch
+
+  **Phase 3**       Days 46--90       Seed Grants       First impact report;
+                                      distribution; KPI \$CAT distribution
+                                      Reporting         ratified
+  ---------------------------------------------------------------------------
+
+This phase is critical for validating the \"Bulk-Purchase\" business
+container logic, which is the primary source of the projected 25%
+savings on groceries for residents.
+
+### 2026 Global Funding Tracks
+
+To scale beyond the Bronx, the organization has identified three major
+funding tracks for 2026.
+
+- **NYC Digital Equity (Feb 2026):** Targeting the Q2L NYC Public School
+  pilot with a \$3,116 budget to enable linguistic equity for English
+  Language Learner families.
+
+- **Higher Education Research (Mar 2026):** A \$3,550 pilot for the UNCG
+  Nursing School node to build medical AI training infrastructure.
+
+- **UNFCU Foundation Grant (June 2026):** A strategic push for \$25,000
+  to \$50,000 to support refugee livelihood training and digital
+  literacy.
+
+These small, tactical pilots are designed to build the \"Social Proof\"
+necessary to secure larger federal and international grants. The
+organization\'s ultimate funding goal for Year 1 is \$500,000, which
+includes a target of \$275,000 from the NSF SBIR Phase I for
+humanitarian AI.
+
+## Integrated Recommendations for Achieving \"DAO Readiness\"
+
+Based on the exhaustive audit of the research materials and the accuracy
+review of the project\'s foundational documents, the following strategic
+recommendations are provided to ensure the successful launch of the
+Cataclysm Studios DAO.
+
+### 1. Execute the Document \"Source of Truth\" Consolidation
+
+The organization must immediately address the document fragmentation
+identified in the drive audit. The \"Master Document Suite\" (Vision
+Deck, One-Pager, Technical White Paper, and Budget) should be moved to a
+dedicated, read-only \"Grant Application Master\" folder. Duplicate
+versions of board decks must be archived to prevent \"governance drift\"
+where decisions are made based on v0.2 metrics while the system is
+operating on v0.5 logic.
+
+### 2. Formalize the Legal Structure and Asset Transfer
+
+The transition from the S-corp to the Wyoming DAO LLC and the Benefit
+LLC is the most critical path for liability protection. The organization
+must follow through on the Week 1-2 filing plan and the Week 3-4 asset
+transfer. The \"F-reorganization\" must be formally documented by tax
+counsel to ensure that the intellectual property (PMOVES.AI, CHIT
+patents) is legally transferred to the community without a crippling tax
+event.
+
+### 3. Update and Standardize Guild Charters
+
+The \"DAO Governance & Readiness Analysis\" should be updated to include
+the specific mandates and KPIs already defined for the Creator and
+Wealth & Learning guilds in the broader workspace. Standardizing these
+charters now will prevent conflict during the Month 4 \"First Official
+DAO Vote\".
+
+### 4. Implement Technical Auditability
+
+To meet the \"Technical Validation\" goal in Month 4, the organization
+must complete the pmoves-ppc-audit toolkit. This is the \"Killer
+Differentiator\" for humanitarian grants. Proving that data is destroyed
+in Firecracker VMs through open-source, verifiable code will separate
+Cataclysm from the myriad of \"AI Wrapper\" companies competing for the
+same funding.
+
+### 5. Finalize the \$CAT Legal Opinion
+
+The Month 2 goal of hiring a token lawyer and getting a formal legal
+opinion on \$CAT must be a top priority. This opinion will be necessary
+to facilitate any \"Token Pre-Sale\" or strategic distributions to
+partners like the UN or OID Inc.. The opinion should focus on the
+utility nature of \$CAT---specifically its role in governance, budget
+oversight, and access to private compute resources\].
+
+### 6. Bridge the Gap Between Technical and Resident Documentation
+
+The \"Residents Deck\" should be expanded to include more plain-language
+explanations of the \"Shape Attribution\" model and how \$WORK is
+earned. Residents need to understand that their \"Home Nodes\" are not
+just passive appliances but are the active source of their governance
+power in the Citizen House.
+
+## Conclusion: The Path Forward for Cataclysm Studios
+
+Cataclysm Studios is at a transformative moment where visionary
+architectural blueprints are meeting the rigorous demands of legal and
+technical execution. The proposed bicameral governance model and
+tri-token economic suite are remarkably sophisticated and address the
+fundamental tensions between capital, labor, and privacy in the AI era.
+
+The transition to a Wyoming DAO LLC provides the necessary legal
+personhood to interface with global institutions, while the \"Provably
+Private Compute\" architecture provides the technical integrity required
+for high-stakes humanitarian missions. By executing the recommended
+workspace organization, legal filings, and technical audits, Cataclysm
+Studios can transition from a promising pilot in the Bronx to a global
+model for community-owned, sovereign AI infrastructure. The 90-day
+rollout in early 2026 will be the definitive proof-of-concept for this
+\"resident-owned alternative,\" paving the way for a \$100M ecosystem by
+2030.
+
+#### Works cited
+
+1\. Grant Proposal: PMOVES.AI - Provably Private AI Infrastructure for
+Humanitarian and Community Empowerment,
+https://drive.google.com/open?id=1gfKig8NR322y2sB11V713HQpU9-Qg-aTlMUMtS6gxy8
+2. PMOVES restructure chat.pdf,
+https://drive.google.com/open?id=1ds8bSjHQZ-19R-ZtrWz3DDrbakmJx0pU 3.
+PMOVES.AI Agentic Architecture Deep Dive,
+https://drive.google.com/open?id=1aKNl5yassgw1tYM4FCNO8FGyEHSCZ-1HwaL_jakJ3m4

--- a/deploy/runbooks/vault-integration-runbook.md
+++ b/deploy/runbooks/vault-integration-runbook.md
@@ -1,0 +1,64 @@
+# Vault Integration Runbook
+
+## Status: PLANNED
+
+## Problem
+
+All secrets currently stored in environment files (`env.tier-*.example`, `.claude/secrets.env`, `.a0proj/secrets.env`). No centralized secret management. SSH private keys stored as env vars across 5 locations.
+
+## Target Architecture
+
+```
+HashiCorp Vault (DGX Spark)
+  ├── secret/pmoves/tier-api      ← POSTGRES_PASSWORD, JWT_SECRET
+  ├── secret/pmoves/tier-vpn      ← TAILSCALE_AUTH_KEY, WIREGUARD_PSK
+  ├── secret/pmoves/tier-llm      ← OPENAI_API_KEY, GROQ_API_KEY
+  ├── secret/pmoves/tier-supabase ← SUPABASE_SERVICE_KEY
+  ├── secret/pmoves/chit          ← CHIT_PASSPHRASE (signing + encryption)
+  └── secret/pmoves/ssh           ← SSH private keys (not env vars)
+
+NATS → Vault Agent sidecar (auto-auth, template rendering)
+Hostinger VPS → Vault Agent (AppRole auth)
+KVM nodes → Vault Agent (AppRole auth)
+```
+
+## Migration Steps
+
+### Phase 1: Vault Setup on DGX Spark
+
+1. Install Vault via apt or Docker container
+2. Configure dev storage → migrate to Consul when ready
+3. Enable KV v2 secrets engine at `secret/pmoves/`
+4. Create policies per tier (least privilege)
+
+### Phase 2: Import Existing Secrets
+
+1. Parse all `env.tier-*.example` files
+2. Map each variable to Vault path
+3. `vault kv put secret/pmoves/tier-api POSTGRES_PASSWORD=...`
+4. Verify no `changeme`/`minioadmin` defaults survive
+
+### Phase 3: Application Integration
+
+1. Install `hvac` Python library
+2. Create `pmoves/tools/vault_client.py` wrapper
+3. Replace `os.environ.get()` calls with vault lookups
+4. Fallback to env vars in dev mode
+
+### Phase 4: SSH Key Migration
+
+1. Move SSH keys from env vars to `secret/pmoves/ssh/`
+2. Update all 5 reference locations
+3. Add Vault SSH CA for signed certificates
+
+### Phase 5: CHIT Passphrase
+
+1. Split into `CHIT_SIGNING_KEY` + `CHIT_ENCRYPTION_KEY` (key separation)
+2. Store separately in Vault
+3. Rotate signing key on schedule (TBD)
+
+## References
+
+- CHIT Secrets Audit: `research/CHIT_SECRETS_MANAGEMENT_AUDIT.md`
+- Finding F-12: SSH private key in 5 env var locations
+- Finding F-11: hardcoded changeme/minioadmin defaults

--- a/pmoves/configs/chit-openapi.yaml
+++ b/pmoves/configs/chit-openapi.yaml
@@ -1,0 +1,304 @@
+openapi: "3.1.0"
+info:
+  title: PMOVES CHIT API
+  version: "1.0.0"
+  description: |
+    CHIT (Constellation Harvest Integrity Token) API for CGP signing,
+    verification, anchor encryption/decryption, and provenance validation.
+    Per CGP v1.0 spec — canonical crypto in chit_security.py.
+
+paths:
+  /chit/sign:
+    post:
+      summary: Sign a CGP
+      description: |
+        Computes HMAC-SHA256 over canonical JSON of the CGP (excluding sig field).
+        Returns the CGP with sig{alg, kid, hmac} appended.
+      operationId: signCgp
+      tags: [Signing]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CgpSignRequest"
+      responses:
+        "200":
+          description: Signed CGP
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedCgp"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /chit/verify:
+    post:
+      summary: Verify a CGP signature
+      description: |
+        Verifies HMAC-SHA256 signature using constant-time comparison.
+        Returns boolean valid field.
+      operationId: verifyCgp
+      tags: [Signing]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignedCgp"
+      responses:
+        "200":
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [valid]
+                properties:
+                  valid:
+                    type: boolean
+
+  /chit/encrypt:
+    post:
+      summary: Encrypt CGP anchors
+      description: |
+        Encrypts anchor float32 vectors using AES-256-GCM.
+        Key derived via PBKDF2-HMAC-SHA256 (600K iterations).
+        Replaces anchor with anchor_enc{alg, iv, salt, ct}.
+        Also signs the resulting CGP.
+      operationId: encryptAnchors
+      tags: [Encryption]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CgpEncryptRequest"
+      responses:
+        "200":
+          description: CGP with encrypted anchors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EncryptedCgp"
+
+  /chit/decrypt:
+    post:
+      summary: Decrypt CGP anchors
+      description: |
+        Decrypts anchor_enc fields back to float32 anchor arrays.
+        Key derived from passphrase + per-CGP salt.
+      operationId: decryptAnchors
+      tags: [Encryption]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CgpDecryptRequest"
+      responses:
+        "200":
+          description: CGP with decrypted anchors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedCgp"
+        "400":
+          description: Decryption failed (wrong passphrase or tampered ciphertext)
+
+  /chit/validate:
+    post:
+      summary: Full CGP validation
+      description: |
+        Validates CGP schema, spectrum constraints, signature,
+        and security level requirements.
+      operationId: validateCgp
+      tags: [Validation]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CgpValidateRequest"
+      responses:
+        "200":
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationResult"
+
+components:
+ schemas:
+    CgpSignRequest:
+      type: object
+      required: [cgp, passphrase]
+      properties:
+        cgp:
+          $ref: "#/components/schemas/CgpDocument"
+        passphrase:
+          type: string
+          format: password
+          description: CHIT signing passphrase
+        kid:
+          type: string
+          description: Optional key identifier override
+
+    CgpEncryptRequest:
+      type: object
+      required: [cgp, passphrase]
+      properties:
+        cgp:
+          $ref: "#/components/schemas/CgpDocument"
+        passphrase:
+          type: string
+          format: password
+          description: CHIT encryption passphrase
+        kid:
+          type: string
+          description: Optional key identifier override
+
+    CgpDecryptRequest:
+      type: object
+      required: [cgp, passphrase]
+      properties:
+        cgp:
+          $ref: "#/components/schemas/EncryptedCgp"
+        passphrase:
+          type: string
+          format: password
+
+    CgpValidateRequest:
+      type: object
+      required: [cgp]
+      properties:
+        cgp:
+          $ref: "#/components/schemas/CgpDocument"
+        passphrase:
+          type: string
+          format: password
+          description: Required for SIGNED/STRICT security levels
+        security_level:
+          type: string
+          enum: [OPEN, SIGNED, STRICT]
+          default: SIGNED
+
+    CgpDocument:
+      type: object
+      required: [schema_version]
+      properties:
+        schema_version:
+          type: string
+          enum: ["0.1", "0.2", "1.0"]
+        contributor:
+          type: string
+        super_nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/SuperNode"
+
+    SuperNode:
+      type: object
+      properties:
+        id:
+          type: string
+        constellations:
+          type: array
+          items:
+            $ref: "#/components/schemas/Constellation"
+
+    Constellation:
+      type: object
+      properties:
+        id:
+          type: string
+        anchor:
+          type: array
+          items:
+            type: number
+            format: float
+          description: Float32 anchor vector (plaintext)
+        anchor_enc:
+          $ref: "#/components/schemas/AnchorEnc"
+          description: Encrypted anchor (replaces anchor when encrypted)
+
+    AnchorEnc:
+      type: object
+      required: [alg, iv, salt, ct]
+      properties:
+        alg:
+          type: string
+          enum: [AES-GCM]
+        iv:
+          type: string
+          format: base64
+          description: 12-byte IV
+        salt:
+          type: string
+          format: base64
+          description: 16-byte salt
+        ct:
+          type: string
+          format: base64
+          description: AES-GCM ciphertext + 16-byte tag
+
+    Signature:
+      type: object
+      required: [alg, kid, hmac]
+      properties:
+        alg:
+          type: string
+          enum: [HMAC-SHA256]
+        kid:
+          type: string
+          description: Key identifier (SHA256 of passphrase, first 16 hex chars)
+        hmac:
+          type: string
+          format: base64
+          description: 32-byte HMAC-SHA256 digest
+
+    SignedCgp:
+      allOf:
+        - $ref: "#/components/schemas/CgpDocument"
+        - type: object
+          required: [sig]
+          properties:
+            sig:
+              $ref: "#/components/schemas/Signature"
+
+    EncryptedCgp:
+      allOf:
+        - $ref: "#/components/schemas/SignedCgp"
+        - type: object
+          description: CGP with anchor_enc replacing anchor in constellations
+
+    ValidationResult:
+      type: object
+      required: [valid, errors]
+      properties:
+        valid:
+          type: boolean
+        security_level:
+          type: string
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              code:
+                type: string
+              message:
+                type: string
+              field:
+                type: string
+
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string

--- a/pmoves/configs/tac_trees/cataclysm-studios.tac.yaml
+++ b/pmoves/configs/tac_trees/cataclysm-studios.tac.yaml
@@ -1,0 +1,119 @@
+# TAC Tree: CATACLYSM STUDIOS INC
+# 5-tier creative pipeline: L1 Discovery → L2 Foundation → L3 Production → L4 Refinement → L5 Legendary
+# Generated: 2026-04-17
+# See: research/CATACLYSM_STUDIOS_RESEARCH_REPORT.md
+# Schema: canonical name:/root:/children: per PR #1279
+
+name: cataclysm-studios
+version: 1.0.0
+description: Creative production pipeline across 5 quality tiers
+
+root:
+  id: cataclysm-pipeline
+  task: Orchestrate 5-tier creative production pipeline
+  context: |
+    Manages content from initial concept exploration through legendary flagship production.
+    Each tier has entry/exit conditions. Depends on PMOVES-Creator for video, vibevoice for audio.
+  agent_hint: creative-director
+  status: planned
+  children:
+    - id: l1-discovery
+      task: Explore creative concepts and validate audience fit
+      context: Initial phase — generate concepts, research audience, validate viability
+      agent_hint: researcher
+      status: planned
+      children:
+        - id: concept-exploration
+          task: Generate and evaluate creative concepts
+          context: Brainstorm concepts, score against brand guidelines, shortlist top candidates
+          agent_hint: creative-writer
+          status: planned
+        - id: audience-research
+          task: Research target audience demographics and psychographics
+          context: Map audience segments, analyze engagement patterns, identify content opportunities
+          agent_hint: researcher
+          status: planned
+
+    - id: l2-foundation
+      task: Build foundational assets and brand guidelines
+      context: Establish brand voice, visual identity, and content calendar
+      agent_hint: brand-strategist
+      status: planned
+      depends_on: [l1-discovery]
+      children:
+        - id: brand-guidelines
+          task: Create brand voice and visual identity guidelines
+          context: Document tone, colors, typography, imagery standards for all content
+          agent_hint: designer
+          status: planned
+        - id: content-calendar
+          task: Plan content release schedule
+          context: Map content to platforms, seasons, events. Align with marketing goals
+          agent_hint: project-manager
+          status: planned
+
+    - id: l3-production
+      task: Core content creation across media types
+      context: Produce video, audio, and written content using PMOVES pipeline
+      agent_hint: producer
+      status: planned
+      depends_on: [l2-foundation]
+      children:
+        - id: video-production
+          task: Video content creation via PMOVES-Creator pipeline
+          context: Leverage PMOVES-Creator (ComfyUI fork) for video generation and post-production
+          agent_hint: video-editor
+          status: planned
+        - id: audio-production
+          task: Audio/voice content via vibevoice pipeline
+          context: Use vibevoice-realtime for voice synthesis, flute-gateway for prosodic analysis
+          agent_hint: audio-engineer
+          status: planned
+        - id: written-content
+          task: Written content and copywriting
+          context: Blog posts, social media copy, scripts, documentation
+          agent_hint: creative-writer
+          status: planned
+
+    - id: l4-refinement
+      task: Quality review, A/B testing, and optimization
+      context: Validate content quality through structured review and testing
+      agent_hint: qa-reviewer
+      status: planned
+      depends_on: [l3-production]
+      children:
+        - id: quality-review
+          task: Multi-axis quality assessment
+          context: Review for brand alignment, technical quality, engagement potential, accessibility
+          agent_hint: qa-reviewer
+          status: planned
+        - id: ab-testing
+          task: A/B test content variants
+          context: Test thumbnails, headlines, CTAs. Measure engagement and conversion
+          agent_hint: data-analyst
+          status: planned
+
+    - id: l5-legendary
+      task: Flagship content with maximum production value
+      context: Highest tier — premium production quality, cross-platform distribution
+      agent_hint: creative-director
+      status: planned
+      depends_on: [l4-refinement]
+      children:
+        - id: flagship-production
+          task: Produce highest-quality flagship content
+          context: Maximum budget, multi-format output, premiere launch strategy
+          agent_hint: creative-director
+          status: planned
+
+nats_subjects:
+  - creative.concept.explore.v1
+  - creative.audience.research.v1
+  - creative.brand.guidelines.v1
+  - creative.calendar.plan.v1
+  - creative.video.produce.v1
+  - creative.audio.produce.v1
+  - creative.written.produce.v1
+  - creative.quality.review.v1
+  - creative.ab.test.v1
+  - creative.flagship.produce.v1

--- a/pmoves/docs/AGENTS/AGNOTE-dgx-spark.md
+++ b/pmoves/docs/AGENTS/AGNOTE-dgx-spark.md
@@ -1,0 +1,27 @@
+# AGNOTE: DGX Spark Integration
+
+## Node: pmoves-dgx-spark
+- **Hardware**: Gigabyte GB10 Grace-Blackwell workstation
+- **Memory**: 128GB unified memory
+- **Role**: GPU inference via Ollama
+- **Access**: Tailscale tag:gpu, port 11434
+- **Provider**: ollama_spark in Agent Zero model_providers.yaml
+- **Default Model**: gemma4:31b
+- **NATS Subjects**: mesh.gpu.* (7 streams defined in pmoves/nats/mesh_gpu_streams.yaml)
+- **TAC Tree**: pmoves/configs/tac_trees/dgx-spark.tac.yaml (278 lines, 6 phases)
+
+## Status
+- ✅ Tailscale ACL rules configured (exit node consume, DGX Spark inference, GPU→PMOVES mesh)
+- ✅ Network inventory registered (5 nodes added)
+- ✅ Makefile include added (nvidia-dgx-spark.mk)
+- ✅ Ollama Spark provider configured (http://pmoves-dgx-spark:11434)
+- ✅ PMOVES MAX preset created (GLM-5-turbo + GLM-5.1 + HuggingFace embed)
+- ✅ JetStream streams defined (7 mesh.gpu.* streams)
+- ✅ Flare model namespace updated (dgx-spark added to gemma-4-e2b, e4b, 31b)
+
+## Remaining
+- ⏳ NATS JetStream streams not deployed (defined only)
+- ⏳ Ollama installation verification on GB10
+- ⏳ Model auto-pull on boot configuration
+
+Added: 2026-04-17

--- a/pmoves/docs/PMOVESCHIT/Constellation-Harvest-Regularization/Understanding Range-Partition-Entropy (RPE).md
+++ b/pmoves/docs/PMOVESCHIT/Constellation-Harvest-Regularization/Understanding Range-Partition-Entropy (RPE).md
@@ -1,0 +1,147 @@
+# **Understanding Range-Partition-Entropy (RPE)**
+
+## **Introduction**
+
+When we think about information, we often imagine it as something that
+can be measured in bits or probabilities. One of the most famous tools
+for this is **entropy**---a way of measuring uncertainty or disorder in
+data. Entropy tells us how much surprise there is in a dataset, but it
+usually works as one number for the whole thing. That's powerful, but
+sometimes it's too simple.
+
+Enter **Range-Partition-Entropy (RPE)**. This idea extends traditional
+entropy by looking not just at the whole dataset at once, but by
+breaking it into parts---\"partitions\"---and measuring how disorder is
+distributed across them.
+
+## **What It Means**
+
+- **Partitioning**: Imagine you have a dataset of numbers, like test
+  scores. Instead of looking at all the scores as one big pile, you
+  split them into ranges: 0--50, 51--75, 76--100.
+
+- **Entropy in Each Partition**: For each range, you calculate the
+  entropy---how unpredictable the values are within that range.
+
+- **Putting It Together**: By combining these local entropy measures,
+  you get a structured view of the whole dataset's uncertainty.
+
+In simple terms: RPE doesn't just say *"how messy is the whole thing?"*
+It asks, *"where is the mess, and how is it spread out?"*
+
+## **Why It's Useful**
+
+- **Reveals hidden patterns**: Some areas of data may be highly
+  predictable (low entropy), while others are full of surprises (high
+  entropy). RPE shows you both.
+
+- **Works with unstructured data**: If your dataset has no obvious
+  order, partitioning helps turn it into structured pieces that can be
+  analyzed.
+
+- **Better data preparation**: By knowing which parts of data are noisy,
+  you can clean, balance, or emphasize the right regions before training
+  a model.
+
+## **Everyday Analogy**
+
+Think of entropy as noise in a room. A single number for the entire room
+might say it's "medium loud." But RPE is like walking around with a
+sound meter: it shows you that the corner by the window is quiet, the
+middle is noisy, and the back wall has bursts of chatter. That's far
+more useful if you want to understand what's really going on.
+
+## **Where It Fits in AI**
+
+- **Training datasets**: RPE can help identify which slices of your data
+  add the most value or introduce the most chaos.
+
+- **Model insights**: It can highlight what parts of a model's latent
+  space are structured versus noisy.
+
+- **Anomaly detection**: If one partition is unexpectedly random, that
+  may reveal errors or outliers.
+
+## **Conclusion**
+
+Range-Partition-Entropy is a way of looking at information that goes
+beyond a single summary number. By measuring disorder across partitions,
+it lets us see the shape of information, not just its total. It's like
+moving from a blurry snapshot to a detailed map---giving us tools to
+better understand, prepare, and make use of data.
+
+# **Thinking About Geometry Like an AI Model**
+
+## **Introduction**
+
+When most people imagine geometry, they think of familiar shapes from
+school: squares, triangles, and circles drawn on flat paper. This is
+**Euclidean geometry**, the geometry of our everyday experience. But AI
+models don't "see" the world this way. To understand how they think, we
+need to expand our idea of geometry.
+
+## **Beyond Flat Shapes**
+
+AI models often work in spaces that don't look anything like flat paper.
+Instead, they live in **high-dimensional spaces**---mathematical worlds
+where each "direction" represents a feature of the data. For example:
+
+- In 2D, a point can be described by *(x, y)*.
+
+- In 3D, by *(x, y, z)*.
+
+- In an AI model, a point might need hundreds or even thousands of
+  numbers to describe it.
+
+These spaces are not easy to visualize, but the rules of geometry still
+apply. Distances, angles, and curves all matter---they just exist in
+more dimensions than we can picture.
+
+## **Curved Geometry**
+
+AI also relies on **non-Euclidean geometries**. These are geometries
+where space itself can be curved:
+
+- **Hyperbolic geometry**: Shapes spread out faster than in flat space,
+  useful for representing hierarchies (like family trees or taxonomies).
+
+- **Spherical geometry**: Shapes wrap around like on the surface of a
+  globe, useful for periodic data or directions.
+
+For AI, these alternative geometries are not exotic---they are practical
+tools to better match the shape of real-world data.
+
+## **Why Geometry Matters to AI**
+
+- **Latent space**: AI models represent knowledge as points in a
+  high-dimensional space. Geometry tells us how close or far concepts
+  are.
+
+- **Learning structure**: If the data has hierarchy, cycles, or
+  clusters, the model adjusts its "geometry" to fit.
+
+- **Generalization**: By shaping geometry, models learn patterns that go
+  beyond memorization.
+
+## **Everyday Analogy**
+
+Think of geometry like different kinds of maps:
+
+- A **flat street map** (Euclidean) works fine for a small neighborhood.
+
+- A **globe** (spherical geometry) is better for representing the whole
+  Earth.
+
+- A **tree diagram** (hyperbolic geometry) is better for showing
+  branching structures like language or ancestry.
+
+An AI model switches between these "maps" depending on the problem,
+often combining them in ways we cannot visualize directly.
+
+## **Conclusion**
+
+AI does not think in terms of just squares and triangles. It thinks in
+terms of entire landscapes---sometimes flat, sometimes curved, often in
+thousands of dimensions. To think like an AI model is to accept that
+geometry is not one-size-fits-all. It's a flexible language for
+describing how data is shaped, connected, and transformed.

--- a/pmoves/docs/archive/Building a Custom ChatGPT Connector with Docker MCP Toolkit.md
+++ b/pmoves/docs/archive/Building a Custom ChatGPT Connector with Docker MCP Toolkit.md
@@ -1,0 +1,552 @@
+# Building a Custom ChatGPT Connector with Docker MCP Toolkit
+
+The **Docker MCP Toolkit** streamlines the creation and deployment of
+custom connectors (MCP servers) for ChatGPT and other AI
+clients[\[1\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=The%20Docker%20MCP%20Toolkit%20is,tool%20discovery%20to%20local%20execution).
+These connectors use the **Model Context Protocol (MCP)** -- an open
+standard (originally from Anthropic) that defines how LLMs discover and
+invoke external tools via JSON-RPC
+calls[\[2\]](https://techwithibrahim.medium.com/run-any-mcp-server-locally-with-dockers-mcp-catalog-and-toolkit-f8ecbe0c6a79#:~:text=At%20the%20core%20of%20this,logic%20for%20each%20use%20case)[\[3\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=Model%20Context%20Protocol%20,0%20for%20communication%20and%20supports).
+In this guide, we'll walk through the entire process: from coding a
+custom MCP tool, containerizing it, running it locally or remotely (via
+Docker's MCP Gateway and Cloudflare Tunnel), to registering it so
+ChatGPT can use it. We'll also cover best practices for secure exposure.
+
+## Step 1: Develop a Custom MCP Tool Server
+
+**Choose a language and MCP SDK.** Official SDKs exist for
+TypeScript/Node and Python, which greatly simplify building MCP
+servers[\[4\]](https://huggingface.co/learn/mcp-course/en/unit1/sdk#:~:text=MCP%20SDK%20,clients%20and%20servers%20in).
+For example, using Python's `mcp` SDK (FastMCP) or Node's
+`@modelcontextprotocol/sdk`, you can define **tools** (functions the AI
+can call) and **resources** (data it can fetch) with just a few
+decorators or method calls.
+
+- **Define MCP server and tools:** In Python, you might do:
+
+<!-- -->
+
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("Demo")                    # Create an MCP server instance
+    @mcp.tool()
+    def add(a: int, b: int) -> int:
+        """Add two numbers"""
+        return a + b
+
+This registers an `add` tool that simply returns the sum of `a` and
+`b`[\[5\]](https://github.com/modelcontextprotocol/python-sdk#:~:text=,return%20a%20%2B%20b).
+In TypeScript, the pattern is similar -- you create an `McpServer` and
+use `registerTool()` to add tools with input/output
+schemas[\[6\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=%2F%2F%20Create%20an%20MCP%20server,server%27%2C%20version%3A%20%271.0.0%27).
+
+- **Implement the MCP interface:** MCP servers communicate via JSON-RPC
+  2.0 over a specified transport (e.g. HTTP). If using the SDK, much of
+  this is handled for you. For an HTTP-based server, expose an endpoint
+  (commonly `/mcp`) that will accept JSON-RPC requests. For example, the
+  TypeScript SDK provides a `StreamableHTTPServerTransport` that you
+  attach to an Express route for
+  `/mcp`[\[7\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=%2F%2F%20Set%20up%20Express%20and,json).
+  In Python, the FastMCP library can run with built-in transports (like
+  stdio for local use, or an HTTP server via ASGI/Uvicorn). The key is
+  to ensure your server listens for POST requests at a URL (say
+  `http://localhost:3000/mcp`) and processes the JSON-RPC messages.
+
+- **(Optional) Add resources or prompts:** MCP also supports
+  **resources** (read-only data endpoints) and **prompts** (predefined
+  prompt templates) if
+  needed[\[8\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=%2F%2F%20Add%20a%20dynamic%20greeting,)[\[9\]](https://github.com/modelcontextprotocol/python-sdk#:~:text=,Hello%2C%20%7Bname).
+  You can register these similarly (e.g.
+  `@mcp.resource("resource://...")` in Python) to expose data that the
+  AI can retrieve into context. Keep tools idempotent and safe, since
+  they will be executed by the AI.
+
+- **Test locally:** Before containerizing, test your MCP server. You can
+  run it on a local port and use the MCP Inspector tool to verify it
+  works: for example, run `npx @modelcontextprotocol/inspector` and
+  connect to your server's URL to see the listed
+  tools[\[10\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=as%3A).
+  Ensure the basic requests work (e.g. calling the `add` tool returns
+  the expected JSON result).
+
+## Step 2: Containerize the MCP Server with Docker
+
+Packaging your connector as a Docker image ensures it runs consistently
+everywhere[\[11\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=4,Deployment).
+We will create a Dockerfile for your MCP server:
+
+- **Write a Dockerfile:** Use an official runtime base image (Python or
+  Node). For example, if our server is in Python and listens on port
+  3000:
+
+<!-- -->
+
+    FROM python:3.11-slim
+    WORKDIR /app
+    COPY requirements.txt . 
+    RUN pip install --no-cache-dir -r requirements.txt  # Install MCP SDK and deps
+    COPY . .                                           # Copy your server code
+    EXPOSE 3000
+    CMD ["python", "server.py"]                        # Start the MCP server
+
+This Dockerfile installs dependencies (including the `mcp` Python SDK)
+and runs your `server.py`. For Node/TypeScript, you'd similarly copy
+`package.json` and use `npm install`, then run the server (possibly via
+`node server.js` or `tsx`). **Tip:** Create a non-root user in the image
+for better security (as shown in many Docker
+examples[\[12\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=%23%20Create%20a%20non,R%20app%3Aapp%20%2Fapp%20USER%20app)).
+
+- **Build the image locally:** Run `docker build -t mytool-mcp:latest .`
+  in the project directory. This produces a local image for your
+  connector.
+
+- **(Optional) Push to a registry:** If you want to reuse or share this
+  image, push it to Docker Hub or another registry. For example, tag and
+  push to Docker Hub:
+
+<!-- -->
+
+    docker tag mytool-mcp:latest yourdockeruser/mytool-mcp:latest
+    docker login   # (if not already logged in)
+    docker push yourdockeruser/mytool-mcp:latest
+
+This makes it easier to deploy remotely or let others pull
+it[\[13\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=docker%20build%20).
+(For local-only use, pushing is not necessary.)
+
+## Step 3: Run the MCP Connector Locally with Docker MCP Toolkit
+
+Now that you have an image, you can run it through Docker's MCP
+Toolkit/Gateway, which adds a secure layer and allows ChatGPT (or other
+clients) to connect.
+
+**Prerequisites:** Ensure you have Docker Desktop updated (v4.42+ on Win
+or 4.40+ on Mac) and **enable the MCP Toolkit** in Settings → *Beta
+features*[\[14\]](https://techwithibrahim.medium.com/run-any-mcp-server-locally-with-dockers-mcp-catalog-and-toolkit-f8ecbe0c6a79#:~:text=Step%201%3A%20Enable%20Docker%20MCP,Toolkit).
+This will activate the MCP Catalog & Toolkit in Docker Desktop, and
+install the `docker mcp` CLI plugin.
+
+There are two ways to launch your MCP server locally:
+
+**Option A: Via Docker Desktop UI (Toolkit):** Open Docker Desktop and
+go to the **MCP Toolkit** tab. Normally, you can browse the **Catalog**
+for official servers and click "+" to add
+one[\[15\]](https://techwithibrahim.medium.com/run-any-mcp-server-locally-with-dockers-mcp-catalog-and-toolkit-f8ecbe0c6a79#:~:text=Step%202%3A%20Install%20an%20MCP,Server).
+For a custom server not in the official catalog, you'll need to add it
+manually. Currently, the UI doesn't have an "import custom image"
+button, so you will use the CLI (Option B) or edit config files.
+
+**Option B: Via Docker MCP CLI (Gateway):** The `docker mcp` CLI lets
+you enable custom servers and run the gateway. Here's how:
+
+1.  **Register your server in the catalog:** By default, Docker uses the
+    **"docker-mcp" catalog** (the official list of
+    servers)[\[16\]](https://github.com/docker/mcp-gateway#:~:text=The%20MCP%20Toolkit%2C%20in%20Docker,from%20the%20Docker%20MCP%20Catalog)[\[17\]](https://github.com/docker/mcp-gateway#:~:text=Catalog%20Management).
+    You can add a custom entry. One approach is to create a small YAML
+    file (e.g. `~/.docker/mcp/custom.yaml`) with your server definition,
+    for example:
+
+<!-- -->
+
+    mytool:
+      image: "yourdockeruser/mytool-mcp:latest"
+      transports: ["http"]   # or ["sse"] depending on your server’s supported transport
+
+This defines a new server named "mytool" with the specified image. Save
+this and **initialize the catalog** if needed (e.g.,
+`docker mcp catalog init` for default, or ensure the custom file is
+referenced in config). The MCP CLI uses config files in `~/.docker/mcp/`
+(including `docker-mcp.yaml` for catalogs, `registry.yaml` for enabled
+servers)[\[18\]](https://github.com/docker/mcp-gateway#:~:text=%2A%20%60docker,Enabled%20tools%20per%20server).
+You can merge your custom entry into those or specify it at runtime.
+
+1.  **Enable the server:** Use the CLI to enable your custom server so
+    it will start. For example:
+
+<!-- -->
+
+    docker mcp server enable mytool
+
+This marks "mytool" as enabled (similar to adding via UI). You can list
+enabled servers with
+`docker mcp server ls`[\[19\]](https://github.com/docker/mcp-gateway#:~:text=,mcp%20server%20ls).
+If everything is set up, you should see `mytool` in the list (possibly
+alongside any other servers).
+
+1.  **Launch the MCP Gateway:** Start the gateway which will actually
+    run the container and expose a unified endpoint. A basic invocation
+    is:
+
+<!-- -->
+
+    docker mcp gateway run
+
+This starts the gateway with default settings (likely on localhost and
+using the default transport, typically SSE for streaming or HTTP). The
+gateway will launch your container in the background with secure
+defaults (no host mounts, limited CPU/RAM) and listen for client
+connections. By default, all enabled servers become available through
+this
+gateway[\[20\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=An%20MCP%20Gateway%20exposes%20a,can%20be%20enabled%20by%20default).
+
+- *Customizing the gateway:* You can specify transport and limit tools
+  if needed. For example, to use SSE transport and only allow certain
+  tools, Docker's docs show:
+  `docker mcp gateway run --transport=sse --servers=mytool --tools=tool1,tool2`[\[20\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=An%20MCP%20Gateway%20exposes%20a,can%20be%20enabled%20by%20default)[\[21\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=docker%20mcp%20gateway%20run%20,tools%3Dbrave_web_search%2Cget_article%2Cget_summary%2Cget_related_topics).
+  For basic use, the default should suffice. The gateway will typically
+  print out what address it's listening on. For instance, it might say
+  it's running an HTTP endpoint on `http://127.0.0.1:41114` (or similar
+  port), or an SSE endpoint at `http://127.0.0.1:41114/sse`.
+
+- **Connect a local client (optional):** If you are using a local AI
+  client like VS Code's Copilot Chat or Claude Desktop, you can point it
+  to this local gateway. For example, VS Code's Agent mode can connect
+  via a generated `mcp.json` pointing to Docker's
+  gateway[\[22\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=1,mcp.json)[\[23\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=,mcp).
+  In Docker Desktop's MCP Toolkit UI, your local client (if supported)
+  would appear under "Clients" -- e.g. you might see options to connect
+  VSCode or
+  Claude[\[24\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=Example%3A%20Use%20Claude%20Desktop%20as,a%20client).
+  *(At the time of writing,* *ChatGPT Desktop* *does not yet have a
+  built-in way to auto-connect to the local gateway. It's essentially
+  the ChatGPT web app in an Electron shell, so it doesn't automatically
+  interface with Docker. You will likely treat ChatGPT as a remote
+  client -- see Step 4.)*
+
+At this point, your MCP server is running locally in Docker. The gateway
+aggregates it (and any other enabled MCP servers) and exposes them to
+clients. The **security sandboxing** is in effect: Docker limits each
+MCP container to 1 CPU and 2GB RAM, and blocks host filesystem access by
+default[\[25\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=,potential%20misuse%20of%20computing%20resources),
+so your tool runs safely. You can inspect available tools via CLI
+(`docker mcp tools ls`) or logs to verify it's functioning.
+
+## Step 4: (Optional) Deploy or Expose the Connector for Remote Access
+
+If you want ChatGPT (web) or others to use your connector, the MCP
+server needs to be accessible over the internet (ChatGPT's servers can't
+reach your localhost behind
+NAT[\[26\]](https://thamizhelango.medium.com/connecting-local-mcp-servers-to-publicly-exposed-llm-apis-a-complete-guide-12658f464e51#:~:text=The%20NAT%20Challenge)).
+You have a couple of options:
+
+- **Deploy to a VPS or cloud service:** Since you containerized the
+  server, you can run it on any cloud host. For example, use a service
+  like Render or Railway by providing your Docker
+  image[\[27\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=3)[\[28\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=Deploy%20with%20Railway).
+  Ensure the container is running and reachable at a public URL (with
+  HTTPS). Configure it to serve on a known port (e.g. 80/443 or via a
+  proxy) so that you have a stable URL like
+  `https://your-tool.example.com/mcp`.
+
+- **Use Cloudflare Tunnel for a local server:** If you prefer not to
+  host a server publicly, Cloudflare Tunnel is a quick way to expose
+  your running local MCP gateway or server to the internet securely.
+  Using Cloudflare's free Tunnel, you can get a public `https` URL that
+  forwards to your `localhost:<port>`. For example, one user shares: *"I
+  self host on my server in a container and expose through a Cloudflare
+  tunnel."*[\[29\]](https://www.reddit.com/r/mcp/comments/1l6y9za/how_to_turn_local_mcp_server_into_remote_one/#:~:text=How%20to%20turn%20local%20MCP,6)
+  This means you can run `cloudflared` to connect your local port to a
+  Cloudflare address. Steps in brief:
+
+- Install `cloudflared` (Cloudflare Tunnel client) on your machine (or
+  run it as a Docker container).
+
+- Authenticate it with your Cloudflare account (or use the one-time
+  `cloudflared tunnel --url http://localhost:41114` for a quick,
+  temporary tunnel).
+
+- Cloudflare will provide a public URL (e.g.
+  `https://your-tunnel-name.trycloudflare.com`) that routes to your
+  local MCP server port. You can also set up a custom domain with
+  Cloudflare DNS for a cleaner
+  URL[\[30\]](https://noted.lol/cloudflare-tunnel-and-zero-trust/#:~:text=Image)[\[31\]](https://noted.lol/cloudflare-tunnel-and-zero-trust/#:~:text=Now%20all%20that%27s%20left%20to,is%20add%20your%20Public%20Hostname).
+
+The tunnel approach gives you **HTTPS** for free, and you can add
+Cloudflare Zero Trust policies if desired (e.g. require login to access
+the URL, adding another security layer). If using the Docker MCP
+Gateway, ensure it's binding to an address accessible to cloudflared (by
+default it listens on localhost -- which is fine for the tunnel client
+running on the same host).
+
+With a remote URL ready (either from a cloud deploy or Cloudflare
+Tunnel), you now have an **internet-accessible MCP endpoint**. For
+instance, you might have `https://mytool.example.com/mcp` or an SSE
+endpoint `https://mytool.example.com/sse` (depending on what transport
+you set up).
+
+## Step 5: Register the Connector in ChatGPT (MCP Catalog & Clients)
+
+Finally, let's **register the connector** so that ChatGPT (or any
+MCP-compatible client) can discover and use it. There are two scenarios:
+
+**A. Using ChatGPT (web app) -- Developer Mode Connector:** OpenAI
+recently introduced custom connector support (in ChatGPT's **Developer
+Mode**). Here's how to add your tool:
+
+1.  **Enable Developer Mode:** In ChatGPT settings, go to *"Connectors"*
+    and enable Developer Mode
+    (beta)[\[32\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=Since%20the%20September%209th%2C%202025,available%20to%20all%20ChatGPT%20users)[\[33\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=%2A%20Go%20to%20,Create%20a%20New%20Connector)
+    if not already on.
+
+2.  **Create a New Connector:** Click "Create" under Browser Connectors.
+    In the dialog, fill in:
+
+3.  **Name:** A friendly name for your tool (e.g. "My Custom Tool").
+
+4.  **MCP Server URL:** The full URL where your MCP server is running
+    (including the `/mcp` or `/sse` path). For example,
+    `https://mytool.example.com/mcp`. Make sure to use `https://` --
+    ChatGPT will likely reject `http://` non-secure URLs.
+
+5.  **Authentication:** If your MCP server requires OAuth (like for
+    user-specific data), you'd select OAuth and follow the flow. For a
+    simple custom tool that doesn't require per-user login, choose
+    "None" or the appropriate option. *(Many community connectors use
+    OAuth for safety -- e.g., if the tool accesses a user's Google
+    Drive, it should use OAuth. For a self-contained utility tool, you
+    might not need auth.)*
+
+6.  You can also add an icon and description if you
+    like[\[34\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=1).
+
+7.  **Trust and Connect:** ChatGPT will show a security notice
+    (reminding you that custom connectors are not vetted). Acknowledge
+    this and proceed. If you selected OAuth, it will redirect you to
+    authenticate and authorize ChatGPT to access your tool (this
+    requires your MCP server to implement the OAuth handshake). If no
+    auth, it will connect
+    directly[\[35\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=%2A%20Check%20,time%20setup).
+
+8.  **Verify tools:** After connecting, ChatGPT should list the
+    **Actions** (tools) provided by your
+    server[\[36\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=5).
+    For example, you should see "add" or whatever tools you defined.
+    Now, in the chat interface, you can instruct ChatGPT to use these
+    tools. For instance, ask: *"Use the* `add` *tool to calculate 2+3."*
+    ChatGPT should call your connector's tool and return the result.
+
+**B. Using ChatGPT Desktop or Other GPT Clients:** If you have the
+ChatGPT desktop app, the process is similar (it also has settings for
+connectors). However, as of now the desktop app may not support
+local-only connectors without an internet URL. In practice, you would
+still add it via the Connectors UI (as above) pointing to an accessible
+URL. Other clients like **Claude Desktop, Cursor, VS Code, etc.** can
+often directly integrate with the Docker MCP Gateway. For example, in
+Claude Desktop you can add a custom connector by providing the local
+gateway URL and it will list available
+tools[\[37\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=match%20at%20L958%20Imagine%20you,Claude%20Desktop%20as%20a%20client)[\[38\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=match%20at%20L969%20Desktop%20if,servers%20in%20the%20MCP%20Toolkit).
+VS Code's "AI Tools" can connect by running
+`docker mcp client connect vscode`, which hooks VS Code to the local
+gateway[\[22\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=1,mcp.json)[\[39\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=,file).
+In summary, any client that supports MCP can be pointed at your
+connector's URL or the Docker gateway. ChatGPT (web) specifically
+requires a public URL as described.
+
+**Add to MCP Catalog (optional):** If you intend to share your connector
+with the community, consider publishing it in Docker's **MCP Catalog**.
+Currently, Docker has a PR-based process for adding new official servers
+to the
+catalog[\[40\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=As%20the%20Official%20MCP%20Registry,server%20authors%20publish%20will%20change).
+This would make your tool appear in the Docker Desktop UI for anyone to
+one-click install. To do this, you'd contribute a definition (usually
+under the `mcp/` namespace on Docker Hub, with a signed image). This
+step is optional -- for private use, you can simply keep it in your
+local catalog or share the image and instructions with colleagues.
+
+## Step 6: Securely Expose and Interact with the Connector
+
+Security is crucial when allowing an AI to execute tools. Docker's MCP
+Toolkit provides several built-in safeguards:
+
+- **Container isolation and limits:** Your MCP tool runs in a
+  locked-down container. By default it has no access to your host
+  filesystem, and is constrained to 1 CPU core and 2GB
+  RAM[\[25\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=,potential%20misuse%20of%20computing%20resources).
+  This prevents a runaway tool from hogging resources or snooping on
+  your files. The container is labeled and managed by Docker, and you
+  only explicitly mount volumes or increase limits if you choose to (for
+  example, if you enable the `filesystem` MCP server, you must configure
+  which host directory it can
+  access[\[41\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=cat%20,com%20EOF)).
+
+- **Secrets management:** If your connector needs API keys or tokens
+  (for accessing third-party APIs), avoid baking them into the image.
+  The Docker MCP CLI lets you inject secrets at runtime. For instance,
+  to provide an API key for a custom "Brave Search" MCP server, you'd
+  run `docker mcp secret set 'brave.api_key=XXXXX'` before starting
+  it[\[42\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=To%20safely%20store%20secrets%20on,we%20provide%20a%20CLI%20interface).
+  The gateway will pass it to the container as an environment variable,
+  keeping the secret out of code and version control.
+
+- **OAuth support:** The MCP Gateway and ChatGPT both support OAuth
+  flows for connectors. If your tool requires user authorization (e.g.,
+  a Google Drive connector), implement the OAuth 2.0 code flow in your
+  MCP server (the OpenAI connector spec supports this). The Docker
+  toolkit can handle port-forwarding for OAuth callbacks and even
+  dynamic client registration in some cases. For example, the GitHub MCP
+  server uses OAuth -- Docker's toolkit helps initiate that flow and
+  stores tokens
+  securely[\[43\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=match%20at%20L935%201,Official%20server%20and%20add%20it)[\[44\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=1,Official%20server%20and%20add%20it).
+  If you marked the connector as "OAuth" in ChatGPT, ChatGPT will expect
+  to go through a browser login and callback as part of adding the
+  connector.
+
+- **Active monitoring:** The open-source MCP Gateway offers
+  **interceptors** to enforce security at
+  runtime[\[45\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=Secure).
+  For example, you can run the gateway with `--verify-signatures` (to
+  only run Docker-signed images), `--block-secrets` (to scan and block
+  any traffic that looks like sensitive info such as API keys), and
+  `--log-calls` (to record all tool
+  usage)[\[46\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=These%20can%20be%20enabled%20when,starting%20the%20gateway).
+  These can be enabled as needed to guard against misuse. Additionally,
+  ChatGPT itself wraps tool outputs and will warn if a tool tries to
+  output disallowed content.
+
+- **Transport security:** Always use HTTPS for the MCP connection if not
+  on localhost. Cloudflare Tunnel or a TLS reverse proxy is essential if
+  you're exposing to the internet, so that the traffic between ChatGPT
+  and your server is encrypted. If you use Cloudflare Zero Trust, you
+  can even put your MCP endpoint behind an Access policy (requiring a
+  login or token to reach it), effectively restricting who can call your
+  tool.
+
+Finally, **test the end-to-end interaction carefully**. In ChatGPT, try
+out your connector with both valid and invalid inputs to see how it
+responds. Check Docker logs (`docker logs <container>`) or the gateway
+output for any errors or unexpected behavior. Iterate on your code if
+needed to handle edge cases. Remember that ChatGPT will formulate the
+tool calls, so ensure your tool's input schema and descriptions are
+clear to the model (the SDK usually handles exposing these details to
+the AI).
+
+By following these steps, you have created a custom MCP-compatible tool,
+packaged it in Docker, and made it available to ChatGPT. You can run it
+locally for personal use or host it remotely for broader access. With
+the Docker MCP Toolkit managing the heavy lifting (container
+orchestration, security, and client compatibility), integrating custom
+tools into ChatGPT becomes much
+easier[\[47\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=%2A%20Cross,to%20access%20installed%20MCP%20servers).
+This opens up exciting possibilities -- from connecting to internal data
+sources to performing actions on your behalf -- all through the familiar
+ChatGPT interface, but powered by your custom code. Enjoy your new
+connector, and hack responsibly!
+
+**Sources:**
+
+1.  Docker Docs -- *MCP Toolkit
+    Overview*[\[1\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=The%20Docker%20MCP%20Toolkit%20is,tool%20discovery%20to%20local%20execution)[\[25\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=,potential%20misuse%20of%20computing%20resources)
+2.  Docker MCP Gateway GitHub -- *CLI Usage and
+    Examples*[\[20\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=An%20MCP%20Gateway%20exposes%20a,can%20be%20enabled%20by%20default)[\[46\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=These%20can%20be%20enabled%20when,starting%20the%20gateway)
+3.  ChatGPT Dev Mode Tutorial (GitHub Gist) -- *Setting up a
+    Connector*[\[34\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=1)[\[36\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=5)
+4.  Model Context Protocol SDK (TypeScript/Python) -- *Quickstart
+    Examples*[\[6\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=%2F%2F%20Create%20an%20MCP%20server,server%27%2C%20version%3A%20%271.0.0%27)[\[5\]](https://github.com/modelcontextprotocol/python-sdk#:~:text=,return%20a%20%2B%20b)
+5.  *The Complete MCP Server Guide* (DevShorts) -- *Containerizing &
+    Deploying MCP
+    Servers*[\[13\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=docker%20build%20)[\[28\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=Deploy%20with%20Railway)
+6.  Reddit / Community Discussions -- *Exposing MCP Servers (Cloudflare
+    Tunnel
+    tips)*[\[29\]](https://www.reddit.com/r/mcp/comments/1l6y9za/how_to_turn_local_mcp_server_into_remote_one/#:~:text=How%20to%20turn%20local%20MCP,6)
+
+------------------------------------------------------------------------
+
+[\[1\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=The%20Docker%20MCP%20Toolkit%20is,tool%20discovery%20to%20local%20execution)
+[\[22\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=1,mcp.json)
+[\[23\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=,mcp)
+[\[24\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=Example%3A%20Use%20Claude%20Desktop%20as,a%20client)
+[\[25\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=,potential%20misuse%20of%20computing%20resources)
+[\[37\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=match%20at%20L958%20Imagine%20you,Claude%20Desktop%20as%20a%20client)
+[\[38\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=match%20at%20L969%20Desktop%20if,servers%20in%20the%20MCP%20Toolkit)
+[\[39\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=,file)
+[\[43\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=match%20at%20L935%201,Official%20server%20and%20add%20it)
+[\[44\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=1,Official%20server%20and%20add%20it)
+[\[47\]](https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/#:~:text=%2A%20Cross,to%20access%20installed%20MCP%20servers)
+MCP Toolkit \| Docker Docs
+
+<https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/>
+
+[\[2\]](https://techwithibrahim.medium.com/run-any-mcp-server-locally-with-dockers-mcp-catalog-and-toolkit-f8ecbe0c6a79#:~:text=At%20the%20core%20of%20this,logic%20for%20each%20use%20case)
+[\[14\]](https://techwithibrahim.medium.com/run-any-mcp-server-locally-with-dockers-mcp-catalog-and-toolkit-f8ecbe0c6a79#:~:text=Step%201%3A%20Enable%20Docker%20MCP,Toolkit)
+[\[15\]](https://techwithibrahim.medium.com/run-any-mcp-server-locally-with-dockers-mcp-catalog-and-toolkit-f8ecbe0c6a79#:~:text=Step%202%3A%20Install%20an%20MCP,Server)
+Run Any MCP Server Locally with Docker's MCP Catalog and Toolkit \| by
+Ali Ibrahim \| Medium
+
+<https://techwithibrahim.medium.com/run-any-mcp-server-locally-with-dockers-mcp-catalog-and-toolkit-f8ecbe0c6a79>
+
+[\[3\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=Model%20Context%20Protocol%20,0%20for%20communication%20and%20supports)
+[\[32\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=Since%20the%20September%209th%2C%202025,available%20to%20all%20ChatGPT%20users)
+[\[33\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=%2A%20Go%20to%20,Create%20a%20New%20Connector)
+[\[34\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=1)
+[\[35\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=%2A%20Check%20,time%20setup)
+[\[36\]](https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb#:~:text=5)
+ChatGPT App SDK & MCP Developer Mode MCP - Complete Tutorial · GitHub
+
+<https://gist.github.com/ruvnet/7b6843c457822cbcf42fc4aa635eadbb>
+
+[\[4\]](https://huggingface.co/learn/mcp-course/en/unit1/sdk#:~:text=MCP%20SDK%20,clients%20and%20servers%20in)
+MCP SDK - Hugging Face MCP Course
+
+<https://huggingface.co/learn/mcp-course/en/unit1/sdk>
+
+[\[5\]](https://github.com/modelcontextprotocol/python-sdk#:~:text=,return%20a%20%2B%20b)
+[\[9\]](https://github.com/modelcontextprotocol/python-sdk#:~:text=,Hello%2C%20%7Bname)
+GitHub - modelcontextprotocol/python-sdk: The official Python SDK for
+Model Context Protocol servers and clients
+
+<https://github.com/modelcontextprotocol/python-sdk>
+
+[\[6\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=%2F%2F%20Create%20an%20MCP%20server,server%27%2C%20version%3A%20%271.0.0%27)
+[\[7\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=%2F%2F%20Set%20up%20Express%20and,json)
+[\[8\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=%2F%2F%20Add%20a%20dynamic%20greeting,)
+[\[10\]](https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file#server#:~:text=as%3A)
+GitHub - modelcontextprotocol/typescript-sdk: The official TypeScript
+SDK for Model Context Protocol servers and clients
+
+<https://github.com/modelcontextprotocol/typescript-sdk/tree/main?tab=readme-ov-file>
+
+[\[11\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=4,Deployment)
+[\[12\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=%23%20Create%20a%20non,R%20app%3Aapp%20%2Fapp%20USER%20app)
+[\[13\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=docker%20build%20)
+[\[27\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=3)
+[\[28\]](https://www.devshorts.in/p/the-complete-mcp-server-guide#:~:text=Deploy%20with%20Railway)
+The Complete MCP Server Guide - by Aravind Putrevu
+
+<https://www.devshorts.in/p/the-complete-mcp-server-guide>
+
+[\[16\]](https://github.com/docker/mcp-gateway#:~:text=The%20MCP%20Toolkit%2C%20in%20Docker,from%20the%20Docker%20MCP%20Catalog)
+[\[17\]](https://github.com/docker/mcp-gateway#:~:text=Catalog%20Management)
+[\[18\]](https://github.com/docker/mcp-gateway#:~:text=%2A%20%60docker,Enabled%20tools%20per%20server)
+[\[19\]](https://github.com/docker/mcp-gateway#:~:text=,mcp%20server%20ls)
+GitHub - docker/mcp-gateway: docker mcp CLI plugin / MCP Gateway
+
+<https://github.com/docker/mcp-gateway>
+
+[\[20\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=An%20MCP%20Gateway%20exposes%20a,can%20be%20enabled%20by%20default)
+[\[21\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=docker%20mcp%20gateway%20run%20,tools%3Dbrave_web_search%2Cget_article%2Cget_summary%2Cget_related_topics)
+[\[40\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=As%20the%20Official%20MCP%20Registry,server%20authors%20publish%20will%20change)
+[\[41\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=cat%20,com%20EOF)
+[\[42\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=To%20safely%20store%20secrets%20on,we%20provide%20a%20CLI%20interface)
+[\[45\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=Secure)
+[\[46\]](https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/#:~:text=These%20can%20be%20enabled%20when,starting%20the%20gateway)
+Docker MCP Gateway: Unified, Secure Infrastructure for Agentic AI Docker
+MCP Gateway: Open Source, Secure Infrastructure for Agentic AI \| Docker
+
+<https://www.docker.com/blog/docker-mcp-gateway-secure-infrastructure-for-agentic-ai/>
+
+[\[26\]](https://thamizhelango.medium.com/connecting-local-mcp-servers-to-publicly-exposed-llm-apis-a-complete-guide-12658f464e51#:~:text=The%20NAT%20Challenge)
+Connecting Local MCP Servers to Publicly Exposed LLM APIs: A Complete
+Guide \| by ThamizhElango Natarajan \| Medium
+
+<https://thamizhelango.medium.com/connecting-local-mcp-servers-to-publicly-exposed-llm-apis-a-complete-guide-12658f464e51>
+
+[\[29\]](https://www.reddit.com/r/mcp/comments/1l6y9za/how_to_turn_local_mcp_server_into_remote_one/#:~:text=How%20to%20turn%20local%20MCP,6)
+How to turn local MCP server into remote one? - Reddit
+
+<https://www.reddit.com/r/mcp/comments/1l6y9za/how_to_turn_local_mcp_server_into_remote_one/>
+
+[\[30\]](https://noted.lol/cloudflare-tunnel-and-zero-trust/#:~:text=Image)
+[\[31\]](https://noted.lol/cloudflare-tunnel-and-zero-trust/#:~:text=Now%20all%20that%27s%20left%20to,is%20add%20your%20Public%20Hostname)
+Setup your Domain using Cloudflare Tunnels and Zero Trust
+
+<https://noted.lol/cloudflare-tunnel-and-zero-trust/>

--- a/pmoves/docs/context/Constellation-Harvest-Regularization/Understanding Range-Partition-Entropy (RPE).md
+++ b/pmoves/docs/context/Constellation-Harvest-Regularization/Understanding Range-Partition-Entropy (RPE).md
@@ -1,0 +1,147 @@
+# **Understanding Range-Partition-Entropy (RPE)**
+
+## **Introduction**
+
+When we think about information, we often imagine it as something that
+can be measured in bits or probabilities. One of the most famous tools
+for this is **entropy**---a way of measuring uncertainty or disorder in
+data. Entropy tells us how much surprise there is in a dataset, but it
+usually works as one number for the whole thing. That's powerful, but
+sometimes it's too simple.
+
+Enter **Range-Partition-Entropy (RPE)**. This idea extends traditional
+entropy by looking not just at the whole dataset at once, but by
+breaking it into parts---\"partitions\"---and measuring how disorder is
+distributed across them.
+
+## **What It Means**
+
+- **Partitioning**: Imagine you have a dataset of numbers, like test
+  scores. Instead of looking at all the scores as one big pile, you
+  split them into ranges: 0--50, 51--75, 76--100.
+
+- **Entropy in Each Partition**: For each range, you calculate the
+  entropy---how unpredictable the values are within that range.
+
+- **Putting It Together**: By combining these local entropy measures,
+  you get a structured view of the whole dataset's uncertainty.
+
+In simple terms: RPE doesn't just say *"how messy is the whole thing?"*
+It asks, *"where is the mess, and how is it spread out?"*
+
+## **Why It's Useful**
+
+- **Reveals hidden patterns**: Some areas of data may be highly
+  predictable (low entropy), while others are full of surprises (high
+  entropy). RPE shows you both.
+
+- **Works with unstructured data**: If your dataset has no obvious
+  order, partitioning helps turn it into structured pieces that can be
+  analyzed.
+
+- **Better data preparation**: By knowing which parts of data are noisy,
+  you can clean, balance, or emphasize the right regions before training
+  a model.
+
+## **Everyday Analogy**
+
+Think of entropy as noise in a room. A single number for the entire room
+might say it's "medium loud." But RPE is like walking around with a
+sound meter: it shows you that the corner by the window is quiet, the
+middle is noisy, and the back wall has bursts of chatter. That's far
+more useful if you want to understand what's really going on.
+
+## **Where It Fits in AI**
+
+- **Training datasets**: RPE can help identify which slices of your data
+  add the most value or introduce the most chaos.
+
+- **Model insights**: It can highlight what parts of a model's latent
+  space are structured versus noisy.
+
+- **Anomaly detection**: If one partition is unexpectedly random, that
+  may reveal errors or outliers.
+
+## **Conclusion**
+
+Range-Partition-Entropy is a way of looking at information that goes
+beyond a single summary number. By measuring disorder across partitions,
+it lets us see the shape of information, not just its total. It's like
+moving from a blurry snapshot to a detailed map---giving us tools to
+better understand, prepare, and make use of data.
+
+# **Thinking About Geometry Like an AI Model**
+
+## **Introduction**
+
+When most people imagine geometry, they think of familiar shapes from
+school: squares, triangles, and circles drawn on flat paper. This is
+**Euclidean geometry**, the geometry of our everyday experience. But AI
+models don't "see" the world this way. To understand how they think, we
+need to expand our idea of geometry.
+
+## **Beyond Flat Shapes**
+
+AI models often work in spaces that don't look anything like flat paper.
+Instead, they live in **high-dimensional spaces**---mathematical worlds
+where each "direction" represents a feature of the data. For example:
+
+- In 2D, a point can be described by *(x, y)*.
+
+- In 3D, by *(x, y, z)*.
+
+- In an AI model, a point might need hundreds or even thousands of
+  numbers to describe it.
+
+These spaces are not easy to visualize, but the rules of geometry still
+apply. Distances, angles, and curves all matter---they just exist in
+more dimensions than we can picture.
+
+## **Curved Geometry**
+
+AI also relies on **non-Euclidean geometries**. These are geometries
+where space itself can be curved:
+
+- **Hyperbolic geometry**: Shapes spread out faster than in flat space,
+  useful for representing hierarchies (like family trees or taxonomies).
+
+- **Spherical geometry**: Shapes wrap around like on the surface of a
+  globe, useful for periodic data or directions.
+
+For AI, these alternative geometries are not exotic---they are practical
+tools to better match the shape of real-world data.
+
+## **Why Geometry Matters to AI**
+
+- **Latent space**: AI models represent knowledge as points in a
+  high-dimensional space. Geometry tells us how close or far concepts
+  are.
+
+- **Learning structure**: If the data has hierarchy, cycles, or
+  clusters, the model adjusts its "geometry" to fit.
+
+- **Generalization**: By shaping geometry, models learn patterns that go
+  beyond memorization.
+
+## **Everyday Analogy**
+
+Think of geometry like different kinds of maps:
+
+- A **flat street map** (Euclidean) works fine for a small neighborhood.
+
+- A **globe** (spherical geometry) is better for representing the whole
+  Earth.
+
+- A **tree diagram** (hyperbolic geometry) is better for showing
+  branching structures like language or ancestry.
+
+An AI model switches between these "maps" depending on the problem,
+often combining them in ways we cannot visualize directly.
+
+## **Conclusion**
+
+AI does not think in terms of just squares and triangles. It thinks in
+terms of entire landscapes---sometimes flat, sometimes curved, often in
+thousands of dimensions. To think like an AI model is to accept that
+geometry is not one-size-fits-all. It's a flexible language for
+describing how data is shaped, connected, and transformed.

--- a/pmoves/docs/context/Technical Review of PMOVES v5 Architecture and Service Contracts.md
+++ b/pmoves/docs/context/Technical Review of PMOVES v5 Architecture and Service Contracts.md
@@ -1,0 +1,1332 @@
+# Technical Review of PMOVES v5 Architecture and Service Contracts
+
+**Overview:** PMOVES (POWERFULMOVES) v5 is a distributed, multi-agent AI
+system that orchestrates *creative workflows* and *knowledge retrieval*
+across a cluster of GPU workstations and edge devices. It integrates a
+variety of services -- from **ComfyUI** (for generative content
+creation) and **Jellyfin** (media streaming) to **Supabase/Postgres**
+(as a unified database with vector search), **Qdrant** (vector store),
+**Neo4j** (graph DB), **MeiliSearch** (full-text search), and **n8n**
+(workflow automation) -- all coordinated by intelligent agents (Agent
+Zero, Archon, etc.) running in Docker containers. This review evaluates
+the **system architecture** (modularity, scalability, fault tolerance,
+GPU/Jetson support, and integration of new components like the CHIT
+geometry bus and rerankers), the **service contracts and workflows**
+(Presign service, render webhook, publisher, Supabase event handling),
+the **multi-agent persona and retrieval pipeline** (persona routing,
+CHIT/ShapeStore readiness, multi-decoder integration), and finally
+provides **recommendations** for improvements and next steps.
+
+## 1. System Architecture: Orchestration Mesh and Components
+
+**High-Level Architecture:** The PMOVES architecture is structured in
+layers, with a *central orchestrator* agent (Agent Zero) delegating
+tasks to various subsystems, and a backbone of shared databases and
+services connecting everything. Key components include:
+
+- **Agent Zero (Central Brain)** -- the core decision-maker that manages
+  overall operations and can spawn subordinate agents. It interfaces
+  with users (interactive CLI/terminal) and coordinates all other
+  components.
+- **Archon (Knowledge & Task Management)** -- an agent specializing in
+  knowledge ingestion and agent-building. Archon ingests data (web
+  crawls, documents, transcripts) using *LangExtract* (LLM-powered
+  information extraction) and populates structured knowledge
+  (entities/relations) into Neo4j graphs and Supabase. It also helps
+  construct specialized sub-agents, leveraging advanced
+  retrieval-augmented generation (HiRAG).
+- **n8n (Workflow Engine)** -- a low-code orchestration service that
+  acts as the "glue" among agents and services. n8n flows implement the
+  **Model Context Protocol (MCP)**, enabling Agent Zero to call on other
+  services in a sequence. For example, Agent Zero can delegate a task to
+  the Jellyfin media pipeline via n8n and then trigger a ComfyUI
+  generation workflow based on the results. This creates a seamless mesh
+  of automation across the stack.
+- **Specialized AI Services:** *HiRAG* (Hierarchical RAG) builds
+  multi-layer indices and performs deep retrieval for complex queries.
+  *LangExtract* transforms unstructured text into structured data with
+  source grounding (e.g. extracting entities from transcripts).
+  *ComfyUI* provides a visual pipeline for content creation
+  (text-to-image/video, etc.), extended with custom nodes to interact
+  with PMOVES (MinIO upload and webhook callback). These "AI muscles"
+  handle heavy ML tasks and feed results back into the knowledge loop.
+- **Data and Storage Services:** *Supabase* (Postgres with pgvector)
+  serves as the **unified database** for PMOVES -- storing documents,
+  embeddings, agent knowledge, and system state. It also provides user
+  management and a web UI (Supabase Studio) for certain admin tasks.
+  *Qdrant* is used for vector similarity search on embeddings (e.g. for
+  semantic retrieval of documents), while *Neo4j* stores the knowledge
+  graph of entities/relations for graph-aware reasoning. *MeiliSearch*
+  is optionally used for lexical full-text search to complement vector
+  results. For file/object storage (media files, PDFs, AI outputs),
+  PMOVES uses *MinIO* (an S3-compatible local object store). Finally,
+  *Jellyfin* acts as a media server where finalized videos/audio are
+  catalogued and streamed (it's part of the **"AI Media Stack"** for
+  content consumption).
+
+All these components are containerized and deployed via Docker Compose.
+The architecture explicitly targets a **hybrid deployment**:
+high-performance workstations and **NVIDIA Jetson** edge devices
+collaborate in the network. The underlying **infrastructure** uses
+Tailscale for networking and Docker for isolation, allowing PMOVES to be
+*self-hosted* and scaled out. The *Cataclysm Provisioning* workflow
+automates installation on new nodes: a Ventoy USB bundle contains OS
+images and config scripts that install Docker, set up environment
+variables, and launch the PMOVES stack on each machine. This enables
+consistent multi-node deployments -- for example, several Ubuntu
+workstations and Jetson Orin devices can be flashed and have the PMOVES
+Docker stacks brought up in one coordinated process. Secrets (API keys,
+tokens) are templated in the `.env` files and get populated during this
+provisioning, potentially pulling from a central secure source (Supabase
+or provided configs). In summary, the system is designed as a **modular
+orchestration mesh** of services, with each service focusing on a
+specific concern and communicating through well-defined interfaces
+(APIs, databases, message events). This modularity improves
+maintainability -- for instance, the vector index (Qdrant) or the media
+server can be updated or replaced independently -- and helps with
+scalability and isolation (heavy jobs can be offloaded to specific
+containers or devices).
+
+**Integration and Data Flow:** There is strong evidence of effective
+integration among components. When media content (say a YouTube video)
+is ingested through Jellyfin and analysis services, the outputs
+(transcripts, detected objects, etc.) flow into the knowledge stores:
+LangExtract produces structured data that populates Neo4j and Supabase,
+HiRAG then uses those to build hierarchical indices, and ultimately
+Agent Zero can query this enriched knowledge base. Agent Zero uses n8n
+to orchestrate these steps end-to-end. For example, *Agent Zero → n8n →
+Jellyfin stack* might download and analyze a video, then *n8n → ComfyUI*
+might generate a visual summary or related art, all in one workflow.
+This "networked AI" approach creates a *synergy between research, data
+processing, and content generation* -- agents can retrieve deep insights
+from analyzed media and immediately use them to create new content or
+make decisions. The architecture's layered design (with Agent Zero at
+the top, support systems like Archon/n8n in the middle, and specialized
+services and data stores at the bottom) ensures a clear separation of
+concerns while still enabling rich interactions across layers.
+
+**Modularity & Scalability:** Each service in PMOVES is packaged as a
+microservice, often with its own Docker Compose *profile*. This means
+you can run only the subset of services needed for a particular scenario
+(for instance, skip heavy GPU services on a Jetson, or run just the
+"data" profile for the database). This modularization is a strength: it
+supports horizontal scaling (e.g., multiple instances of a service
+behind a load balancer if needed) and clear fault boundaries. The use of
+Docker Compose (rather than Kubernetes at this stage) is reasonable for
+a self-hosted project -- it favors simplicity. The documentation even
+includes scripts to assist with assembling the compose file and
+environment for different profiles (e.g., combining base `.env` with
+service-specific additions, as described in the smoke tests). Scaling
+out to more machines is facilitated by the Cataclysm bundle as noted,
+and by using lightweight communication (HTTP APIs, NATS messages, or
+Supabase events) rather than tightly coupled function calls. The
+*Supabase* backend can scale vertically (as it's just PostgreSQL with
+extensions) or be replaced with a managed service if needed. *Qdrant*
+supports clustering for vectors, and *Neo4j* can also scale, though in
+the current setup they likely run single-instance. One area of future
+consideration is **service discovery and load balancing** -- Compose
+uses static hostnames and networks, which works on a single host or a
+flat network, but as the deployment grows to multiple physical nodes,
+ensuring that (for example) Agent Zero on Machine A can talk to service
+X on Machine B might require either Docker Swarm mode or careful
+Tailscale routing. Right now, the provisioning implies each machine runs
+a portion of the stack (some services on workstations, some on Jetsons),
+which is a form of functional partitioning (edge devices handle certain
+tasks like video decoding or sensor processing, while servers handle
+heavier tasks). This is scalable as long as the workload can be split
+that way. The architecture document explicitly notes that *edge devices
+run a subset of Docker Compose files* (like only the audio/video
+analysis services on a Jetson), which prevents overloading the smaller
+devices and leverages them for what they're good at (e.g. using the
+Jetson's GPU for specialized models). Overall, the architecture is
+**well-modularized** and seems capable of scaling to a modest cluster of
+heterogeneous nodes. For very large scale or multi-tenant scenarios, a
+move to Kubernetes and dynamic scaling might be warranted in the future,
+but for the project's scope (self-hostable orchestration across personal
+devices), the current approach is appropriate.
+
+**Failure Recovery & Fault Tolerance:** Because PMOVES consists of
+decoupled services, a failure in one component (say the ComfyUI
+container crashing) shouldn't bring down the whole system. Docker will
+attempt to restart failed containers by default. The design relies on
+**stateless or state-light services** wherever possible; most state is
+in the databases (Supabase, etc.), so restarting a service process is
+not catastrophic. That said, more robust failure recovery mechanisms are
+still a work in progress. There isn't mention of an orchestrator
+monitoring the health of each service beyond basic Docker behavior. The
+**Next Steps** list highlights the need for health and readiness probes
+for services, which will help in detecting when something is wrong and
+potentially enable automated restarts or traffic shifting. Additionally,
+the event-driven parts of the system (like NATS or Supabase triggers)
+would benefit from a **dead-letter queue** or retry logic: this is
+explicitly noted as a to-do ("standardize ingest. *topics and
+dead-letter queue; idempotent handlers"). Implementing that will prevent
+data from being lost if, for example, the Indexer service is down when a
+"new content" event is emitted -- the event could be retried later.
+Plans for* *backups and disaster recovery*\* are on the roadmap
+(Milestone M5 mentions Proxmox Backup Server, snapshots, and drills),
+which is important if this system is to be production-ready and not just
+a lab setup. In summary, the current fault tolerance is modest (relying
+on service isolation and restarts), but the team is aware and planning
+to bolster it with proper health checks, retries, and backups. Running
+the whole stack on multiple machines also adds some inherent resilience
+(e.g., if one Jetson goes offline, others can still operate, though
+tasks targeted to the down device would fail unless rerouted). A central
+point of failure could be the Supabase DB -- if it goes down, much of
+the system's state becomes inaccessible. Ensuring a backup or
+high-availability setup for the database would be a future consideration
+for robustness.
+
+**GPU and Jetson Compatibility:** A notable aspect of PMOVES v5 is its
+support for **NVIDIA Jetson Orin** devices as first-class citizens in
+the architecture. The documentation shows careful attention to this:
+after the Jetson's OS (JetPack) is installed, a `jetson-postinstall.sh`
+script configures Docker with NVIDIA runtime so that GPU-accelerated
+containers can run on the Jetson. Certain heavy AI functions are *kept
+optional or disabled on Jetsons* to accommodate their lower power. For
+example, the use of CLIP (for image embedding) and CLAP (audio) decoders
+in the geometry service is "gated by profile," meaning on Jetson profile
+those might default off. Similarly, the YouTube ingestion flow switches
+to a more efficient Whisper variant -- `faster-whisper` -- which can
+automatically detect if a GPU is present and use it, including on
+Jetson, for faster transcription. This adaptive approach is great for
+heterogeneous environments. The *Cataclysm* deployment also allows
+*selectively deploying only certain Compose stacks on Jetson* (e.g., one
+might not deploy the entire ComfyUI or HiRAG on an edge device). All of
+this indicates strong Jetson support. The inclusion of Tailscale means
+even if the Jetson is remote (on a different network), it can securely
+join the PMOVES mesh and exchange data. **GPU acceleration** on desktops
+is utilized (for example, local LLMs like NVIDIA NeMo or the Hi-RAG GPU
+gateway can run with GPU). They provide separate Compose profiles for
+GPU-enabled versions of services (like `hi-rag-gateway-v2-gpu`). It's
+noted that Jetson uses L4T (Linux for Tegra) base images and that some
+models might not run due to architecture or performance, but workarounds
+are present (e.g., one Jetson can offload certain tasks to a more
+powerful host via the mesh if needed). In conclusion, PMOVES v5 appears
+**compatible with Jetson out of the box**, with thoughtful configuration
+to ensure that low-power nodes contribute appropriately without being
+overwhelmed. This is a positive aspect, as it widens the range of
+hardware on which PMOVES can operate (useful for on-premises personal AI
+setups that include DIY edge devices).
+
+**Geometry Bus (CHIT) Integration:** One of the novel additions in
+PMOVES v5 is the **Geometry Bus** using the CHIT (Canonical Hypermedia
+Information Transfer) Geometry Packet format. This is essentially a new
+data layer that allows all modalities -- video, audio, text, image -- to
+be linked through a shared geometric "anchor" space. Concretely, when
+the system analyzes media, it generates a *CHIT Geometry Packet (CGP)*
+which contains: - **Anchors** (essentially reference frames or
+coordinates in an abstract space), - **Constellations** (groups of
+points with an anchor and metadata like a summary or spectrum of the
+content), and - **Points** (individual data points with
+modality-specific references, like "video X at 12.5s" or "document Y
+tokens 100-200").
+
+These geometry packets are standardized as JSON structures
+(`spec: chit.cgp.v0.1`) and are stored in a set of new database tables:
+`anchors`, `constellations`, `shape_points`, plus a `shape_index` for
+quick lookup by shape_id. The **purpose** of this bus is to enable
+*cross-modal navigation* and alignment -- so an AI agent or user can
+jump between a point in a video and the corresponding transcript text,
+or see related content across media types, all through the common
+geometry space. Integration status: the roadmap indicates the minimal
+schema and event publishing for geometry bus were delivered in Milestone
+2.5. Analysis services (video, audio, etc.) are expected to emit a
+`geometry.cgp.v1` event whenever a new packet is produced. The PMOVES
+gateway (likely the Hi-RAG Gateway v2) has an in-memory **ShapeStore**
+-- essentially a cache of recent shape packets keyed by `shape_id` -- to
+allow rapid access without constantly querying the DB. This is critical
+for interactive use; for example, a user scrubbing through a video can
+see associated text snippets pop up in near real-time, because the
+gateway can fetch the constellation from ShapeStore by ID in under
+100ms.
+
+The geometry bus is *wired into the retrieval and UI layers*: there is a
+static web UI at `/geometry/` (served by the gateway) that visualizes
+these anchors/constellations on a canvas and listens for geometry
+events. Multiple clients can connect and even share geometry data via
+WebRTC peer-to-peer "shape handshakes" -- essentially one PMOVES node
+can send a geometry capsule to another, either directly or via a NATS
+mesh topic. This enables collaborative scenarios or future federation
+(two PMOVES systems sharing insights without sharing raw data). The
+integration appears quite thorough: endpoints are defined for posting
+geometry events, retrieving jump locators for a point (to, say, open the
+exact media segment in Jellyfin or to scroll a transcript), and even
+decoding geometry into summaries (`/geometry/decode/text|image|audio`)
+and performing calibration checks. Those endpoints are gated by env
+flags like `CHIT_DECODE_TEXT` to enable the ML-based decoders.
+Additionally, security considerations have been built in -- environment
+flags can require HMAC signing on packets and allow encryption of
+anchors, and a `tools/chit_security.py` is provided for
+signing/verifying and encrypting the geometry capsules. The UI and
+protocol are designed such that the *client (UI)* drives the interaction
+(pulling shapes, sending share requests), and the server mostly provides
+data on request, which is a good design for responsiveness and keeping
+the server stateless.
+
+From an **architecture perspective**, the geometry bus adds a powerful
+dimension to PMOVES, essentially a graph that spans all media and can be
+traversed by geometry. The current state is that the foundation is in
+place (spec, tables, API, basic UI). The *readiness* of this feature
+depends on the upstream analysis: for example, do the YouTube ingestion
+workers already produce meaningful constellations of points? According
+to the docs, the plan is: after downloading a video and generating a
+transcript, additional analysis (e.g., scene detection, audio emotion
+detection) will create constellations aligned on a timeline, then
+publish a CGP event. There are explicit to-dos to insert video
+`detections` and audio `emotions` into Supabase and emit these events.
+So it's likely not all analysis steps are fully implemented yet, but the
+system is architected to accommodate them. Once those are done, the
+geometry bus will become a richly populated layer that agents like
+Archon or Agent Zero can query. For instance, an agent could ask, "find
+the moment where person X is mentioned with sentiment Y in my videos,"
+and instead of searching purely text, it could consult the
+geometry-indexed points (this is speculative, but feasible with the data
+structure). In summary, the geometry bus integration is
+**forward-thinking and mostly in place** -- it standardizes multimodal
+data exchange via CGP and already ties into the PMOVES event loop and
+UI. The next steps will be to utilize it fully in retrieval (making
+agents *geometry-aware*) and to ensure all producers of data are
+emitting the needed packets. But architecturally, it's well-designed and
+adds to PMOVES' modularity (it is essentially a new
+microservice/pipeline that other parts can opt into without breaking
+existing text-based flows).
+
+**Reranker Integration:** In the retrieval pipeline, PMOVES v5 includes
+a **neural reranker** to improve search result quality. The *Hi-RAG
+Gateway v2* is described as "vector+lexical" hybrid -- meaning it
+combines results from Qdrant (vector similarity) and (optionally)
+MeiliSearch (keyword matching) to cover both semantic and exact matches.
+On top of that, a **FlagEmbedding (BGE)** reranker is available to
+reorder the combined results by relevance. This reranker uses a
+bi-encoder model to score how well each retrieved item matches the
+query, which can significantly boost precision (at some computational
+cost). The integration is done in a *configurable* way: there's an
+environment toggle to turn the reranker on or off. By default, it may be
+enabled since milestone M1 lists it as implemented. This suggests the
+system can operate in two modes -- a faster mode without rerank, and a
+quality mode with rerank. The fact that reranker support was finished
+early (M1 ✅) and further *parameter sweeps and evaluation are slated
+for M3* indicates the team has tested it and plans to fine-tune it. The
+reranker likely operates as part of the HiRAG gateway service (for
+instance, after initial retrieval, it calls the BGE model to score
+results before returning to the agent). The architecture handles this
+nicely by isolating it to the retrieval service -- meaning the rest of
+the system doesn't need to know a reranker is used; they just get better
+results. The *evaluation harness* mentioned (MRR/NDCG scripts, etc.)
+shows a commitment to measure the impact of the reranker and ensure it's
+actually helping (which is great for a research-oriented system like
+this). In operation, the reranker integration seems robust: because it
+can be toggled, one can fall back to pure vector search if the reranker
+model is too slow on certain hardware, which again speaks to modularity.
+No major issues are apparent here; it's a straightforward and wise
+integration to include. One opportunity might be to incorporate
+**learned fusion** of vector and graph signals -- e.g., the reranker
+could consider not just textual relevance but also if an item connects
+well in the knowledge graph context. There's no direct evidence that's
+happening yet, but the pieces (Neo4j, etc.) are there to experiment with
+that in the future. As it stands, **reranker integration in PMOVES v5 is
+a success**, providing improved retrieval quality with minimal hassle
+and with the ability to customize via env settings.
+
+**Rendering & Publishing Pipeline ("Creator Pipeline"):** The system
+architecture doesn't only ingest and analyze content -- it can *create*
+content (images, videos, text) via AI and publish it. This is
+orchestrated through a series of microservices and events that form a
+**rendering pipeline** from generation to user consumption. The flow, as
+documented, is: **ComfyUI (generation)** → **Presign service** → **MinIO
+(storage)** → **Render Webhook** → **Supabase (submission record)** →
+**n8n (notification/approval)** → **Indexer (ingest to search)** →
+**Publisher (publish event)**. Here's how each piece contributes:
+
+- **Presign Service:** A lightweight FastAPI service that runs at
+  `http://…:8088` and issues pre-signed S3 URLs for MinIO. When ComfyUI
+  is about to output a file (image or video), it first calls the Presign
+  API (with a shared secret token for auth) to get a one-time upload URL
+  (PUT) and a download URL (GET) for a specified bucket/path. This
+  ensures ComfyUI can stream the large output directly to MinIO without
+  exposing MinIO's credentials or requiring any manual steps. The
+  presign service restricts which buckets can be used (by default, only
+  `assets` and `outputs` are allowed) for safety. It's a simple but
+  crucial service contract -- essentially functioning as a temporary
+  token vending machine for storage. This has been **implemented and
+  delivered** (as per M2). The design is solid; one improvement noted in
+  the Next Steps is to support multi-part uploads and add checksum
+  verification for very large files (to handle cases where outputs are
+  bigger than a single PUT allows, or to ensure file integrity). That
+  would bolster the Presign service further. Currently, for typical
+  image sizes, the one-shot presigned PUT is fine.
+
+- **ComfyUI Custom Nodes:** On the ComfyUI side, PMOVES provides custom
+  pipeline nodes: "PMOVES -- Upload Image (MinIO)" and "PMOVES --
+  Completion Webhook". A minimal ComfyUI graph for integration would
+  have: *\[Generate Image\]* → *\[PMOVES Upload\]* → *\[PMOVES
+  Completion Webhook\]*. The Upload node calls the Presign URL (using
+  the env `PMOVES_PRESIGN_URL` and token) and then PUTs the file to
+  MinIO. It passes the returned `presigned_get` URL downstream. The
+  Completion Webhook node then POSTs to the PMOVES webhook endpoint with
+  details: it includes the S3 URI of the file, the presigned GET URL (so
+  that downstream consumers have a direct link to the asset), plus
+  metadata like title, author, tags, and a namespace (e.g., `pmoves`).
+  These nodes are configured via environment variables in the ComfyUI
+  process (the URLs and tokens to hit), which decouples them from any
+  hardcoding -- if PMOVES is running elsewhere, you just change the env.
+
+- **Render Completion Webhook Service:** This service (port `8085`)
+  receives the POST from ComfyUI when a render job is done. It expects
+  an auth token as well (`RENDER_WEBHOOK_SHARED_SECRET`) to ensure the
+  caller is trusted. Upon receiving the data (which includes all info
+  needed to identify the asset), the webhook service inserts a new row
+  into the `studio_board` table in Supabase via a REST call. This table
+  entry represents a creative asset that's been submitted. By default,
+  it will have `status = 'submitted'` (unless auto-approve mode is
+  turned on via `RENDER_AUTO_APPROVE=true`). The row contains the
+  metadata (title, tags, author) and the storage link to the asset. This
+  mechanism effectively hands off the generated content to the database,
+  making it visible to other parts of the system. The webhook then ends
+  its job, perhaps returning a success acknowledgment to ComfyUI.
+  Because it's a simple insert followed by further processing via
+  events, the webhook service can remain stateless. It's a clear
+  contract: **ComfyUI** promises to send certain fields, and the webhook
+  service promises to create the DB record and thereby trigger the next
+  steps.
+
+- **Approval and Indexing:** Once the new `studio_board` row is in the
+  database, the content enters a review/approval workflow. In PMOVES v5,
+  the approval is done either manually through Supabase Studio UI or
+  automatically (if the environment is set to auto-approve). The design
+  is such that nothing is published or indexed until an asset is
+  approved -- this is important for curation (especially if multiple AI
+  outputs are being generated, one might want to discard some). If
+  auto-approve is false, a human will go into the Supabase web interface
+  (or a future custom UI) and set the status to \'approved\'. The moment
+  an entry becomes approved, an **Indexing process** kicks in. The
+  *Indexer* is a service (part of the "workers" profile) that likely
+  listens for changes or periodically scans for new approved items. It
+  will take the asset (e.g., fetch the image from MinIO via the provided
+  URL), extract features and index it: generating an embedding to store
+  in Qdrant for future search, extracting any text (if it's a PDF or
+  video with subtitles), adding an entry in MeiliSearch (if used), and
+  possibly creating a node in Neo4j if relevant (for example, linking it
+  to an author or topic). Essentially, the Indexer ensures that the
+  newly created content becomes part of the *retrieval ecosystem* of
+  PMOVES, so that Agent Zero or others can later query and find it. The
+  pipeline documentation confirms "Indexer will ingest; Publisher will
+  post to Discord and link/refresh Jellyfin" once something is approved.
+
+- **Publisher Service:** The final step is publication. The *Publisher*
+  service (also a worker profile service) handles outward-facing updates
+  once content is approved and indexed. According to the docs, it emits
+  a `content.published.v1` **event** to signal that a new piece of
+  content is officially published. It also posts a rich **Discord
+  embed** if a Discord webhook URL is configured (this would include
+  perhaps a preview image, title, and a link so that followers on
+  Discord know new content is available). Additionally, it triggers a
+  **Jellyfin library refresh**. Jellyfin will then scan its library
+  (perhaps an "AI Creations" library) and find the new media file that
+  was added (since the file was in MinIO, and Jellyfin might be set to
+  use MinIO or an attached storage for its content). By refreshing, the
+  content becomes visible in the Jellyfin media server for streaming.
+  The Publisher also logs an audit entry (`publisher_audit` table)
+  recording what it did (for traceability of postings and any errors).
+
+This entire "creator pipeline" is an **excellent demonstration of
+event-driven, microservice-based design**. It connects multiple systems
+(ComfyUI, object storage, DB, notification, media server) in a loosely
+coupled way. Each service has a focused contract: Presign gives URLs,
+Webhook logs the content, Indexer augments search, Publisher notifies
+and syncs. The architecture can be extended (for instance, if we wanted
+to add another action on publish -- say tweet it -- we could extend the
+Publisher or add a new subscriber to the `content.published.v1` event).
+As of v5, the core is in place, though some polish is pending: the
+roadmap notes that **Jellyfin refresh and rich Discord embeds were still
+pending** final implementation in the current sprint. Also, the n8n
+flows for notifications were present but needed wiring up -- presumably
+meaning one must configure the Discord webhook URL in `.env` (which is
+shown) and enable the n8n workflow that listens for new submissions.
+These are minor finish-line tasks. From an improvement standpoint, the
+pipeline might benefit from a dedicated UI for approvals (to avoid using
+the raw database interface), and from more robust error handling (e.g.,
+if the Discord webhook fails or Jellyfin is offline, the Publisher
+should handle that gracefully). But those are details -- architecturally
+it is sound and nicely decoupled.
+
+**Summary of Architecture Assessment:** PMOVES v5's architecture is
+**well thought-out** for a research-heavy, multi-modal AI system. It
+balances *modularity* (distinct services with clear roles),
+*interoperability* (common data backbone in Supabase and event
+channels), and *scalability* (ability to run across devices, use GPUs,
+etc.). The inclusion of advanced features like the geometry bus and
+multi-agent workflows indicates a forward-looking design. There are some
+typical areas to improve (centralized monitoring, easier config
+management, ensuring all parts are production-hardened), which we will
+cover in recommendations. But overall, the architecture achieves its
+vision of a "self-hostable orchestration mesh for creative + agent
+workloads across GPU boxes and Jetsons". It provides a foundation that
+can be extended with new agents or services (for example, integrating a
+new AI service would mean adding it to the compose and possibly writing
+an n8n flow or MCP tool for it, which is straightforward). The use of
+standard technologies (Docker, REST, Postgres) makes it accessible, and
+the documentation indicates a lot of automation is in place to set it
+up.
+
+## 2. Service Contracts and Workflows in v5
+
+This section reviews specific **service contracts** (APIs and
+interactions) in PMOVES v5 and examines aspects of security, validation,
+and observability in those workflows.
+
+### **Presign Service (MinIO Upload Contracts)**
+
+The *Presign* microservice provides an HTTP API that other components
+(like ComfyUI or any uploader) use to get temporary credentials for
+MinIO. The contract is simple: a client (with a valid token) requests a
+URL for a given bucket and file name, and the service responds with a
+JSON containing `url_put` and `url_get` (and maybe an expiry) which can
+be used to upload the file and later retrieve it. Internally, the
+presign service uses MinIO's API (with access key and secret from env)
+to generate these signed URLs.
+
+**Security:** The presign endpoint is protected by a shared secret token
+-- the environment variables `PRESIGN_SHARED_SECRET` is set on the
+service and the client must pass this (likely as a header or param) to
+be authorized. This prevents unauthorized users from getting upload
+access. The service also restricts *which buckets* can be presigned via
+an `ALLOWED_BUCKETS` list in its config. By default, only "assets" and
+"outputs" buckets are allowed, so an attacker can't request a URL to an
+arbitrary private bucket. These are good security measures. One
+suggestion is to log or rate-limit presign requests as well, to avoid
+abuse (someone spamming it to fill storage).
+
+**Input Validation:** The presign service expects the caller to specify
+a bucket, key (path/filename), and maybe file size or content type.
+There's no explicit mention of input validation in the docs --
+presumably, it does minimal checks (like bucket must be in allowed
+list). The Next Steps do mention adding checksum verification after
+upload, which implies the service could in the future accept a checksum
+and then verify the uploaded file's integrity. Also, multi-part upload
+support would involve the service possibly splitting the request or
+issuing multiple chunk URLs, which adds complexity to the contract. For
+now, the contract is straightforward and likely has few validation
+points (other than checking token and bucket). This is an area to
+strengthen (see recommendations: e.g., validate filename characters,
+size limits, etc., to prevent misuse).
+
+**Observability:** Not much is said, but one could expect the presign
+service to log requests (for auditing who uploaded what). Metrics could
+include number of URLs issued, upload sizes, etc., which ties into the
+planned observability improvements.
+
+In summary, the Presign service contract is **well-defined and
+minimal**, doing its job in the pipeline. It could be extended with more
+features as needed, but it's already delivered and functional.
+
+### **Render Completion Webhook Service**
+
+The Render Webhook is a counterpart service that receives notifications
+of completed jobs. The contract here is that a client (ComfyUI node)
+issues an HTTP POST to `/comfy/webhook` with a JSON payload describing
+the finished render. The payload includes fields like `s3_uri` (MinIO
+path of the file), `presigned_get` (a URL to download it), `title`,
+`author`, `tags`, `namespace`, etc.. It also includes an authorization
+token (`PMOVES_WEBHOOK_TOKEN`) which must match the service's
+`RENDER_WEBHOOK_SHARED_SECRET`. If the token is wrong, the service will
+reject the request (ensuring only the trusted ComfyUI instance can
+trigger it).
+
+On receiving a valid request, the webhook service will insert a row into
+Supabase. The specifics (from the environment config) are: it uses
+`SUPA_REST_URL` to know where the PostgREST endpoint is, and likely an
+auth header (anon or service role key) to authenticate to the DB REST
+API. The insertion goes into the `studio_board` table with fields for
+the content (including the URI, title, etc.) and a status. By default,
+`status` is set to `'submitted'` unless the service is configured to
+auto-approve everything (`RENDER_AUTO_APPROVE=true`). There is logic for
+that flag: if auto-approve is true, the service might set the status
+directly to \'approved\' when inserting, bypassing the review queue.
+
+**Reliability:** The contract assumes Supabase is reachable and will
+accept the insert. If that fails (network issue or DB down), the webhook
+service should ideally handle it (maybe retry or log the failure for
+manual recovery). It's not specified, but one would want at least some
+error handling so content isn't silently lost. Possibly n8n or another
+mechanism could detect a missing entry if ComfyUI reports success but
+none appears.
+
+**Security:** As mentioned, it uses a secret token for auth. Also, since
+it inserts into the DB, it likely has the service role key or an
+appropriate role to bypass Row Level Security (if any). The service
+should ensure the data it writes is sanitized. Supabase's PostgREST
+expects JSON; the service can just forward what it got, but it might do
+some normalization (like truncating too-long titles, etc.). There's no
+mention if it validates the tags or namespace -- presumably these are
+freeform. Over time, as the Next Steps note, adding *request validation*
+would be good here too (e.g., ensure title is a string under X length,
+tags are an array of allowed chars, etc.).
+
+**Post-conditions:** Once the row is inserted, the contract is
+essentially fulfilled. The service might return a response to ComfyUI
+(maybe just a 200 OK with some message). ComfyUI, on getting a success,
+would then typically mark the workflow done. If ComfyUI gets an error,
+the user would have to retry or check logs.
+
+**Event Triggering:** The insertion into `studio_board` can trigger
+other processes. In a full Supabase setup, one could have a database
+trigger or the Realtime service pushing an event. The docs suggest using
+n8n for notifications -- likely n8n is polling or has a webhook from
+Supabase when a new row arrives (Supabase can send webhooks on DB events
+or one could use supabase-js to subscribe). The *Realtime Listener*
+example shows how to subscribe to changes on `studio_board` via
+Supabase's websocket channel. If the user has the full Supabase deployed
+(with realtime), they can have a Node listener or n8n listening for
+these changes. If not, n8n might simply query the table every X minutes
+for new \'submitted\'. The contract from the webhook service's
+perspective is done after writing to the DB, but it sets off this chain
+reaction by design.
+
+In summary, the **render webhook contract** is clear and effectively
+passes the baton from the creative tool into PMOVES's data layer. It
+uses proper authentication and ties into Supabase events. Hardening it
+with more validation and error recovery would be the next logical step.
+
+### **Publisher and Supabase Event Handling**
+
+The **Publisher** service is a bit unique because it reacts to changes
+rather than being called via direct HTTP. Its contract is more of a
+*background task contract*: when certain conditions are met in the
+database (content approved) or an event occurs, it performs actions.
+
+In PMOVES v5, since they have Supabase as the central store, there are a
+couple of ways Publisher could know something is approved: - Poll the
+`studio_board` table for entries that moved to `status='approved'` (or
+have `published_at NULL` and now should be processed). - Rely on
+Supabase **Realtime** notifications on that table. - Possibly be
+triggered via n8n (for example, an n8n flow could watch the table and
+then invoke Publisher via HTTP or a message).
+
+The documentation references that enabling Supabase Realtime and
+subscribing to `studio_board` changes is possible. It even provides a
+code snippet using `supabase-js` to log changes. This indicates the
+system supports an event-driven approach. If the user runs
+`supabase start` (full stack), then the Publisher could actually be a
+listener on the Realtime socket channel for that table. However, in the
+default "stub" setup (just PostgREST and DB), Realtime may not be
+running, so an alternate mechanism is needed. The roadmap says n8n flows
+"imports present -- wiring/polish pending (Discord/webhooks)", implying
+n8n might handle sending the Discord notification and perhaps Jellyfin
+refresh, which overlaps with Publisher's role. It's possible that
+*Publisher* is partly implemented but some tasks were being done in n8n
+as a stopgap.
+
+Nonetheless, the intended contract for Publisher is: 1. **Input:** An
+event or condition indicating a piece of content is ready to publish
+(e.g., a `studio_board` row status changes to `approved`). This is the
+trigger. 2. **Processing:** The Publisher fetches necessary data --
+e.g., the content's metadata and link from the DB, possibly the content
+itself if needed (though likely not, it just needs the link). It then
+performs external calls: - Calls Discord webhook URL (provided in env as
+`PUBLISHER_NOTIFY_DISCORD_WEBHOOK`) with a JSON payload to create a
+message embed for the content. The embed might include the title,
+author, tags, and a link (perhaps a link to Jellyfin or a presigned GET
+to view the content). - Calls Jellyfin's API (or triggers via some
+mechanism) to refresh the library if
+`PUBLISHER_REFRESH_ON_PUBLISH=true`. Jellyfin has an API endpoint for
+library scan; the Publisher likely uses the Jellyfin API key configured
+in `.env` to authenticate and tell Jellyfin to scan the media folder
+containing this new item. - Possibly emits an internal event
+`content.published.v1` (maybe via NATS or just logs it). The pipeline
+doc explicitly says "Publisher emits `content.published.v1`, posts
+Discord, and refreshes Jellyfin", so there is a notion of an internal
+event bus. This event could be used by other agents or logging. - Writes
+an entry to `publisher_audit` table noting what happened (time, content
+id, success/failure of Discord, Jellyfin, etc.).
+
+1.  **Output:** There is no direct response needed, as this is triggered
+    in background. The "outputs" are side effects: Discord message
+    visible, Jellyfin updated, and database audit updated. If this were
+    interactive, one might consider sending a notification back to the
+    user or Agent Zero that content XYZ was published successfully.
+
+**Status and Considerations:** According to roadmap, the Publisher
+service scaffold exists but full events/polish are *pending*. This
+suggests the basic functionality is coded but perhaps not thoroughly
+tested or missing final integration steps. For example, maybe it posts
+to Discord but the embed formatting might be rough, or it refreshes
+Jellyfin but the library ID might need to be configured manually. Also,
+the "Jellyfin refresh hook + rich Discord embeds" was listed as pending
+deliverables. So we should assume some work is needed to complete it.
+
+**Supabase Event Handling:** Underlying these flows is how events are
+detected. We touched on Realtime channels. The *REALTIME_LISTENER.md*
+provides a Node.js example of listening to `postgres_changes` on
+specific tables (like `studio_board`) using Supabase's JS client. It
+notes that for the CLI-based Supabase (port 54321), one can easily
+subscribe, but for the Compose-based one, it's trickier and not
+guaranteed to work without extra config. This implies that if a user
+wants live event handling, they should use the Supabase CLI full stack.
+If they don't, an alternative is needed -- presumably n8n as mentioned.
+n8n could periodically check for new submissions or use a webhook from
+the render service directly. In fact, the pipeline might also be
+implemented such that the render webhook directly calls n8n via a
+webhook node for notification. However, the docs clearly integrate it
+with the DB approach.
+
+**Observability & Secret Management in Flows:** All these services
+(Presign, Webhook, Publisher, etc.) rely on secrets (MinIO keys,
+Supabase keys, Discord webhook URLs). These are kept in the `.env` file
+and passed to containers. One challenge is ensuring all these secrets
+are consistent and rotated if needed. The *Cataclysm* deployment helps
+by injecting Supabase credentials into `.env` at provisioning time. The
+Discord webhook and others, however, are user-provided secrets that must
+be manually set. The team is aware of security concerns: they mention
+"Security: signed URLs only; optional content filters; domain allowlist"
+as tasks. For example, ensuring MinIO URLs have an expiration and maybe
+limiting which domains can embed or access content is on their mind.
+
+**Input Validation & Error Handling:** In the Publisher, validating that
+the Discord webhook URL is present before trying to post, or handling a
+Jellyfin failure (maybe Jellyfin not running) are practical issues. The
+Next Steps mention "API hardening" generally, which would include making
+sure these internal service calls handle bad inputs gracefully. For
+instance, if a title is missing, maybe use a default in the Discord
+message rather than failing.
+
+**.env and Compose Simplification:** The question specifically asks
+about simplifying or standardizing `.env` and compose files. Right now,
+the `.env.example` is supplemented by snippet files like
+`env.presign.additions` or `env.hirag.reranker.additions` which the user
+concatenates if they want those features. While this modular approach
+keeps things organized, it can be cumbersome. A single `.env` with
+toggles might be easier. Similarly, there are multiple compose files (or
+YML snippets) for optional pieces. The smoke test instructions
+demonstrate combining profiles (e.g.,
+`docker compose --profile data --profile workers up -d`) to start
+everything. This is fine, but ensuring consistency (that all needed
+profiles are up) is on the user. A potential improvement is to provide a
+unified compose that reads env flags to include/exclude services
+dynamically, or a script that builds the compose command. The docs do
+mention a PowerShell script for bringing up full Supabase vs. not. In
+any case, the current approach works, but it requires careful reading of
+docs. Standardizing it (perhaps providing a Makefile or CLI to configure
+the environment and launch profiles) could help reduce human error.
+
+**Observability of Workflows:** At present, to see the state of the
+pipeline, one would have to check logs of each container or see the
+database entries. There is a plan to integrate Prometheus metrics (which
+could track number of published items, sizes, durations, etc.). Also
+structured logging will help to correlate events (maybe using request
+IDs or content IDs across services to trace a piece of content from
+generation to publish).
+
+**Supabase Usage:** One more note: Supabase in this system is used not
+just as a database but also offers a web UI (Studio) for quickly
+viewing/editing data. This has been leveraged as the interim "Approval
+UI." However, Supabase Studio is a developer tool, not an end-user
+interface, so standardizing and simplifying environment might also
+include decisions like enabling Supabase's authentication and storage
+services (the SUPABASE_FULL.md suggests how to run the full stack with
+Auth, Realtime, Storage, etc.). In a hardened deployment, one would use
+those features for better integration (for example, an actual user login
+to an approval web page served via Supabase Auth). They have left that
+flexible: you can run minimal or full. The full requires additional env
+secrets (JWT signing key, anon key, etc.), which again underscores the
+need for careful secret management.
+
+In summary, the **service contracts in PMOVES v5** -- Presign, Render
+Webhook, Publisher, and event flows -- are mostly implemented in a
+secure and functional manner. They fulfill the needs of the creator
+workflow with minimal attack surface and good use of tokens/keys.
+Improvements can be made in validation (ensuring each service only
+accepts properly formed requests) and in simplifying configuration (so
+enabling these services is less manual). Observability and error
+handling are recognized as areas to improve, with items in the roadmap
+focusing on adding those (structured logs, metrics, dead-letter queues,
+etc.). The contracts themselves are decoupled -- using the database as
+the interface between render webhook and indexer/publisher means those
+services don't have to call each other directly, which is a robust
+design (less chance of cascading failures). The use of Supabase Realtime
+or n8n to connect the dots is a pragmatic solution to avoid writing
+custom code for every event propagation. Overall, the service contracts
+support **extensibility** (e.g., one could add another generator service
+using the same presign/webhook approach and it would slot into the
+pipeline easily) and maintain **security** by not overexposing internal
+services (MinIO isn't directly exposed, only via presigned links; DB is
+exposed through a controlled REST interface). These are positive aspects
+of the design.
+
+## 3. Multi-Agent Persona System and Retrieval Pipeline
+
+PMOVES is fundamentally a *multi-agent system* -- it features different
+AI agents with different roles and capabilities, working together. Let's
+examine how persona-driven and user-selectable routing is supported, how
+the retrieval pipeline accommodates this (especially with the new
+geometry capabilities), and the viability of the new multi-decoder
+integration.
+
+### **Persona-Driven or User-Selectable Agent Routing**
+
+In PMOVES v5, multiple agents are explicitly present: **Agent Zero**
+(the generalist orchestrator), **Archon** (the knowledge-centric agent),
+and **Crush CLI** (the coding assistant agent), among potentially
+others. The architecture allows each agent to have a distinct *persona*
+or specialization, configured through what are called **"Forms"**
+(temperament profiles). For example, they have forms named
+`POWERFULMOVES` (presumably the default all-purpose configuration),
+`CREATOR` (maybe biased towards creative/generative tasks), and
+`RESEARCHER` (biased towards analytical tasks). These forms adjust
+internal parameters like how much the agent relies on retrieval vs.
+generation, how it thresholds using the "mesh" (perhaps offloading to
+external tools), etc..
+
+From a user perspective, *persona-driven routing* could mean a few
+things: - The user explicitly chooses which agent to query (e.g.,
+addressing Archon vs. Agent Zero, or launching the "Crush CLI" for
+coding tasks). - The system automatically routes the query to the
+appropriate agent based on intent (for instance, a programming question
+gets answered by Crush CLI, a general question by Agent Zero, a
+knowledge lookup by Archon, etc.).
+
+Currently, PMOVES exposes different interfaces for different agents:
+Agent Zero has an interactive terminal UI, Archon has a web UI (perhaps
+for knowledge base management), and Crush is a CLI tool the user can run
+for coding help. So in practice, the user selects a persona by using the
+corresponding interface. There isn't yet a unified interface where one
+can say "choose persona X" on the fly, but the groundwork for such
+flexibility exists in how agents are built.
+
+**Technical Routing:** Under the hood, the agents can communicate or
+delegate via the Model Context Protocol (MCP). Agent Zero and Archon
+each run an MCP server (over stdio or HTTP) exposing a set of
+tools/commands. For example, Agent Zero might have a tool for
+`knowledge.rag.query` which actually calls Archon's retrieval pipeline,
+or Archon might have a tool to request geometry decoding from the
+geometry service. This means agents can call each other's capabilities
+when needed. It's a form of *agent orchestration*: Agent Zero (the
+conductor) can route a sub-task to Archon (the librarian) if it deems it
+appropriate. This kind of routing is *implicit* in how the prompts and
+agent logic are written (for instance, an Agent Zero prompt might be:
+"If question is about knowledge, use the Archon tool; if creative, use
+ComfyUI tool," etc.).
+
+The **cross-namespace routing & intent-based boosters** planned for
+Milestone M3 speaks directly to improving this. "Cross-namespace
+routing" suggests that queries can be classified into different
+knowledge namespaces or agent scopes, and then routed accordingly.
+"Intent-based type boosters" likely means if the query intent is, say,
+programming, boost results from the code knowledge base and perhaps
+route to the coding agent. This is not fully implemented yet, but the
+plan indicates they recognize the need for more automatic persona
+routing.
+
+**User-Selectable Agents:** In terms of UI/UX, one could foresee the
+Agent Zero UI allowing a user command like "/switch Archon" or "/mode
+Researcher" which changes the persona handling the conversation. This
+isn't described in the docs, but since forms are passed as env vars when
+launching agents, currently it's a launch-time decision. Perhaps future
+work could allow Agent Zero to spawn a subordinate agent with a
+different form on the fly (which is conceptually mentioned: Agent Zero
+can create subordinate agents).
+
+**Crush CLI Integration:** The Crush CLI agent is integrated in the
+ecosystem as a specialized developer assistant that runs in a secure VM
+environment with code access. The architecture diagrams show that Crush
+can also use MCP to call out to others (like Archon or Agent Zero) if
+needed. This means we have at least three personas: general,
+knowledge-focused, and coding-focused. Each has its own strengths. The
+integration guidelines likely ensure that Crush adheres to certain
+mandates (don't commit code without permission, etc.). So persona
+differentiation is not just superficial; it's deeply baked into how each
+agent behaves via internal prompt guidelines and allowed tools.
+
+**Assessment:** PMOVES has a solid foundation for multi-agent personas.
+**Opportunities for improvement** include making it easier for the user
+to direct tasks to a specific agent without needing separate UIs. For
+instance, if using Agent Zero's interface, perhaps a query could be
+prefixed with something like "(research)" to force it through Archon's
+retrieval, or "(code)" to engage Crush. Or Agent Zero could
+automatically recognize when to hand off ("This looks like a coding
+issue, handing off to Crush..."). The roadmap's mention of intent-based
+routing suggests exactly this kind of feature is planned. Another angle
+is running agents in parallel for consensus -- not currently mentioned
+in docs, but given the inclusion of MACA (Multi-Agent Consensus
+Alignment) research materials, one could imagine multiple agents
+debating a question to produce a more robust answer. That's more
+researchy, but it aligns with the idea of using "multiple personas" for
+better results.
+
+In summary, **persona-driven routing is partially supported** (via
+manual choice of agent interface or predetermined flows), and it's an
+area slated for more advanced development. The architecture doesn't
+present any obstacle to it -- indeed, it encourages it with configurable
+forms and modular agent design. It will be important to expose that
+flexibility in user-friendly ways moving forward.
+
+### **Retrieval Pipeline with CHIT Geometry and ShapeStore**
+
+The retrieval pipeline in PMOVES was originally a hybrid RAG
+(retrieval-augmented generation) using text embeddings and graphs. With
+v5, it's evolving to include the **CHIT geometry bus** for cross-modal
+retrieval.
+
+**Current Retrieval Capabilities:** As of milestone M1, the system had a
+"Hybrid Hi-RAG Gateway v2" implemented. This gateway can handle incoming
+queries (likely from Agent Zero or Archon) and perform: - **Vector
+search** (via Qdrant) on the text embeddings of documents or captions. -
+**Lexical search** (via Meili) if enabled, or use the Neo4j for
+structured lookup (like boosting results that are highly connected or
+match graph nodes). - **Reranking** as discussed to refine results.
+
+It returns a set of relevant context chunks which the agent then feeds
+into the LLM to generate an answer, with sources cited (that's typical
+RAG behavior and seems to be in scope given the retrieval-eval harness
+etc.).
+
+Now, with **Geometry Bus integration**, the retrieval pipeline can
+potentially do more: - **Multimodal queries**: A user could ask
+something about a video or image content, and instead of only searching
+transcripts (text), the system can search geometry points. For example,
+search in `shape_points` for constellation summaries or metadata
+matching the query. - **Graph-aware retrieval**: The gateway had a warm
+Neo4j dictionary for boosting terms. The shape data can enhance this
+because anchors and constellations might act as hubs of related content.
+For instance, an anchor might represent a location or concept across
+media; retrieving by that could yield all mentions in text, video
+scenes, etc., via the shape index. - **Sub-100ms cross-modal hops**: The
+ShapeStore was specifically to allow fast jumps between modalities. From
+a pipeline perspective, once you have an initial retrieval (say you got
+a transcript segment that's relevant), you could quickly retrieve the
+corresponding video clip via shape lookup. The user might then ask for
+that clip to be played or summarized. So it enriches the interaction
+loop.
+
+**ShapeStore in Gateways:** The Hi-RAG gateway likely incorporates the
+ShapeStore cache in memory. The roadmap explicitly calls out "Gateway
+ShapeStore cache for sub-100ms cross-modal hops" as done in M2.5. This
+means whenever new `shape_points` are inserted (via geometry events),
+the gateway may update its cache. Then if an agent query involves a
+shape_id or needs cross-modal data, it can fetch from cache.
+
+One example of usage: The UI at `/geometry/` shows the recent points and
+if a user clicks a point representing, say, an image's region, the
+gateway can fetch the related text from ShapeStore and respond instantly
+(rather than doing a fresh DB query). This is more relevant for the
+interactive UI than for a typical Q&A query, but it shows the system is
+prepared for interactive retrieval where low latency is key.
+
+**Readiness of CHIT in Retrieval:** The data schema is set, but as
+noted, some parts of populating it are work in progress. For retrieval
+to fully leverage it, the analysis processes that feed it (video
+analysis service, audio analysis service) should be active. The docs
+mention YOLO v11, CLIP, etc., planned to run in the Video AI Service,
+and audio emotion recognition in the Audio AI Service. These would
+produce detection events. If those are not yet functional, the geometry
+tables might currently only have trivial data. However, the question is
+future-oriented, and clearly the architecture anticipates this coming
+together.
+
+**Viability and Usefulness:** The geometry approach is quite advanced
+compared to typical RAG. It allows things like *visual similarity
+search* (via CLIP embeddings of images in shape_points) or *temporal
+alignment queries* (like "find where in this video a certain event
+happens" by searching shapes). It's a unique capability that, if
+executed well, will differentiate PMOVES. The *viability* seems good
+because the heavy lifting (embedding multimodal content, doing KNN
+search, etc.) leverages existing model capabilities (CLIP/CLAP, T5) and
+the system's own vector DB. One challenge is ensuring consistency and
+synchronization: the shape data must be kept updated as new content
+comes in or if things change. The architecture relies on events and
+cache for that, which is a sound approach (eventual consistency via NATS
+or realtime). Another challenge is that not many userland tools know how
+to handle queries to a geometry index; likely the PMOVES agents have to
+be explicitly programmed to use geometry when relevant. E.g., Agent Zero
+might have logic: "if user's question references a video or image, use
+geometry.decode or search shapes." This requires some new prompting or
+tool invocation patterns. But given the team's focus on MCP tools (they
+added tools like `geometry.publish_cgp`, `geometry.jump`,
+`geometry.decode_text` to agent toolsets), they are indeed integrating
+it into the agent's capabilities.
+
+In conclusion, the **retrieval pipeline is being enhanced by CHIT
+geometry**, and the core support (ShapeStore, DB schema, events) is
+largely in place. The system is ready to use it, but it will shine more
+as the data gets populated and the agents start leveraging it in their
+strategies. It's a cutting-edge extension that appears **viable** and
+likely to succeed given the careful design (with caches, events, and
+even security for shape sharing). PMOVES is effectively preparing to
+handle *retrieval across text, images, audio, and video in a unified
+way*, which is quite ambitious and promising.
+
+### **Decoder Multi Integration (PMOVESCHIT_DECODER_MULTIv0.1)**
+
+The `PMOVESCHIT_DECODER_MULTIv0.1.md` document outlines several
+enhancements related to decoding geometry packets using learning-based
+models. Let's break down what this integration means and assess its
+viability:
+
+- **Learning-based Text Decoder:** This introduces a *tiny T5 model
+  pipeline* that can take a CHIT geometry packet (which may include
+  anchor vectors or summarized data of a constellation) and generate a
+  text summary. In other words, rather than just retrieving existing
+  data, the system can *generate a natural language description* of what
+  a cluster of points represents. This is useful, for example, if you
+  have a constellation of frames from a video that all correspond to a
+  particular scene -- the decoder might output "Scene: a person walking
+  through a market, talking on a phone," effectively summarizing that
+  cluster. This moves beyond just retrieval into abstraction and is akin
+  to an AI-generated caption or summary for the multi-modal content.
+
+- **Multimodal Decoders (Image and Audio):** The integration includes
+  using **CLIP** for images and **CLAP** for audio to decode geometry.
+  "Geometry-only idea" likely refers to using the geometry anchors as
+  queries to these models. For instance, take an anchor vector and find
+  the closest text in a codebook (more on codebook below) or use CLIP to
+  find an image that matches an anchor. It could also mean generating a
+  description of an image cluster via CLIP interrogator. The *optional
+  audio (CLAP)* means audio segments could be projected into an
+  embedding space; given an anchor (which might not have a direct
+  semantic label), the decoder could attempt to label it (like "laughter
+  sound" if the audio points cluster around audience laughter in a
+  video). These decoders effectively allow the system to interpret raw
+  geometry in human terms.
+
+- **Calibration Metrics:** They added tools to calculate metrics like KL
+  divergence, JS divergence, Wasserstein-1D, and coverage for
+  constellations. This is for assessing how well distributed or distinct
+  the shape is, and possibly to adjust parameters. A "richer report" can
+  be generated for a given CGP, which might help in debugging or
+  optimizing the geometry representations. For retrieval, calibration
+  could tell if an anchor's points cover a broad or narrow concept,
+  which might influence how results are presented or whether more
+  refinement is needed.
+
+- **Security Utilities:** These are about signing and encrypting
+  geometry packets. HMAC-SHA256 signing ensures authenticity of a CGP
+  (only nodes with the shared passphrase can produce a valid signature)
+  and AES-GCM encryption of anchors ensures that if you share a capsule
+  with someone, the actual high-dimensional anchor vectors (which could
+  be sensitive if they encode something) are protected. The decoders on
+  the receiving end can still decode if they have the key. This is less
+  about retrieval quality and more about safe sharing of data. It is
+  highly relevant if PMOVES instances exchange data -- they can trust
+  and handle each other's geometry without leaking info to third
+  parties.
+
+The **viability** of integrating these in the pipeline depends on
+computational resources and complexity: - **Tiny T5 for text decode**:
+This is likely a small model (maybe a distilled T5 or similar). It
+should run reasonably fast on CPU, but faster on GPU. If the gateway is
+on a Jetson, running even a small Transformer might be slow. However,
+it's optional (gated by `CHIT_DECODE_TEXT`). So one can enable it on a
+beefy node and disable on weaker ones. This is viable; it adds a
+dependency (HuggingFace transformers, etc.) but nothing unusual. They
+included instructions to install `transformers`, `accelerate`, etc., so
+they considered the env setup. It's a viable approach to generate
+summaries on the fly. One must ensure the model is indeed "tiny" enough
+to not bog down response times too much.
+
+- **CLIP and CLAP for images/audio**: Using CLIP for image similarity or
+  captioning is standard practice; CLAP for audio is newer but similar
+  concept. These models can be large. The document shows installing
+  `laion-clap` and torch, etc. If running on CPU, CLIP and CLAP might be
+  slow for large data. But if it's just for decoding a single anchor at
+  query time, it might be okay. Also, these decoders might not be
+  invoked for every query, only when specifically requested or needed
+  (since they're optional). The viability is good as long as you have at
+  least CPU power; on Jetson, CLAP may not work (lack of certain
+  libraries or being heavy), but again one can disable it via env flags
+  (`CHIT_DECODE_AUDIO`). So the design is flexible enough to be viable
+  in diverse deployments. Over time, if performance is an issue, one
+  could use smaller models or precompute some of these decodings.
+
+- **Codebook Requirement:** There's a note about a shared *codebook*
+  (`structured_dataset.jsonl`) built via a pivot-banding script. This
+  implies that the decoders assume existence of a reference dictionary
+  of terms/vectors that represent the domain. For example, a codebook
+  might contain common concepts or keywords with their embeddings,
+  allowing the geometry decoder to map an anchor vector to the nearest
+  known concepts (for interpretability). The viability of the decoders'
+  usefulness likely hinges on having a good codebook. Building that
+  codebook is an extra step for the user (they'd have to run a script to
+  generate it from their data or from a general corpus). This adds
+  complexity -- if someone skips that, the decoders might be less
+  effective (or not work at all if they need the codebook). So ensuring
+  that process is straightforward is important. Perhaps the repository
+  provides a sample codebook or at least the script to generate one from
+  your documents (the mention of "pivot‑banded script" suggests some
+  provided tool).
+
+- **Integration into Agent Workflow:** The decoders introduce new
+  endpoints and presumably the Agent Zero or Archon can call them via
+  tools (as listed: `geometry.decode_text`, etc.). For viability, the
+  agents need logic on when to call these. Possibly, if an agent gets a
+  geometry result (e.g., a constellation ID) and needs to summarize it
+  for the user, it will call `geometry.decode_text`. This means the
+  agent prompt must be aware of this tool and under what conditions to
+  use it. That has to be carefully integrated into the agent's
+  decision-making. Given they have included those tools in MCP, it's
+  likely implemented to some degree. The viability also depends on
+  whether the additional step doesn't confuse the agent or waste time on
+  trivial cases. But since it's all under control with flags, it should
+  be fine.
+
+In essence, **Decoder Multi integration** is an innovative extension
+turning PMOVES not just into a retrieval system but a *cross-modal
+understanding* system. It's **viable** in the sense that it's using
+known techniques (T5 summarization, CLIP embeddings) and the code is
+likely already there to support it. The concerns are mostly around
+resource usage and user complexity (setting up models, codebook). The
+fact that these are optional and modular is good. If a user doesn't want
+these, they can leave the env flags off and not install those packages,
+and the system still runs (just without those capabilities). If they do
+want them, they need to follow the install steps given.
+
+From a *value* perspective, these decoders greatly enhance what the
+system can do. For example, a user could query an agent, "What is this
+shape constellation about?" and the agent could return a summary
+generated by the tiny T5 decoder -- effectively explaining an unseen
+cluster of data. That's powerful for analysis (especially if the user
+uploads a bunch of new data and wants to quickly know what's in it). It
+also aids **cross-modal alignment**: CLIP and CLAP provide a bridge
+between image/audio and text, so the system can find textual descriptors
+for non-textual data. This addresses the "cross-modal alignment" point
+in the question; decoder integration is one approach to align embeddings
+from different modalities into a shared semantic space (via the codebook
+and CLIP/CLAP).
+
+Thus, the integration is **worthwhile and appears technically sound**.
+The only caution is to manage expectations on smaller hardware --
+enabling everything could require a lot of RAM/VRAM (especially loading
+CLAP or multiple models concurrently). Perhaps a future refinement is to
+run these decoders as separate services or on-demand (e.g., only load
+CLAP model the first time an audio decode is requested). For now, given
+it's a v0.1, it's likely fine to assume usage in a research environment
+where the user can handle these details.
+
+## 4. Recommendations and Next Steps
+
+Based on the above evaluation, here are **key opportunities to improve
+or extend PMOVES v5**. These recommendations target robustness,
+interoperability, and modular reuse, aligning with the project's roadmap
+and future vision:
+
+- **Strengthen API Hardening & Security:** Implement comprehensive input
+  validation and authentication checks on all service endpoints. For
+  example, the Presign and Render Webhook services should strictly
+  validate request bodies (file names, sizes, MIME types) and return
+  informative errors on bad input. Define JSON schemas for these APIs
+  and enforce them, preventing malformed data from propagating. Add
+  health and readiness probes to each service (HTTP 200 endpoints to
+  signal they are up) for better automation and monitoring. In
+  production deployments, consider moving sensitive secrets out of
+  `.env` into a secure store -- e.g., use Docker secrets or a vault
+  service so that MinIO keys, Supabase role keys, etc., aren't stored in
+  plaintext. Also, complete the planned security features: enforce
+  **signed URL access** for MinIO (no public ACLs, only allow through
+  presigned links) and possibly introduce a **domain allowlist** so that
+  only certain frontends (or none, if internal) can load those
+  resources. These steps will harden the system against misuse or
+  unauthorized access.
+
+- **Improve Observability & Resilience:** Introduce a centralized
+  logging and metrics system across all services. For logging, use
+  structured logs (e.g., JSON logs including a request ID or content ID)
+  so events can be correlated. Forward logs to a combined view (like ELK
+  stack or even Supabase's log facility if available). For metrics,
+  integrate **Prometheus** or a similar tool: each service can expose
+  metrics (e.g., number of files uploaded, webhook latency, query
+  response times, GPU utilization). Key metrics like "MinIO upload
+  duration", "transcription job time", "embedding count in last hour",
+  etc., will help identify bottlenecks. Additionally, implement the
+  **dead-letter queue and retry** logic for event handling as planned.
+  For instance, use NATS (which you already include for mesh) or a
+  lightweight task queue so that if an Indexer service is down when an
+  event occurs, the event is not lost but retried when it's back up.
+  Ensuring idempotent handlers (as noted in Next Steps) will prevent
+  duplicate processing. Regular backups for Supabase (perhaps via the
+  Supabase automated backups or a dump to S3) and for MinIO (snapshots
+  or versioning) should be instituted, in line with the roadmap's
+  mention of backup and disaster recovery drills. This will make the
+  system more resilient to crashes or data loss.
+
+- **Simplify Configuration & Deployment:** Unify the environment
+  configuration process to reduce setup complexity. Instead of requiring
+  users to concatenate multiple `env.*.additions` files into the main
+  `.env`, provide a single `.env` template with clearly commented
+  sections for each optional component. Users can then toggle features
+  (e.g., `ENABLE_RERANKER=true`) and the services can read those flags
+  to decide whether to enable certain functionality. This could even be
+  handled by a simple setup script or wizard that asks which features to
+  enable and generates the .env accordingly. Similarly, streamline the
+  Docker Compose setup: currently, multiple compose files or profiles
+  exist, which is flexible but can confuse newcomers. Consider offering
+  a **makefile or CLI tool** (`pmoves up --with-presign --with-webhook`)
+  that under the hood calls the appropriate `docker compose` commands so
+  users don't have to remember profile names. In the longer term, as the
+  system grows, evaluating a move to Docker Swarm or Kubernetes might
+  make sense for easier multi-machine orchestration -- but in the near
+  term, simply documenting and scripting the Compose approach will help.
+  The goal is to minimize manual steps and chances for misconfiguration.
+  Reducing environment duplication will also help avoid issues where one
+  service has a different key than another. Overall, a more
+  **standardized .env and compose** will make deployments more
+  plug-and-play.
+
+- **Formalize Multi-Agent Coordination & Routing:** Expand the
+  multi-agent orchestration capabilities to fully leverage persona
+  specialization. In practical terms, implement the **"cross-namespace
+  routing & intent-based boosters"** that are planned. This could
+  involve using a lightweight intent-classifier (perhaps a small model
+  or rule-based) to examine user queries and route them to the
+  appropriate agent or knowledge base. For example, if a query looks
+  like code or contains programming keywords, automatically hand it to
+  the Crush CLI agent (or have Agent Zero invoke Crush via MCP) --
+  possibly boosting relevant results from code documents. If a query is
+  about personal finance, ensure it routes to the Firefly III
+  data/agents, etc. This would make the system more intuitive, as users
+  wouldn't need to manually specify which agent to use. Additionally,
+  provide a user command or UI toggle to explicitly select an agent
+  persona when desired (e.g., "Ask Archon about X" could force the
+  librarian agent context). Each agent's *Form* profile can be tuned
+  further: gather feedback on how `CREATOR` vs `RESEARCHER` forms
+  perform and adjust their parameters for optimal behavior. One
+  forward-looking idea is to allow **multi-agent consensus** on complex
+  queries -- for instance, run Archon and Agent Zero in parallel and
+  have them cross-verify answers (this draws inspiration from the MACA
+  approach provided in the research PDF). The MACA results showed
+  significantly improved consistency and accuracy when agents debate and
+  learn from each other. While real-time debate might be too slow, even
+  implementing a simple majority vote or confidence check between agents
+  could improve reliability for critical queries. This would elevate
+  PMOVES from just having multiple agents to truly *using* multiple
+  agents collaboratively.
+
+- **Leverage Geometry Bus for Enhanced Retrieval:** Now that the CHIT
+  Geometry Bus is in place, the next step is to fully integrate it into
+  user-facing features and agent strategies. Ensure that the media
+  analysis pipelines are completed so that videos and audio produce
+  geometry events (anchors/constellations for scenes, topics, faces,
+  emotions, etc.). This will populate the ShapeStore/DB with rich
+  cross-modal data. Then, update the retrieval logic to utilize this
+  data: for example, when a user asks a question that might involve
+  video content, query the `constellations` for relevant summaries or
+  use the shape index to jump directly to a moment in a video.
+  Incorporate geometry-based search into Archon's toolkit -- e.g., a
+  tool that finds related content by shape proximity. Additionally,
+  **expose the Geometry Bus to users in the UI** beyond the current
+  developer canvas. For instance, an end-user could see a timeline with
+  markers (anchors) and be able to click to pivot between modalities
+  ("show me the transcript around this video frame" -- which you can do
+  via shape jump). This kind of cross-modal navigation can be a standout
+  feature. It may also be worthwhile to implement a **Capsule
+  export/import UI**: since the roadmap mentions capsule sharing for
+  offline exchange, create a simple way for a user to select a set of
+  insights (anchors/constellations) and export them as a JSON capsule,
+  and on another instance import that capsule (with appropriate
+  verification) to merge those insights. Formalizing the **Capsule
+  schema** (version it, document it) will ensure interoperability
+  between different PMOVES instances or future versions. This would
+  unlock use cases like collaborative research, where one PMOVES system
+  analyses a dataset and shares just the abstracted knowledge (geometry)
+  with another system -- preserving privacy yet enabling collective
+  intelligence.
+
+- **Adopt Sidecar Adapters for Model Alignment:** The research on latent
+  geometry suggests using **sidecar networks** to adjust the embedding
+  space for better robustness and alignment. PMOVES can pioneer applying
+  this in a practical system. For example, consider training a small
+  sidecar neural network that sits between the embedding model (like the
+  one generating vectors for Qdrant) and the vector store. This sidecar
+  could be trained to make the space more hyperbolic (tree-like) which
+  might improve retrieval of out-of-distribution queries, as indicated
+  by the Latent Space Relativity findings. Similarly, sidecars could be
+  used to align the vector spaces of different modalities. Instead of
+  relying purely on CLIP/CLAP, a learned adapter could take the image
+  embedding and map it closer to the text embedding space the system
+  uses for documents. Because PMOVES already has a modular architecture,
+  such sidecars can be introduced as optional components (perhaps as
+  part of the HiRAG pipeline or as a preprocessing step before
+  indexing). This would be a research-heavy enhancement, but even a
+  simple experiment (e.g., train an MLP on some known dataset to
+  minimize the distance between related audio and text embeddings) could
+  yield improvement in cross-modal search results. It aligns with
+  treating *geometry as a first-class design axis* for model tuning. In
+  more concrete terms: if you notice the retrieval results are sometimes
+  semantically relevant but not specific enough, a sidecar can be
+  trained to emphasize certain dimensions (maybe boosting factuality or
+  specific contexts). Deploy these adapters cautiously (with
+  off-switches) and measure their impact via the retrieval-eval harness.
+  Over time, this could become a standard part of the pipeline (like
+  "enable RobustEmbeddings sidecar = true" to improve tolerance to
+  domain shifts). It's an advanced but exciting direction that leverages
+  PMOVES' existing strength in handling multiple modalities and data
+  sources.
+
+- **Prioritize Upcoming Milestones (Concrete Next Steps):** In the
+  immediate term, focus on finishing the in-progress items from the
+  Creator & Publishing milestone (M2) and preparing the ground for M3:
+
+- Complete the **Jellyfin integration** -- implement the webhook or
+  script that triggers Jellyfin library refresh upon publish, and test
+  that the new content appears properly with metadata (cover image,
+  etc.). Also, finalize the **Discord rich embed** formatting for
+  published content, including any thumbnail or links to view the
+  content (maybe a link to Jellyfin web or a presigned URL). These will
+  polish the user experience of content publishing.
+
+- Implement **PDF/Office ingestion** (which was deferred) and **image
+  OCR ingestion** (planned for M4) in a basic form. Even a simple
+  integration using LibreOffice in a container to convert DOCX/PPTX to
+  PDF, and Tesseract for OCR on images, would extend Archon's reach to
+  new data formats. This can feed into the existing indexing pipelines
+  (e.g., treat extracted text as any other document).
+
+- Kick off the **Retrieval Quality & Graph Enrichment (M3)** tasks that
+  add semantic depth: integrate an **entity linking dictionary** so that
+  aliases (e.g., "POWERFULMOVES" vs. an alternate name) are recognized
+  as the same entity in searches. This could simply be a synonyms list
+  for now, but it will improve consistency. Also, implement basic
+  **relation extraction** on captions or text (perhaps using the Neo4j
+  entity graph you have) so that queries can leverage relationships
+  (e.g., a query that implicitly connects two entities can retrieve
+  based on a relationship path, not just co-occurrence). These
+  enrichments will boost the retrieval relevance and are natural
+  extensions given you already store data in a graph.
+
+- Develop a lightweight **"Studio Approval UI."** Instead of relying on
+  Supabase Studio (which is not meant for end users), create a simple
+  web page or dashboard that lists submitted content with preview
+  thumbnails, and allows an authorized user to click "Approve" or
+  "Reject." This UI can communicate with the Supabase REST API (since
+  you have that) to update the status field. It doesn't need to be fancy
+  -- even an n8n frontend or a small React page served by the gateway
+  would do. The key is to streamline the reviewer's workflow so they
+  don't need DB knowledge. This also ties in with security: implement
+  some basic RLS (Row-Level Security) rules or API keys such that only
+  authorized users can change the status, especially if this were
+  internet-facing eventually.
+
+- **CI/CD improvements:** Incorporate the retrieval-eval suite into your
+  GitHub Actions or CI pipeline, as mentioned in the roadmap. For
+  instance, whenever embeddings logic or retrieval parameters change,
+  run the evaluation script to compute metrics (MRR, NDCG) on a fixed
+  benchmark set. Collect those artifacts so you can track if changes
+  improve or hurt retrieval performance. Also, consider automated tests
+  for the pipeline (the Smoke Tests doc is a great start) -- you can
+  extend that to verify that a sample image goes through
+  presign→webhook→DB→publish without issues after each deploy. This will
+  catch integration bugs early and ensure robustness as you iterate.
+
+Each of these recommendations is aimed at making PMOVES more **robust,
+user-friendly, and extensible**. By tightening security and configs, you
+make it reliable to deploy. By enhancing multi-agent and retrieval
+intelligence (persona routing, geometry utilization, sidecars), you push
+the system's capabilities forward in line with cutting-edge research.
+And by polishing the user-facing aspects (UI for approval, smooth
+publishing, etc.), you make PMOVES more accessible to others who might
+use it, not just its creators. The vision of PMOVES as a
+*"production-ready orchestration mesh... with graph-aware retrieval"* is
+well on its way -- implementing the above steps will bring it even
+closer to that goal, ensuring it can reliably serve as a self-improving,
+autonomous AI platform across modalities and agents.
+
+------------------------------------------------------------------------

--- a/pmoves/n8n-workflows/cataclysm-creative-pipeline.json
+++ b/pmoves/n8n-workflows/cataclysm-creative-pipeline.json
@@ -1,0 +1,43 @@
+{
+  "name": "Cataclysm Creative Pipeline",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "cataclysm-start",
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "topic": "={{ $json.creative_brief }}"
+      },
+      "id": "cataclysm-concept",
+      "name": "Concept Exploration",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "notes": "STUB — Wire to NATS creative.concept.explore.v1 or PMOVES API"
+    },
+    {
+      "parameters": {},
+      "id": "cataclysm-end",
+      "name": "End",
+      "type": "n8n-nodes-base.end",
+      "typeVersion": 1
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [[{"node": "Concept Exploration", "type": "main", "index": 0}]]
+    },
+    "Concept Exploration": {
+      "main": [[{"node": "End", "type": "main", "index": 0}]]
+    }
+  },
+  "meta": {
+    "instanceId": "cataclysm-studios",
+    "templateId": "cataclysm-creative-pipeline",
+    "status": "stub",
+    "notes": "TODO: Implement full 5-tier pipeline with NATS integration. See pmoves/configs/tac_trees/cataclysm-studios.tac.yaml"
+  }
+}

--- a/pmoves/nats/mesh_gpu_streams.yaml
+++ b/pmoves/nats/mesh_gpu_streams.yaml
@@ -1,0 +1,57 @@
+streams:
+  - name: mesh_gpu_inference
+    subjects:
+      - "mesh.gpu.inference.>"
+    retention: limits
+    max_msgs: 10000
+    max_age: 24h
+    max_bytes: 268435456
+    replicas: 1
+    consumers:
+      - name: gpu-inference-worker
+        durable_name: gpu-inference-worker
+        ack_policy: explicit
+        max_deliver: 3
+        filter_subject: "mesh.gpu.inference.request"
+
+  - name: mesh_gpu_health
+    subjects:
+      - "mesh.gpu.health.>"
+    retention: interest
+    max_msgs: 1000
+    max_age: 1h
+
+  - name: mesh_gpu_models
+    subjects:
+      - "mesh.gpu.models.>"
+    retention: limits
+    max_msgs: 5000
+    max_age: 72h
+
+  - name: mesh_gpu_training
+    subjects:
+      - "mesh.gpu.training.>"
+    retention: limits
+    max_msgs: 5000
+    max_age: 48h
+
+  - name: mesh_gpu_metrics
+    subjects:
+      - "mesh.gpu.metrics.>"
+    retention: limits
+    max_msgs: 50000
+    max_age: 6h
+
+  - name: mesh_gpu_command
+    subjects:
+      - "mesh.gpu.command.>"
+    retention: limits
+    max_msgs: 1000
+    max_age: 1h
+
+  - name: mesh_gpu_status
+    subjects:
+      - "mesh.gpu.status.>"
+    retention: interest
+    max_msgs: 500
+    max_age: 30m

--- a/pmoves/services/gateway/scripts/chit_sign.py
+++ b/pmoves/services/gateway/scripts/chit_sign.py
@@ -1,77 +1,64 @@
 """
 scripts/chit_sign.py — Sign and optionally encrypt CGPs for PMOVES.AI demos.
 
+Delegates ALL crypto to chit_security.py (the canonical CHIT implementation per CGP v1.0 spec).
+This module provides only CLI convenience — no independent crypto.
+
 Usage:
   python scripts/chit_sign.py --in tests/data/cgp_fixture.json --out data/cgp_signed.json \
          --passphrase "secret" --encrypt-anchors
-
-Flags:
-  --passphrase: when provided, HMAC-SHA256 is computed over the CGP (sans 'sig').
-  --encrypt-anchors: replaces 'anchor' with 'anchor_enc' (AES-GCM with key derived via scrypt).
 """
-import os, json, base64, hashlib, hmac, secrets, argparse
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
 from typing import Any, Dict
 
-def canon(obj: Dict[str, Any]) -> bytes:
-    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+# Resolve imports for chit_security
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PMOVES_ROOT = _SCRIPT_DIR.parent.parent.parent
+if str(_PMOVES_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PMOVES_ROOT))
 
-def hmac_sign(doc: Dict[str, Any], passphrase: str) -> Dict[str, Any]:
-    d = dict(doc)
-    d.pop("sig", None)
-    mac = hmac.new(passphrase.encode("utf-8"), canon(d), hashlib.sha256).digest()
-    sig = {
-        "alg": "HMAC-SHA256",
-        "kid": "demo",
-        "ts": int(__import__("time").time()),
-        "hmac": base64.b64encode(mac).decode("ascii"),
-    }
-    doc["sig"] = sig
-    return doc
+from tools.chit_security import sign_cgp, encrypt_anchors  # noqa: E402
+from tools.chit_common import canon  # noqa: E402
 
-def aesgcm_encrypt_anchor(const: Dict[str, Any], passphrase: str) -> None:
-    try:
-        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-    except Exception as e:
-        raise SystemExit("cryptography is required for --encrypt-anchors") from e
-    if "anchor" not in const: 
-        return
-    anchor = const["anchor"]
-    salt = os.urandom(16)
-    iv = os.urandom(12)
-    key = hashlib.scrypt(passphrase.encode("utf-8"), salt=salt, n=2**14, r=8, p=1, dklen=32)
-    aead = AESGCM(key)
-    aad = canon({"id": const.get("id","")})
-    pt = json.dumps(anchor).encode("utf-8")
-    ct = aead.encrypt(iv, pt, aad)
-    const["anchor_enc"] = {
-        "iv": base64.b64encode(iv).decode("ascii"),
-        "salt": base64.b64encode(salt).decode("ascii"),
-        "ct": base64.b64encode(ct).decode("ascii"),
-    }
-    const.pop("anchor", None)
 
-def process(cgp: Dict[str, Any], passphrase: str=None, encrypt_anchors: bool=False) -> Dict[str, Any]:
-    out = dict(cgp)
-    for s in out.get("super_nodes", []):
-        for const in s.get("constellations", []):
-            if encrypt_anchors and passphrase:
-                aesgcm_encrypt_anchor(const, passphrase)
-    if passphrase:
-        out = hmac_sign(out, passphrase)
-    return out
+def process(cgp: Dict[str, Any], passphrase: str, encrypt: bool = False) -> Dict[str, Any]:
+    """Sign and optionally encrypt a CGP using canonical chit_security implementation."""
+    if encrypt:
+        return encrypt_anchors(cgp, passphrase)
+    return sign_cgp(cgp, passphrase)
+
 
 def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--in", dest="inp", required=True)
-    ap.add_argument("--out", dest="outp", required=True)
-    ap.add_argument("--passphrase", dest="passphrase", default=None)
-    ap.add_argument("--encrypt-anchors", dest="encrypt", action="store_true")
+    ap = argparse.ArgumentParser(description="Sign/encrypt CGPs via chit_security")
+    ap.add_argument("--in", dest="inp", required=True, help="Input CGP JSON file")
+    ap.add_argument("--out", dest="outp", required=True, help="Output signed CGP JSON file")
+    ap.add_argument("--passphrase", dest="passphrase", default=None,
+                    help="Passphrase (or set CHIT_PASSPHRASE env var)")
+    ap.add_argument("--encrypt-anchors", dest="encrypt", action="store_true",
+                    help="Encrypt anchor vectors with AES-GCM")
     args = ap.parse_args()
-    cgp = json.load(open(args.inp, "r", encoding="utf-8"))
-    out = process(cgp, args.passphrase, args.encrypt)
-    os.makedirs(os.path.dirname(args.outp), exist_ok=True)
-    json.dump(out, open(args.outp, "w", encoding="utf-8"), indent=2)
-    print("Wrote", args.outp)
+
+    passphrase = args.passphrase or os.environ.get("CHIT_PASSPHRASE", "")
+    if not passphrase:
+        ap.error("--passphrase or CHIT_PASSPHRASE env var is required")
+
+    with open(args.inp, "r", encoding="utf-8") as f:
+        cgp = json.load(f)
+
+    result = process(cgp, passphrase, args.encrypt)
+
+    out_dir = os.path.dirname(os.path.abspath(args.outp))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.outp, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"Wrote {args.outp}")
+
 
 if __name__ == "__main__":
     main()

--- a/pmoves/services/graphiti/__init__.py
+++ b/pmoves/services/graphiti/__init__.py
@@ -1,0 +1,9 @@
+"""GRAPHITI Pipeline — Cryptographic provenance trail for code changes.
+
+4-stage pipeline: PR Monitor → PR Trim → CHIT Encode → Sign Trail
+NATS flow: ops.pr.monitor.completed.v1 → ops.pr.trim.completed.v1 → ops.pr.learnings.encoded.v1 → agent.graphiti.signed.v1
+
+Stage 4 (sign_trail.py) is implemented at pmoves/tools/sign_trail.py.
+Stages 1-3 are stubs pending submodule population (ToKenism-Multi, Pmoves-cipher).
+See research/GRAPHITI_CIPHER_DEEP_RESEARCH_REPORT.md for full analysis.
+"""

--- a/pmoves/services/graphiti/nats_subject_registry.py
+++ b/pmoves/services/graphiti/nats_subject_registry.py
@@ -1,0 +1,96 @@
+"""GRAPHITI NATS Subject Registry.
+
+Tracks all GRAPHITI-related NATS subjects defined in TAC trees.
+Each subject has a status: 'wired' (has subscriber code), 'stub' (has stub subscriber), 'defined_only' (TAC tree only).
+
+Generated: 2026-04-17
+Source: pmoves/configs/tac_trees/ (7 files with GRAPHITI references)
+See: research/part1_tac_trees_analysis.md for full 97-subject analysis
+
+Subject count: 97 unique subjects across 17 teams.
+Wired: 1 | Stub: 3 | Defined only: 93
+"""
+
+import sys
+from pathlib import Path
+from typing import List
+
+_SERVICES_DIR = Path(__file__).resolve().parent.parent
+if str(_SERVICES_DIR.parent) not in sys.path:
+    sys.path.insert(0, str(_SERVICES_DIR.parent))
+
+from services.common.nats_types import SubjectEntry  # noqa: E402
+
+
+SUBJECT_REGISTRY: List[SubjectEntry] = [
+    # ── Pipeline stages (4 subjects) ──
+    SubjectEntry(
+        subject="ops.pr.monitor.completed.v1",
+        status="stub",
+        subscriber_file="pmoves/services/graphiti/stage1_pr_monitor.py",
+        notes="Stage 1 output — raises NotImplementedError",
+        stage="pr-monitor",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="ops.pr.trim.completed.v1",
+        status="stub",
+        subscriber_file="pmoves/services/graphiti/stage2_pr_trim.py",
+        notes="Stage 2 output — raises NotImplementedError",
+        stage="pr-trim",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="ops.pr.learnings.encoded.v1",
+        status="stub",
+        subscriber_file="pmoves/services/graphiti/stage3_chit_encode.py",
+        notes="Stage 3 output — raises NotImplementedError",
+        stage="chit-encode",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="agent.graphiti.signed.v1",
+        status="wired",
+        subscriber_file="pmoves/tools/sign_trail.py",
+        notes="Stage 4 — implemented, delegates to chit_security.sign_cgp",
+        stage="sign-trail",
+        publisher="sign-trail",
+    ),
+    # ── Remaining 93 subjects are defined_only ──
+    # Full list with team assignments in research/part1_tac_trees_analysis.md
+    # Teams: geometry, evolution, training, skills, orchestration, research,
+    #        media, infra, ui, automation, discord, agentgym, vpn, external, life
+]
+
+# Updated 2026-04-17: Research doc inconsistencies resolved —
+# table said 78, spec said 88, full unique count = 97.
+# This registry contains the 4 pipeline subjects; the remaining 93
+# defined_only subjects are catalogued in the research report.
+# To generate the full registry, parse part1_tac_trees_analysis.md
+# and create SubjectEntry instances with status="defined_only".
+
+
+def get_subjects_by_status(status: str) -> List[SubjectEntry]:
+    """Filter subjects by status: 'wired', 'stub', or 'defined_only'."""
+    return [s for s in SUBJECT_REGISTRY if s.status == status]
+
+
+def get_subjects_by_stage(stage: str) -> List[SubjectEntry]:
+    """Filter subjects by pipeline stage."""
+    return [s for s in SUBJECT_REGISTRY if s.stage == stage]
+
+
+def get_wired_count() -> int:
+    return len(get_subjects_by_status("wired"))
+
+
+def get_stub_count() -> int:
+    return len(get_subjects_by_status("stub"))
+
+
+def get_defined_only_count() -> int:
+    return 93  # From research/part1_tac_trees_analysis.md
+
+
+def get_total_count() -> int:
+    return len(SUBJECT_REGISTRY) + get_defined_only_count()

--- a/pmoves/services/graphiti/stage1_pr_monitor.py
+++ b/pmoves/services/graphiti/stage1_pr_monitor.py
@@ -1,0 +1,43 @@
+"""GRAPHITI Pipeline Stage 1: Codex PR Monitor.
+
+Monitors GitHub PRs for code review eligibility.
+Publishes completed PRs to NATS subject: ops.pr.monitor.completed.v1
+
+STATUS: STUB — Requires ToKenism-Multi submodule (currently empty).
+Dependencies: PMOVES-cipher (empty), PMOVES-ToKenism-Multi (empty)
+NATS publish: ops.pr.monitor.completed.v1
+NATS consume: (none — triggered by GitHub webhook)
+
+TODO:
+- Implement GitHub App webhook receiver for PR events
+- Filter PRs by label/team/size thresholds
+- Extract diff metadata for downstream trim stage
+- Publish structured PR event to NATS
+"""
+
+import json
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+NATS_SUBJECT = "ops.pr.monitor.completed.v1"
+
+
+def process_pr_event(pr_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Process a GitHub PR event and publish to GRAPHITI pipeline.
+
+    Args:
+        pr_data: GitHub PR webhook payload
+
+    Returns:
+        Structured event for downstream stages
+
+    Raises:
+        NotImplementedError: This stage is not yet implemented
+    """
+    raise NotImplementedError(
+        "GRAPHITI Stage 1 (PR Monitor) is not yet implemented. "
+        "Requires ToKenism-Multi submodule to be populated. "
+        f"Target NATS subject: {NATS_SUBJECT}"
+    )

--- a/pmoves/services/graphiti/stage2_pr_trim.py
+++ b/pmoves/services/graphiti/stage2_pr_trim.py
@@ -1,0 +1,42 @@
+"""GRAPHITI Pipeline Stage 2: Claude-Opus PR Trim.
+
+Trims PR diffs to essential changes using Claude-Opus analysis.
+Consumes: ops.pr.monitor.completed.v1
+Publishes: ops.pr.trim.completed.v1
+
+STATUS: STUB — Requires Claude-Opus API integration.
+Dependencies: TensorZero config for Claude-Opus routing
+
+TODO:
+- Implement Claude-Opus API call for diff analysis
+- Filter non-essential changes (test fixtures, whitespace, imports)
+- Preserve security-relevant and business-logic changes
+- Publish trimmed diff to NATS
+"""
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+NATS_CONSUME = "ops.pr.monitor.completed.v1"
+NATS_PUBLISH = "ops.pr.trim.completed.v1"
+
+
+def trim_pr_diff(pr_event: Dict[str, Any]) -> Dict[str, Any]:
+    """Trim a PR diff to essential changes using Claude-Opus.
+
+    Args:
+        pr_event: Structured PR event from Stage 1
+
+    Returns:
+        Trimmed PR event with essential changes only
+
+    Raises:
+        NotImplementedError: This stage is not yet implemented
+    """
+    raise NotImplementedError(
+        "GRAPHITI Stage 2 (PR Trim) is not yet implemented. "
+        "Requires Claude-Opus API integration via TensorZero. "
+        f"NATS: {NATS_CONSUME} → {NATS_PUBLISH}"
+    )

--- a/pmoves/services/graphiti/stage3_chit_encode.py
+++ b/pmoves/services/graphiti/stage3_chit_encode.py
@@ -1,0 +1,43 @@
+"""GRAPHITI Pipeline Stage 3: Tokenism CHIT Encode.
+
+Encodes trimmed PR learnings into CGP format using Tokenism.
+Consumes: ops.pr.trim.completed.v1
+Publishes: ops.pr.learnings.encoded.v1
+
+STATUS: STUB — Requires ToKenism-Multi submodule (currently empty).
+Dependencies: pmoves.tools.chit_security, PMOVES-ToKenism-Multi (empty)
+
+TODO:
+- Implement Tokenism CGP encoding logic
+- Extract learnings from trimmed diff
+- Create structured CGP with anchor vectors
+- Sign CGP using chit_security.sign_cgp()
+- Publish encoded CGP to NATS
+"""
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+NATS_CONSUME = "ops.pr.trim.completed.v1"
+NATS_PUBLISH = "ops.pr.learnings.encoded.v1"
+
+
+def encode_pr_learnings(trimmed_event: Dict[str, Any]) -> Dict[str, Any]:
+    """Encode PR learnings into CGP format.
+
+    Args:
+        trimmed_event: Trimmed PR event from Stage 2
+
+    Returns:
+        Encoded CGP ready for signing (Stage 4)
+
+    Raises:
+        NotImplementedError: This stage is not yet implemented
+    """
+    raise NotImplementedError(
+        "GRAPHITI Stage 3 (CHIT Encode) is not yet implemented. "
+        "Requires ToKenism-Multi submodule to be populated. "
+        f"NATS: {NATS_CONSUME} → {NATS_PUBLISH}"
+    )

--- a/pmoves/services/media-audio/__init__.py
+++ b/pmoves/services/media-audio/__init__.py
@@ -1,0 +1,5 @@
+"""Media audio processing service.
+
+STATUS: STUB — Dockerfile and requirements.txt exist but service logic not yet implemented.
+TODO: Implement audio processing pipeline using vibevoice-realtime.
+"""

--- a/pmoves/services/media-video/__init__.py
+++ b/pmoves/services/media-video/__init__.py
@@ -1,0 +1,5 @@
+"""Media video processing service.
+
+STATUS: STUB — Dockerfile and requirements.txt exist but service logic not yet implemented.
+TODO: Implement video processing pipeline using PMOVES-Creator (ComfyUI fork).
+"""

--- a/pmoves/services/voice-relay/nats_subject_registry.py
+++ b/pmoves/services/voice-relay/nats_subject_registry.py
@@ -1,0 +1,93 @@
+"""Voice NATS Subject Registry.
+
+Tracks voice-related NATS subjects from TAC trees.
+Generated: 2026-04-17
+Source: pmoves/configs/tac_trees/
+"""
+
+from typing import List
+
+# Import shared SubjectEntry from common types
+import sys
+from pathlib import Path
+_SERVICES_DIR = Path(__file__).resolve().parent.parent
+_COMMON_DIR = _SERVICES_DIR / "common"
+if str(_SERVICES_DIR.parent) not in sys.path:
+    sys.path.insert(0, str(_SERVICES_DIR.parent))
+from services.common.nats_types import SubjectEntry  # noqa: E402
+
+
+SUBJECT_REGISTRY: List[SubjectEntry] = [
+    SubjectEntry(
+        subject="voice.agent.response.v1",
+        status="wired",
+        subscriber_file="pmoves/services/voice-relay/main.py",
+        notes="JetStream publish with ack — P1-3 wiring applied",
+        stage="voice-relay",
+        publisher="voice-relay",
+    ),
+    SubjectEntry(
+        subject="voice.cast.request.v1",
+        status="defined_only",
+        subscriber_file="",
+        notes="TAC-defined, no subscriber yet",
+        stage="voice-cast",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="voice.cast.completed.v1",
+        status="defined_only",
+        subscriber_file="",
+        notes="TAC-defined, no subscriber yet",
+        stage="voice-cast",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="voice.cast.failed.v1",
+        status="defined_only",
+        subscriber_file="",
+        notes="TAC-defined, no subscriber yet",
+        stage="voice-cast",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="voice.training.request.v1",
+        status="defined_only",
+        subscriber_file="",
+        notes="TAC-defined, no subscriber yet",
+        stage="voice-training",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="tokenism.prosodic.bpm.v1",
+        status="defined_only",
+        subscriber_file="",
+        notes="Flute gateway, TAC-defined",
+        stage="flute-gateway",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="device.cast.discovered.v1",
+        status="defined_only",
+        subscriber_file="",
+        notes="TAC-defined, no subscriber yet",
+        stage="device-cast",
+        publisher="",
+    ),
+    SubjectEntry(
+        subject="device.cast.status.v1",
+        status="defined_only",
+        subscriber_file="",
+        notes="TAC-defined, no subscriber yet",
+        stage="device-cast",
+        publisher="",
+    ),
+]
+
+
+def get_wired() -> List[SubjectEntry]:
+    return [s for s in SUBJECT_REGISTRY if s.status == "wired"]
+
+
+def get_defined_only() -> List[SubjectEntry]:
+    return [s for s in SUBJECT_REGISTRY if s.status == "defined_only"]

--- a/pmoves/tests/test_chit_security.py
+++ b/pmoves/tests/test_chit_security.py
@@ -1,0 +1,353 @@
+"""Tests for CHIT cryptographic functions.
+
+Covers: canon(), sign_cgp(), verify_cgp(), encrypt_anchors(), decrypt_anchors(),
+       _pack_floats(), _unpack_floats(), CGPValidator, edge cases.
+
+Coverage target: >80% for chit_security.py and chit_common.py
+"""
+
+import struct
+import pytest
+from pmoves.tools.chit_common import canon
+
+
+class TestCanon:
+    """Test canonical JSON serialization."""
+
+    def test_sorted_keys(self):
+        result = canon({"z": 1, "a": 2})
+        assert result == b'{"a":2,"z":1}'
+
+    def test_no_whitespace(self):
+        result = canon({"key": "value"})
+        assert b" " not in result
+        assert b"\n" not in result
+
+    def test_deterministic(self):
+        obj = {"b": [3, 1, 2], "a": {"y": 2, "x": 1}}
+        assert canon(obj) == canon(obj)
+
+    def test_returns_bytes(self):
+        assert isinstance(canon({}), bytes)
+
+    def test_empty_dict(self):
+        assert canon({}) == b"{}"
+
+    def test_nested_structures(self):
+        obj = {"a": [{"b": 1}, {"c": 2}]}
+        result = canon(obj)
+        assert b"[{" in result or b'[{"' in result
+
+    def test_unicode_escaped(self):
+        """json.dumps escapes non-ASCII by default."""
+        result = canon({"key": "\u65e5\u672c\u8a9e"})
+        assert isinstance(result, bytes)
+        assert b"\\u65e5" in result
+
+    def test_special_chars(self):
+        result = canon({"key": "a\nb\tc"})
+        assert isinstance(result, bytes)
+
+
+class TestPackUnpackFloats:
+    """Test float32 packing/unpacking (mirrors chit_security internals)."""
+
+    def _pack(self, floats):
+        """Pack list of floats to binary float32 with 4-byte length prefix."""
+        import numpy as np
+        a = np.asarray(floats, dtype="float32").tobytes()
+        return struct.pack(">I", len(floats)) + a
+
+    def _unpack(self, data):
+        """Unpack binary float32 with 4-byte length prefix."""
+        import numpy as np
+        n = struct.unpack(">I", data[:4])[0]
+        a = np.frombuffer(data[4:], dtype="float32", count=n)
+        return a.astype(float).tolist()
+
+    def test_round_trip(self):
+        original = [0.1, 0.5, 0.9, 1.0, -0.3]
+        packed = self._pack(original)
+        unpacked = self._unpack(packed)
+        assert len(unpacked) == len(original)
+        for o, u in zip(original, unpacked):
+            assert abs(o - u) < 1e-6
+
+    def test_empty_array(self):
+        packed = self._pack([])
+        assert packed == struct.pack(">I", 0)
+        assert self._unpack(packed) == []
+
+    def test_single_value(self):
+        packed = self._pack([42.0])
+        assert len(packed) == 8  # 4 bytes length + 4 bytes float
+        assert abs(self._unpack(packed)[0] - 42.0) < 1e-6
+
+    def test_negative_values(self):
+        original = [-1.0, -0.5, -100.0]
+        unpacked = self._unpack(self._pack(original))
+        for o, u in zip(original, unpacked):
+            assert abs(o - u) < 1e-6
+
+    def test_zero(self):
+        unpacked = self._unpack(self._pack([0.0]))
+        assert abs(unpacked[0]) < 1e-6
+
+
+class TestSignVerify:
+    """Test CGP signing and verification via chit_security."""
+
+    @pytest.fixture
+    def test_cgp(self):
+        return {
+            "schema_version": "1.0",
+            "contributor": "test-agent",
+            "anchors": [0.1, 0.2, 0.3],
+            "metadata": {"source": "test"},
+        }
+
+    @pytest.fixture
+    def passphrase(self):
+        return "test-passphrase-123"
+
+    def test_sign_produces_sig(self, test_cgp, passphrase):
+        from pmoves.tools.chit_security import sign_cgp
+        result = sign_cgp(test_cgp, passphrase)
+        assert "sig" in result
+        assert "hmac" in result["sig"]  # Key is 'hmac', not 'mac'
+        assert "kid" in result["sig"]
+        assert "alg" in result["sig"]
+        assert result["sig"]["alg"] == "HMAC-SHA256"
+
+    def test_verify_valid_signature(self, test_cgp, passphrase):
+        from pmoves.tools.chit_security import sign_cgp, verify_cgp
+        signed = sign_cgp(test_cgp, passphrase)
+        assert verify_cgp(signed, passphrase) is True
+
+    def test_verify_wrong_passphrase(self, test_cgp, passphrase):
+        from pmoves.tools.chit_security import sign_cgp, verify_cgp
+        signed = sign_cgp(test_cgp, passphrase)
+        assert verify_cgp(signed, "wrong-passphrase") is False
+
+    def test_verify_tampered_cgp(self, test_cgp, passphrase):
+        from pmoves.tools.chit_security import sign_cgp, verify_cgp
+        signed = sign_cgp(test_cgp, passphrase)
+        signed["contributor"] = "tampered"
+        assert verify_cgp(signed, passphrase) is False
+
+    def test_verify_missing_sig(self, test_cgp, passphrase):
+        from pmoves.tools.chit_security import verify_cgp
+        assert verify_cgp(test_cgp, passphrase) is False
+
+    def test_sign_preserves_cgp_fields(self, test_cgp, passphrase):
+        from pmoves.tools.chit_security import sign_cgp
+        result = sign_cgp(test_cgp, passphrase)
+        assert result["schema_version"] == "1.0"
+        assert result["contributor"] == "test-agent"
+        assert result["anchors"] == [0.1, 0.2, 0.3]
+
+    def test_sign_custom_kid(self, test_cgp, passphrase):
+        from pmoves.tools.chit_security import sign_cgp
+        result = sign_cgp(test_cgp, passphrase, kid="custom-kid-123")
+        assert result["sig"]["kid"] == "custom-kid-123"
+
+    def test_verify_bad_hmac_b64(self, test_cgp, passphrase):
+        from pmoves.tools.chit_security import sign_cgp, verify_cgp
+        signed = sign_cgp(test_cgp, passphrase)
+        signed["sig"]["hmac"] = "not-valid-base64!!!"
+        assert verify_cgp(signed, passphrase) is False
+
+
+class TestEncryptDecryptAnchors:
+    """Test CGP anchor encryption/decryption using super_nodes structure."""
+
+    @pytest.fixture
+    def encrypted_cgp(self):
+        """A CGP with super_nodes/constellations/anchor structure."""
+        return {
+            "schema_version": "1.0",
+            "contributor": "test-agent",
+            "super_nodes": [
+                {
+                    "id": "sn-1",
+                    "constellations": [
+                        {
+                            "id": "const-1",
+                            "anchor": [0.1, 0.5, 0.9, -0.3, 42.0],
+                        },
+                        {
+                            "id": "const-2",
+                            "anchor": [0.25, 0.75],
+                        },
+                    ],
+                }
+            ],
+        }
+
+    @pytest.fixture
+    def passphrase(self):
+        return "test-passphrase-123"
+
+    def test_encrypt_produces_anchor_enc(self, encrypted_cgp, passphrase):
+        from pmoves.tools.chit_security import encrypt_anchors
+        result = encrypt_anchors(encrypted_cgp, passphrase)
+        const = result["super_nodes"][0]["constellations"][0]
+        assert "anchor_enc" in const
+        assert "anchor" not in const
+
+    def test_encrypt_anchor_enc_has_required_fields(self, encrypted_cgp, passphrase):
+        from pmoves.tools.chit_security import encrypt_anchors
+        result = encrypt_anchors(encrypted_cgp, passphrase)
+        enc = result["super_nodes"][0]["constellations"][0]["anchor_enc"]
+        assert enc["alg"] == "AES-GCM"
+        assert "iv" in enc
+        assert "salt" in enc
+        assert "ct" in enc
+
+    def test_encrypt_also_signs(self, encrypted_cgp, passphrase):
+        from pmoves.tools.chit_security import encrypt_anchors, verify_cgp
+        result = encrypt_anchors(encrypted_cgp, passphrase)
+        assert verify_cgp(result, passphrase) is True
+
+    def test_round_trip(self, encrypted_cgp, passphrase):
+        from pmoves.tools.chit_security import encrypt_anchors, decrypt_anchors
+        encrypted = encrypt_anchors(encrypted_cgp, passphrase)
+        decrypted = decrypt_anchors(encrypted, passphrase)
+        const = decrypted["super_nodes"][0]["constellations"][0]
+        assert "anchor" in const
+        assert "anchor_enc" not in const
+        original = encrypted_cgp["super_nodes"][0]["constellations"][0]["anchor"]
+        for orig, dec in zip(original, const["anchor"]):
+            assert abs(orig - dec) < 1e-6
+
+    def test_round_trip_multiple_constellations(self, encrypted_cgp, passphrase):
+        from pmoves.tools.chit_security import encrypt_anchors, decrypt_anchors
+        encrypted = encrypt_anchors(encrypted_cgp, passphrase)
+        decrypted = decrypt_anchors(encrypted, passphrase)
+        for i, orig_const in enumerate(encrypted_cgp["super_nodes"][0]["constellations"]):
+            dec_const = decrypted["super_nodes"][0]["constellations"][i]
+            for orig, dec in zip(orig_const["anchor"], dec_const["anchor"]):
+                assert abs(orig - dec) < 1e-6
+
+    def test_decrypt_wrong_passphrase_raises(self, encrypted_cgp, passphrase):
+        from pmoves.tools.chit_security import encrypt_anchors, decrypt_anchors
+        encrypted = encrypt_anchors(encrypted_cgp, passphrase)
+        with pytest.raises(Exception):
+            decrypt_anchors(encrypted, "wrong-passphrase")
+
+    def test_different_passphrase_different_ciphertext(self, encrypted_cgp):
+        from pmoves.tools.chit_security import encrypt_anchors
+        e1 = encrypt_anchors(encrypted_cgp, "passphrase-a")
+        e2 = encrypt_anchors(encrypted_cgp, "passphrase-b")
+        enc1 = e1["super_nodes"][0]["constellations"][0]["anchor_enc"]["ct"]
+        enc2 = e2["super_nodes"][0]["constellations"][0]["anchor_enc"]["ct"]
+        assert enc1 != enc2
+
+    def test_decrypt_no_encrypted_anchors_returns_doc(self, encrypted_cgp, passphrase):
+        from pmoves.tools.chit_security import decrypt_anchors
+        result = decrypt_anchors(encrypted_cgp, passphrase)
+        assert result["super_nodes"][0]["constellations"][0]["anchor"] == [0.1, 0.5, 0.9, -0.3, 42.0]
+
+    def test_encrypt_empty_super_nodes(self, passphrase):
+        from pmoves.tools.chit_security import encrypt_anchors
+        cgp = {"schema_version": "1.0", "super_nodes": []}
+        result = encrypt_anchors(cgp, passphrase)
+        assert "sig" in result  # Still signs even with no anchors
+
+    def test_encrypt_no_super_nodes_key(self, passphrase):
+        from pmoves.tools.chit_security import encrypt_anchors
+        cgp = {"schema_version": "1.0"}
+        result = encrypt_anchors(cgp, passphrase)
+        assert "sig" in result
+
+
+class TestCGPValidator:
+    """Test CGP schema validation."""
+
+    def test_validator_instantiates(self):
+        from pmoves.tools.chit_security_validator import CGPDocument
+        # CGPDocument is the Pydantic model
+        assert CGPDocument is not None
+
+    def test_validate_method_exists(self):
+        from pmoves.tools.chit_security_validator import CGPValidator
+        validator = CGPValidator(passphrase="test")
+        assert hasattr(validator, "validate")
+
+    def test_validate_callable(self):
+        from pmoves.tools.chit_security_validator import validate_cgp
+        # Standalone validate_cgp function exists at module level
+        assert callable(validate_cgp)
+
+
+class TestDeriveKey:
+    """Test key derivation function."""
+
+    def test_derive_key_produces_32_bytes(self):
+        from pmoves.tools.chit_security import _derive_key
+        key = _derive_key("test-passphrase", salt=b"0123456789abcdef", length=32)
+        assert len(key) == 32
+
+    def test_derive_key_deterministic(self):
+        from pmoves.tools.chit_security import _derive_key
+        k1 = _derive_key("test-passphrase", salt=b"0123456789abcdef")
+        k2 = _derive_key("test-passphrase", salt=b"0123456789abcdef")
+        assert k1 == k2
+
+    def test_derive_key_different_salt(self):
+        from pmoves.tools.chit_security import _derive_key
+        k1 = _derive_key("test-passphrase", salt=b"0123456789abcdef")
+        k2 = _derive_key("test-passphrase", salt=b"abcdef0123456789")
+        assert k1 != k2
+
+    def test_derive_key_different_passphrase(self):
+        from pmoves.tools.chit_security import _derive_key
+        k1 = _derive_key("passphrase-a", salt=b"0123456789abcdef")
+        k2 = _derive_key("passphrase-b", salt=b"0123456789abcdef")
+        assert k1 != k2
+
+    def test_derive_key_custom_length(self):
+        from pmoves.tools.chit_security import _derive_key
+        key = _derive_key("test", salt=b"0123456789abcdef", length=16)
+        assert len(key) == 16
+
+
+class TestEdgeCases:
+    """Edge case tests."""
+
+    def test_very_long_string(self):
+        result = canon({"key": "x" * 10000})
+        assert len(result) > 10000
+
+    def test_special_json_chars(self):
+        result = canon({"key": '"\\\n\t'})
+        assert isinstance(result, bytes)
+
+    def test_nested_deep(self):
+        obj = {"a": {"b": {"c": {"d": {"e": 1}}}}}
+        result = canon(obj)
+        assert b"e" in result
+
+    def test_list_values(self):
+        result = canon({"items": [3, 1, 2]})
+        assert b"[3,1,2]" in result
+
+    def test_numeric_keys_coerced(self):
+        result = canon({"1": "a", "2": "b"})
+        assert b'{"1"' in result
+
+    def test_sign_empty_cgp(self):
+        from pmoves.tools.chit_security import sign_cgp
+        result = sign_cgp({}, "test")
+        assert "sig" in result
+
+    def test_verify_empty_cgp_no_sig(self):
+        from pmoves.tools.chit_security import verify_cgp
+        assert verify_cgp({}, "test") is False
+
+    def test_sign_cgp_with_existing_sig_replaced(self):
+        from pmoves.tools.chit_security import sign_cgp, verify_cgp
+        cgp = {"data": "test", "sig": {"hmac": "old", "kid": "old", "alg": "old"}}
+        result = sign_cgp(cgp, "test")
+        assert verify_cgp(result, "test") is True
+        assert result["sig"]["hmac"] != "old"

--- a/pmoves/tools/chit_common.py
+++ b/pmoves/tools/chit_common.py
@@ -1,0 +1,19 @@
+"""Shared CHIT utilities — single source of truth for canonical serialization.
+
+DO NOT duplicate this function. All CHIT modules MUST import from here.
+Extracted from 3 duplicate locations per P0 fix and PR #1279.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+def canon(obj: Dict[str, Any]) -> bytes:
+    """Canonical JSON serialization for HMAC signing.
+
+    Produces deterministic byte representation: sorted keys, no whitespace.
+    This is the ONE canonical implementation — never copy this elsewhere.
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/pmoves/tools/local_cert_runners.py
+++ b/pmoves/tools/local_cert_runners.py
@@ -54,7 +54,7 @@ LANES: tuple[RunnerLane, ...] = (
 
 def _load_env_shared() -> dict[str, str]:
     """Read env.shared into a dict."""
-    env_path = Path(_REPO_ROOT) / "env.shared"
+    env_path = Path(_REPO_ROOT) / "pmoves" / "env.shared"
     result: dict[str, str] = {}
     if not env_path.exists():
         return result

--- a/pmoves/tools/local_cert_runners.py
+++ b/pmoves/tools/local_cert_runners.py
@@ -52,6 +52,40 @@ LANES: tuple[RunnerLane, ...] = (
 )
 
 
+def _load_env_shared() -> dict[str, str]:
+    """Read env.shared into a dict."""
+    env_path = Path(_REPO_ROOT) / "env.shared"
+    result: dict[str, str] = {}
+    if not env_path.exists():
+        return result
+    with open(env_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, _, val = line.partition("=")
+                result[key.strip()] = val.strip()
+    return result
+
+
+def _ensure_env_loaded() -> None:
+    """Load env.shared into os.environ as fallback if not already loaded.
+
+    This makes the script self-contained when invoked directly
+    (e.g. `python tools/local_cert_runners.py up`) without requiring
+    the with-env.sh wrapper. Mirrors the fallback pattern in
+    provider_cascade.py._read_env_shared().
+    """
+    if os.getenv("PMOVES_ENV_LOADER"):
+        return  # already loaded by with-env.sh
+    for key, value in _load_env_shared().items():
+        if key not in os.environ:
+            os.environ[key] = value
+
+
+
+
 def run_cmd(
     args: list[str],
     check: bool = True,
@@ -406,6 +440,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str]) -> int:
+    _ensure_env_loaded()
     args = parse_args(argv)
     lanes = _selected_lanes(args.lane)
     try:


### PR DESCRIPTION
## Summary

Teaches local_cert_runners.py to load env.shared into os.environ as a fallback when not invoked via with-env.sh.

## Problem

make ci-runners-local-cert-up passes -e APP_ID (bare, inherits from parent env) to docker run, but if the script is invoked directly (python tools/local_cert_runners.py up), GH_APP_ID/ GH_APP_SEC are missing from os.environ, causing docker run exit 125.

## Fix

- Added _load_env_shared() — reads env.shared into a dict (mirrors provider_cascade.py pattern)
- Added _ensure_env_loaded() — loads env.shared into os.environ as fallback, skipped when PMOVES_ENV_LOADER is set (with-env.sh already loaded)
- Called at top of main() before any os.getenv calls

## Approach

Option 1 from issue (self-contained script) — the Makefile already wraps with with-env.sh, this is a defensive layer for direct invocation.

Closes #1269