### PR TITLE
feat(yt-ingest): unblock Phase 9C — multi-client + cookie path + PO token defaults

### DIFF
--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -1835,7 +1835,11 @@ services:
     - NATS_URL=${NATS_URL:-nats://nats:pmoves@nats:4222}
     - YT_NATS_ENABLE=${YT_NATS_ENABLE:-true}
     - HIRAG_URL=${HIRAG_URL:-http://hi-rag-gateway-v2:8086}
-    - YT_PLAYER_CLIENT=${YT_PLAYER_CLIENT:-android}
+    # Multi-client rotation (Phase 9C): yt-dlp tries clients in order until one succeeds.
+    # 'web' first to use cookies + PO token (highest auth fidelity), then mobile fallbacks
+    # that skip signature checks. 'tv_embedded' last as a known-good for age/region gates.
+    - YT_PLAYER_CLIENT=${YT_PLAYER_CLIENT:-web,mweb,android,ios,tv_embedded}
+    - YT_ENABLE_PO_TOKEN=${YT_ENABLE_PO_TOKEN:-true}
     - YT_USER_AGENT=${YT_USER_AGENT:-Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15}
     - YT_COOKIES=${YT_COOKIES:-/app/config/cookies/darkxside.youtube.cookies.txt}
     - BGUTIL_HTTP_BASE_URL=${BGUTIL_HTTP_BASE_URL:-http://bgutil-pot-provider:4416}

--- a/pmoves/docker-compose.yt-cookies.yml
+++ b/pmoves/docker-compose.yt-cookies.yml
@@ -89,7 +89,15 @@ services:
           cpus: '0.5'
           memory: 256M
 
-  # Override pmoves-yt to mount the shared cookie volume (read-only)
+  # Override pmoves-yt to mount the shared cookie volume (read-only).
+  # Path alignment: yt-cookie-writer outputs /cookies/yt-cookies.txt inside its
+  # own container; the same volume mounted here exposes that file at
+  # /app/config/cookies/yt-cookies.txt. YT_COOKIES is overridden to point at
+  # this location so the base compose default
+  # (/app/config/cookies/darkxside.youtube.cookies.txt — placeholder filename)
+  # does not silently shadow the writer's output.
   pmoves-yt:
+    environment:
+      - YT_COOKIES=/app/config/cookies/yt-cookies.txt
     volumes:
       - yt-cookies-vol:/app/config/cookies:ro


### PR DESCRIPTION
## Summary

Closes the YouTube ingestion 403 loop blocking Phase 9C. **One-command operator UX**: `make -C pmoves yt-ingest-bootstrap` runs the entire stack and opens the browser once for Google consent. Three precise edits + one submodule bump + one convenience target:

1. **`docker-compose.yml`** — flip two pmoves-yt env defaults that were silently leaving the pipeline single-client + PO-tokenless:
   - `YT_PLAYER_CLIENT`: `android` → `web,mweb,android,ios,tv_embedded` (yt-dlp internal rotation across clients on a single attempt)
   - `YT_ENABLE_PO_TOKEN`: in-code default of `false` → compose-default `true` (bgutil-pot-provider + invidious-companion have been generating tokens for weeks but yt-dlp wasn't using them; documented in PR #1262 description, commit d51a6d4cd6)

2. **`docker-compose.yt-cookies.yml`** — fix the cookie filename mismatch. yt-cookie-writer outputs `/cookies/yt-cookies.txt`; via the shared `yt-cookies-vol` that lands at `/app/config/cookies/yt-cookies.txt` inside pmoves-yt. Base compose `YT_COOKIES` env defaulted to a placeholder filename `darkxside.youtube.cookies.txt` so the writer's real cookies were silently ignored. Now overridden in the cookies overlay only — base compose still works as standalone with the placeholder file.

3. **PMOVES.YT submodule bump** — `feat/phase9c-multi-client` adds `_download_with_fallback_chain()` with structured tier walking and per-client Prometheus metrics, plus auto-emits `ingest.cookies.invalid.v1` on auth-shaped errors so the cookie pipeline self-heals. Companion PR: POWERFULMOVES/PMOVES.YT#7

4. **`pmoves/mk/yt-cookies.mk`** — two new convenience Make targets:
   - `yt-cookies-bootstrap` — OAuth consent + first cookie harvest in one shot
   - `yt-ingest-bootstrap` — full end-to-end: env-setup → egress → build → cookies → smoke test, walking 6 sub-steps with progress output

## Operator UX (one command, one click)

```bash
make -C pmoves yt-ingest-bootstrap
```

That's it. The target walks all six sub-steps:
1. `env-setup --accept-defaults` + `secrets-funnel`
2. `up-yt-egress` + `yt-egress-verify` (confirms outbound IP is now KVM4-1 / Hostinger)
3. `docker compose build pmoves-yt` + `up-yt` (picks up new image)
4. `up-yt-cookies` (starts refresher + writer)
5. `yt-cookies-bootstrap` — **browser pops up; operator clicks "Allow"; that's the only human-in-the-loop step**
6. Live ingest smoke test against a known-good Cole Medin video

The Google consent screen is unavoidable per OAuth2 spec, but it's a single click and the URL auto-opens in the operator's default browser. The refresh-token then lives in Supabase, encrypted with `VAULT_ENC_KEY` (Fernet), and the croniter scheduler in yt-cookie-refresher harvests fresh cookies weekly without further input.

## Per-step Make targets (still callable individually)

```bash
make -C pmoves up-yt-egress              # just activate egress
make -C pmoves yt-egress-verify          # check outbound IP
make -C pmoves up-yt-cookies             # just start cookie services
make -C pmoves yt-cookies-auth           # just OAuth consent
make -C pmoves yt-cookies-refresh        # just force a refresh
make -C pmoves yt-cookies-status         # show current vault state
make -C pmoves down-yt-egress            # rollback to residential egress
```

## Verification

```bash
# Egress is active — outbound IP rewritten
make -C pmoves yt-egress-verify

# Cookies file populated by writer (expect 50+ lines with SAPISID/HSID/SSID)
docker exec pmoves-pmoves-yt-1 wc -l //app/config/cookies/yt-cookies.txt

# Per-client metrics visible
curl -s http://localhost:8077/metrics | grep yt_download_

# Hi-RAG retrieval reaches the new content
curl -X POST http://localhost:8086/hirag/query \
  -H 'Content-Type: application/json' \
  -d '{"query":"Cole Medin AI Dark Factory","top_k":3,"rerank":true}'
```

## Rollback

```bash
make -C pmoves down-yt-egress             # revert to residential egress
docker compose -f pmoves/docker-compose.yml -f pmoves/docker-compose.yt-cookies.yml --profile yt-cookies down
```

Both compose overlays are additive — removing them restores the prior topology. The submodule revert is a normal gitlink bump.

## Refs

- Closes: Phase 9C (Cole Medin channel ingestion)
- Builds on: #1262 (Phase 9Q egress), PRs #1270 / #1273 / #1274 (Phase 9Q.2 cookie pipeline)
- Unblocks: Phase 9D (Archon video-driven TAC review), broader 14-channel watched feed
- Companion submodule PR: POWERFULMOVES/PMOVES.YT#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)