### PR TITLE
feat(a2a): wire A2A server into agent-zero compose runtime

### DIFF
--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -2334,6 +2334,9 @@ services:
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}
     - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
+    # A2A protocol — Agent-to-Agent interoperability (AGNOTE4482 Item 2)
+    - A2A_DISCOVERY_PUBLIC=${A2A_DISCOVERY_PUBLIC:-false}
+    - A2A_TASKS_PUBLIC=${A2A_TASKS_PUBLIC:-false}
     # LLM routing: use TensorZero gateway as OpenAI-compatible provider
     # Agent Zero's get_default_value() reads A0_SET_* from env (dotenv priority)
     # Dummy key silences LiteLLM "Missing API Key" warning — TensorZero handles auth

--- a/pmoves/docs/AGENTS/AGNOTE4482.md
+++ b/pmoves/docs/AGENTS/AGNOTE4482.md
@@ -122,7 +122,7 @@ Elder-context support is always available to reduce drift and collision across p
 | BoTZ JWT fail-open (P0) | **RESOLVED** | `gateway.py:292-299` returns HTTPException 500 on missing HAS_JOSE or SUPABASE_JWT_SECRET. `auth.py:57-65` returns HTTPException 500 on missing HAS_JOSE or JWT_SECRET. Both fail-closed. |
 | BPM encoder not implemented (P2) | **RESOLVED** | `pmoves/tools/bpm_encoder.py` exists, 574 lines, delivered in PR #1168 (Shift Crew tools) |
 | NATS unauthenticated references (P0) | **NOT IMPROVED** | 57 unauthenticated references across 34 files in `pmoves/` (grep: `nats://(nats\|localhost):4222` excluding `@`; measured 2026-04-02). Not reduced from baseline — batch migration still needed. |
-| A2A server not exposed (P0) | **CODE EXISTS** | `services/agent-zero/python/features/a2a/server.py` defines `/.well-known/agent-card.json` and `/.well-known/agent.json`. Compose exposure unconfirmed — needs runtime verification. |
+| A2A server not exposed (P0) | **RESOLVED** | `server.py` refactored: `create_a2a_router()` exports mountable APIRouter. `main.py` mounts it via `app.include_router()` on port 8080. `docker-compose.yml` adds `A2A_DISCOVERY_PUBLIC`/`A2A_TASKS_PUBLIC` env vars. Routes: `/.well-known/agent-card.json`, `/a2a/v1/tasks`, `/a2a/v1/discover`. Auth via `SUPABASE_JWT_SECRET` (from x-hardening). |
 | Agent registry count | **STALE** | Registry has 71 entries, 13 external contributors. Docs said 60 agents, 7 contributors. |
 | AGENTS file count | **STALE** | 107 documents (66 root + 41 SUBMODULE_CODEX_HOMES). Docs said 73+. |
 
@@ -148,3 +148,29 @@ Elder-context support is always available to reduce drift and collision across p
 - Timestamp: `2026-04-01`
 
 <!-- GRAPHITI_MARK: CLAUDE-OPUS::SELF-REVIEW-AUDIT::2026-04-01 -->
