### PR TITLE
ci: deduplicate CodeQL — remove from merge-gate, keep codeql.yml

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,6 +1,9 @@
 # Merge Gate — Required status checks for all PRs targeting main
 # Configure branch protection in GitHub Settings > Branches > main:
 #   Required status checks: Merge Gate / merge-decision
+#
+# Note: CodeQL scanning is handled by codeql.yml (CodeQL Advanced) separately.
+# This avoids duplicate scans and transient init failures.
 
 name: Merge Gate
 
@@ -56,19 +59,8 @@ jobs:
           # Verify no root user in Dockerfiles
           grep -r 'USER' pmoves/services/*/Dockerfile 2>/dev/null | head -10 || echo 'No USER directives found'
 
-  codeql:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v4
-        with:
-          languages: python
-      - uses: github/codeql-action/analyze@v4
-
   merge-decision:
-    needs: [python-tests, docker-build-validation, hardening-validation, codeql]
+    needs: [python-tests, docker-build-validation, hardening-validation]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -78,11 +70,9 @@ jobs:
           echo "  python-tests: ${{ needs.python-tests.result }}"
           echo "  docker-build-validation: ${{ needs.docker-build-validation.result }}"
           echo "  hardening-validation: ${{ needs.hardening-validation.result }}"
-          echo "  codeql: ${{ needs.codeql.result }}"
           if [[ "${{ needs.python-tests.result }}" == "failure" ]] || \
              [[ "${{ needs.docker-build-validation.result }}" == "failure" ]] || \
-             [[ "${{ needs.hardening-validation.result }}" == "failure" ]] || \
-             [[ "${{ needs.codeql.result }}" == "failure" ]]; then
+             [[ "${{ needs.hardening-validation.result }}" == "failure" ]]; then
             echo "::error::Merge gate FAILED — one or more required checks failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary

merge-gate.yml had its own CodeQL job duplicating codeql.yml (CodeQL Advanced). The duplicate caused:
- Transient 2s init failures on PRs (e.g., PR #1275)
- Redundant scans (same language, same build-mode)
- Unnecessary CI minutes

## Changes

- Removed `codeql` job from merge-gate.yml
- Removed `codeql` from `merge-decision` needs list
- Added comment explaining CodeQL is handled by codeql.yml

## Impact

- **No security regression**: codeql.yml scans actions, javascript-typescript, and python on every PR
- **Eliminates flaky check**: merge-gate CodeQL was the only failing CI check on recent PRs
- **Saves ~3-5 min/run**: one fewer CodeQL init+analyze cycle

## Branch protection note

If branch protection requires "Merge Gate / merge-decision" as a status check, no changes needed — CodeQL Advanced runs as a separate required check.