+
+## A2A Server Runtime Wiring (2026-04-17)
+
+### Work Performed
+- Refactored `server.py`: extracted `create_a2a_router()` returning mountable `APIRouter` with all A2A routes (discovery, tasks, artifacts)
+- Moved agent card from `app.state` to module-level `_agent_card` for router compatibility
+- Excluded `/healthz` from router to avoid conflict with parent `main.py`
+- `create_app()` preserved as backward-compatible standalone mode (internally uses `create_a2a_router()`)
+- Updated `main.py`: added try/except import guard, `app.include_router(create_a2a_router())` after app creation
+- Updated `docker-compose.yml`: added `A2A_DISCOVERY_PUBLIC` and `A2A_TASKS_PUBLIC` env vars (default: `false`)
+- Updated `__init__.py`: exported `create_a2a_router` in `__all__`
+
+### Files Changed
+| File | Change |
+|------|--------|
+| `services/agent-zero/python/features/a2a/server.py` | Added `create_a2a_router()`, refactored to module-level `_agent_card`, `_register_a2a_routes()` shared by router and app |
+| `services/agent-zero/python/features/a2a/__init__.py` | Added `create_a2a_router` to exports |
+| `services/agent-zero/main.py` | Import guard + `include_router` mount |
+| `docker-compose.yml` | `A2A_DISCOVERY_PUBLIC`, `A2A_TASKS_PUBLIC` env vars |
+
+### Agent ACK
+- Agent: `AGENT-ZERO-GLM`
+- Signature: `ACK::AGENT-ZERO-GLM::A2A-RUNTIME-WIRING`
+- Timestamp: `2026-04-17`
+
+<!-- GRAPHITI_MARK: AGENT-ZERO-GLM::A2A-RUNTIME-WIRING::2026-04-17 -->

--- a/pmoves/services/agent-zero/main.py
+++ b/pmoves/services/agent-zero/main.py
@@ -50,6 +50,14 @@ from services.common.forms import (
 
 import mcp_server
 
+# A2A protocol integration
+try:
+    from python.features.a2a.server import create_a2a_router
+    _A2A_ROUTER_AVAILABLE = True
+except ImportError:
+    create_a2a_router = None
+    _A2A_ROUTER_AVAILABLE = False
+
 
 @dataclass
 class AgentZeroRuntimeConfig:
@@ -641,6 +649,14 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Agent Zero Supervisor", lifespan=lifespan)
+
+# Mount A2A protocol routes
+if _A2A_ROUTER_AVAILABLE:
+    a2a_router = create_a2a_router()
+    app.include_router(a2a_router)
+    logger.info("A2A protocol routes mounted (/.well-known/agent-card.json, /a2a/v1/*)")
+else:
+    logger.warning("A2A router not available — python.features.a2a.server import failed")
 
 # Prometheus metrics
 from prometheus_client import (

--- a/pmoves/services/agent-zero/python/features/a2a/__init__.py
+++ b/pmoves/services/agent-zero/python/features/a2a/__init__.py
@@ -11,16 +11,11 @@ Key components:
 - Client: HTTP client for discovering and communicating with agents
 
 Example:
-    from features.a2a import AgentCard, create_server
+    from features.a2a import create_a2a_router, AgentCard
 
-    card = AgentCard(
-        name="my-agent",
-        description="An example agent",
-        version="1.0.0",
-        capabilities=["task_execution"],
-        input_modalities=["text/plain"],
-        output_modalities=["text/plain"]
-    )
+    # Mount into existing FastAPI app:
+    a2a_router = create_a2a_router()
+    app.include_router(a2a_router)
 """
 
 from .types import (
@@ -34,7 +29,7 @@ from .types import (
     TaskErrorResponse,
     JSONRPCError,
 )
-from .server import create_app, lifespan
+from .server import create_app, create_a2a_router, lifespan
 
 __all__ = [
     "AgentCard",
@@ -47,6 +42,7 @@ __all__ = [
     "TaskErrorResponse",
     "JSONRPCError",
     "create_app",
+    "create_a2a_router",
     "lifespan",
 ]
 

--- a/pmoves/services/agent-zero/python/features/a2a/server.py
+++ b/pmoves/services/agent-zero/python/features/a2a/server.py
@@ -16,7 +16,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, AsyncIterator, Dict, List, Optional
 
-from fastapi import FastAPI, Header, HTTPException, status
+from fastapi import APIRouter, FastAPI, Header, HTTPException, status
 from fastapi.responses import JSONResponse
 import uvicorn
 
@@ -56,6 +56,9 @@ except Exception:
 # In-memory task storage (replace with persistent storage in production)
 _tasks: Dict[str, Task] = {}
 _tasks_lock = asyncio.Lock()
+
+# Module-level agent card — used by router mode and standalone app mode
+_agent_card: AgentCard = AGENT_ZERO_CARD
 
 
 def _is_enabled_env(var_name: str, default: str = "false") -> bool:
@@ -143,84 +146,44 @@ def _require_task_auth(authorization: Optional[str]) -> None:
     _require_a2a_auth(authorization, public_mode=_is_task_api_public())
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """
-    Lifespan context manager for startup and shutdown events.
-
-    This is the recommended pattern for FastAPI 0.100+. Replaces
-    deprecated startup/shutdown decorator pattern.
-
-    Yields:
-        None: Control is yielded to the application while running
-    """
-    # Startup: Initialize resources
-    logger.info("Starting Agent Zero A2A server...")
-    logger.info(f"Agent: {AGENT_ZERO_CARD.name} v{AGENT_ZERO_CARD.version}")
-    logger.info(f"Capabilities: {', '.join(AGENT_ZERO_CARD.capabilities)}")
-
-    # Initialize task storage (could connect to database here)
-    global _tasks
-    _tasks.clear()
-
-    # Yield control to the application
-    yield
-
-    # Shutdown: Clean up resources
-    logger.info("Shutting down Agent Zero A2A server...")
-    logger.info(f"Processed {len(_tasks)} tasks during session")
-
-    # Cleanup task storage
-    async with _tasks_lock:
-        _tasks.clear()
+# ---------------------------------------------------------------------------
+# A2A Router — mountable into any FastAPI application
+# ---------------------------------------------------------------------------
 
 
-def create_app(
+def create_a2a_router(
     agent_card: Optional[AgentCard] = None,
-    title: str = "Agent Zero A2A Server",
-    version: str = "2.0.0"
-) -> FastAPI:
+) -> APIRouter:
     """
-    Create and configure the FastAPI application.
+    Create an APIRouter with all A2A protocol routes.
+
+    Designed to be mounted into an existing FastAPI application via
+    ``app.include_router(create_a2a_router())``. This avoids running a
+    separate uvicorn process and shares the main server's port.
 
     Args:
         agent_card: Optional custom agent card. Defaults to AGENT_ZERO_CARD.
-        title: API title for documentation.
-        version: API version.
 
     Returns:
-        Configured FastAPI application instance
+        APIRouter with A2A discovery, task, and artifact routes.
     """
-    # Use provided card or default
-    card = agent_card or AGENT_ZERO_CARD
+    global _agent_card
+    _agent_card = agent_card or AGENT_ZERO_CARD
 
-    # Create FastAPI app with lifespan context manager
-    app = FastAPI(
-        title=title,
-        version=version,
-        description="Agent2Agent protocol server for PMOVES.AI Agent Zero",
-        lifespan=lifespan,
-        docs_url="/docs",
-        redoc_url="/redoc",
-    )
-
-    # Store agent card in app state for access in endpoints
-    app.state.agent_card = card
-
-    # Register endpoints
-    _register_endpoints(app)
-
-    # Register exception handlers
-    _register_exception_handlers(app)
-
-    return app
+    router = APIRouter(tags=["A2A"])
+    _register_a2a_routes(router)
+    return router
 
 
-def _register_endpoints(app: FastAPI) -> None:
-    """Register all route handlers with the application."""
+def _register_a2a_routes(target: Any) -> None:
+    """Register A2A route handlers on a FastAPI app or APIRouter.
 
-    @app.get(WELL_KNOWN_AGENT_CARD_PATH, tags=["Discovery"])
-    @app.get(LEGACY_AGENT_CARD_PATH, include_in_schema=False, tags=["Discovery"])
+    NOTE: /healthz is intentionally excluded here — the parent application
+    owns its own health endpoint to avoid route conflicts.
+    """
+
+    @target.get(WELL_KNOWN_AGENT_CARD_PATH, tags=["Discovery"])
+    @target.get(LEGACY_AGENT_CARD_PATH, include_in_schema=False, tags=["Discovery"])
     async def get_agent_card(
         authorization: Optional[str] = Header(default=None, alias="Authorization"),
     ) -> AgentCard:
@@ -234,23 +197,9 @@ def _register_endpoints(app: FastAPI) -> None:
             AgentCard: Agent identity and capability statement
         """
         _require_discovery_auth(authorization)
-        return app.state.agent_card
+        return _agent_card
 
-    @app.get("/healthz", tags=["Health"])
-    async def health_check() -> Dict[str, str]:
-        """
-        Health check endpoint.
-
-        Returns:
-            Health status response
-        """
-        return {
-            "status": "healthy",
-            "agent": app.state.agent_card.name,
-            "version": app.state.agent_card.version
-        }
-
-    @app.post("/a2a/v1/tasks", response_model=SendMessageResponse, tags=["Tasks"])
+    @target.post("/a2a/v1/tasks", response_model=SendMessageResponse, tags=["Tasks"])
     async def create_task(
         request: Dict[str, Any],
         authorization: Optional[str] = Header(default=None, alias="Authorization"),
@@ -339,7 +288,7 @@ def _register_endpoints(app: FastAPI) -> None:
                 detail=f"Failed to create task: {str(e)}"
             )
 
-    @app.get("/a2a/v1/tasks/{task_id}", tags=["Tasks"])
+    @target.get("/a2a/v1/tasks/{task_id}", tags=["Tasks"])
     async def get_task(
         task_id: str,
         authorization: Optional[str] = Header(default=None, alias="Authorization"),
@@ -375,7 +324,7 @@ def _register_endpoints(app: FastAPI) -> None:
 
         return task
 
-    @app.post("/a2a/v1/tasks/{task_id}/cancel", tags=["Tasks"])
+    @target.post("/a2a/v1/tasks/{task_id}/cancel", tags=["Tasks"])
     async def cancel_task(
         task_id: str,
         authorization: Optional[str] = Header(default=None, alias="Authorization"),
@@ -424,7 +373,7 @@ def _register_endpoints(app: FastAPI) -> None:
 
         return task
 
-    @app.post("/a2a/v1/tasks/{task_id}/artifacts", tags=["Tasks"])
+    @target.post("/a2a/v1/tasks/{task_id}/artifacts", tags=["Tasks"])
     async def add_artifact(
         task_id: str,
         artifact: Dict[str, Any],
@@ -471,7 +420,7 @@ def _register_endpoints(app: FastAPI) -> None:
 
         return task
 
-    @app.get("/a2a/v1/tasks", tags=["Tasks"])
+    @target.get("/a2a/v1/tasks", tags=["Tasks"])
     async def list_tasks(
         status_filter: Optional[TaskState] = None,
         limit: int = 100,
@@ -497,7 +446,7 @@ def _register_endpoints(app: FastAPI) -> None:
 
         return tasks[:limit]
 
-    @app.post("/a2a/v1/discover", response_model=AgentDiscoveryResponse, tags=["Discovery"])
+    @target.post("/a2a/v1/discover", response_model=AgentDiscoveryResponse, tags=["Discovery"])
     async def discover_agents(
         authorization: Optional[str] = Header(default=None, alias="Authorization"),
     ) -> AgentDiscoveryResponse:
@@ -513,9 +462,99 @@ def _register_endpoints(app: FastAPI) -> None:
         _require_discovery_auth(authorization)
 
         return AgentDiscoveryResponse(
-            agents=[app.state.agent_card],
+            agents=[_agent_card],
             total=1
         )
+
+
+# ---------------------------------------------------------------------------
+# Standalone app (backward compatible — used by test_server.py and __main__)
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """
+    Lifespan context manager for startup and shutdown events.
+
+    This is the recommended pattern for FastAPI 0.100+. Replaces
+    deprecated startup/shutdown decorator pattern.
+
+    Yields:
+        None: Control is yielded to the application while running
+    """
+    # Startup: Initialize resources
+    logger.info("Starting Agent Zero A2A server...")
+    logger.info(f"Agent: {_agent_card.name} v{_agent_card.version}")
+    logger.info(f"Capabilities: {', '.join(_agent_card.capabilities)}")
+
+    # Initialize task storage (could connect to database here)
+    global _tasks
+    _tasks.clear()
+
+    # Yield control to the application
+    yield
+
+    # Shutdown: Clean up resources
+    logger.info("Shutting down Agent Zero A2A server...")
+    logger.info(f"Processed {len(_tasks)} tasks during session")
+
+    # Cleanup task storage
+    async with _tasks_lock:
+        _tasks.clear()
+
+
+def create_app(
+    agent_card: Optional[AgentCard] = None,
+    title: str = "Agent Zero A2A Server",
+    version: str = "2.0.0"
+) -> FastAPI:
+    """
+    Create and configure the FastAPI application (standalone mode).
+
+    Args:
+        agent_card: Optional custom agent card. Defaults to AGENT_ZERO_CARD.
+        title: API title for documentation.
+        version: API version.
+
+    Returns:
+        Configured FastAPI application instance
+    """
+    global _agent_card
+    _agent_card = agent_card or AGENT_ZERO_CARD
+
+    # Create FastAPI app with lifespan context manager
+    app = FastAPI(
+        title=title,
+        version=version,
+        description="Agent2Agent protocol server for PMOVES.AI Agent Zero",
+        lifespan=lifespan,
+        docs_url="/docs",
+        redoc_url="/redoc",
+    )
+
+    # Mount A2A routes from shared router
+    app.include_router(create_a2a_router(_agent_card))
+
+    # App-specific health endpoint (not in router — avoids conflict with main.py)
+    @app.get("/healthz", tags=["Health"])
+    async def health_check() -> Dict[str, str]:
+        """
+        Health check endpoint.
+
+        Returns:
+            Health status response
+        """
+        return {
+            "status": "healthy",
+            "agent": _agent_card.name,
+            "version": _agent_card.version
+        }
+
+    # Register exception handlers
+    _register_exception_handlers(app)
+
+    return app
 
 
 def _register_exception_handlers(app: FastAPI) -> None:
@@ -560,7 +599,7 @@ def run_server(
     )
 
 
-# Create default app instance for direct import
+# Create default app instance for direct import (backward compat with tests)
 app = create_app()
 
 


### PR DESCRIPTION
## AGNOTE4482 P0 — A2A Server Runtime Exposure

### Summary
A2A protocol code existed as dead code in `features/a2a/server.py` — now wired into the agent-zero FastAPI app at runtime via sub-router.

### Changes
- `server.py`: Added `create_a2a_router()` → `APIRouter`, refactored `_register_a2a_routes()` shared by router+app, module-level `_agent_card` replaces `app.state`
- `__init__.py`: Exported `create_a2a_router` in `__all__`
- `main.py`: Try/except import guard + `app.include_router(create_a2a_router())` at line 654
- `docker-compose.yml`: Added `A2A_DISCOVERY_PUBLIC` + `A2A_TASKS_PUBLIC` env vars (default: `false`)

### A2A Routes (Port 8080)
| Method | Path | Purpose |
|--------|------|---------|
| GET | `/.well-known/agent-card.json` | Agent discovery |
| GET | `/.well-known/agent.json` | Legacy alias |
| POST | `/a2a/v1/tasks` | Create task |
| GET | `/a2a/v1/tasks` | List tasks |
| GET | `/a2a/v1/tasks/{task_id}` | Get task status |
| POST | `/a2a/v1/tasks/{task_id}/cancel` | Cancel task |
| POST | `/a2a/v1/tasks/{task_id}/artifacts` | Attach artifact |
| POST | `/a2a/v1/discover` | Agent discovery |

### Security
- Auth inherits `SUPABASE_JWT_SECRET` from `x-hardening`
- `A2A_DISCOVERY_PUBLIC=false` and `A2A_TASKS_PUBLIC=false` by default — all endpoints require valid JWT
- No extra port mapping needed (shares port 8080 with supervisor)

### Backward Compatibility
- `create_app()` still works standalone (used by `test_server.py`)
- `/healthz` excluded from router to avoid conflict