### PR TITLE
feat(deploy): portable sidecar config for PMOVES.AI deployment on any device

### DIFF
--- a/PMOVES_AI_CONFIG.promptinclude.md
+++ b/PMOVES_AI_CONFIG.promptinclude.md
@@ -1,0 +1,54 @@
+# PMOVES.AI Sidecar Configuration
+
+## Instance Role
+- **Mode**: Sidecar (standalone) — TOPOLOGY_MODE=standalone
+- **Parent System**: PMOVES.AI v1.0.0-hardened
+- **Hardware**: Any device with Docker — laptop, VPS, workstation, or DGX
+- **GPU**: Optional — nvidia-container-runtime if available, CPU-only otherwise
+
+## LLM Providers
+- **ollama_local**: Ollama on host via host.docker.internal:11434 (works on any device with Ollama)
+- **zai_coding**: GLM-5-turbo via Z.AI MAX plan (chat + utility)
+- **tensorzero**: Prepared profile — activate when compose stack is up
+
+## Agent Profiles (agents.json)
+- `sidecar`: Default — Ollama local inference on any device
+- `tensorzero`: Prepared — TensorZero LLM routing (compose required)
+- `researcher`: GLM-5-turbo for research tasks
+- `code-reviewer`: GLM-5-turbo for code review
+
+## Deployment Role
+The sidecar is the agent interface for deploying PMOVES.AI on new systems.
+It uses code_execution_remote for host access and the PMOVES Mini CLI for orchestration.
+
+### Mini CLI Deployment Commands
+- `python3 -m pmoves.tools.mini_cli bootstrap --accept-defaults --service agent-zero` — env bootstrap
+- `python3 -m pmoves.tools.mini_cli profile_detect` — auto-detect hardware capabilities
+- `python3 -m pmoves.tools.mini_cli profile_apply <id>` — apply detected hardware profile
+- `python3 -m pmoves.tools.mini_cli credentials_fetch` — pull secrets from GitHub
+- `python3 -m pmoves.tools.mini_cli tailscale_authkey` — configure Tailscale networking
+- `python3 -m pmoves.tools.mini_cli deps check` — verify host tooling (make, jq, pytest, etc.)
+
+## CHIT Configuration (Dev Mode)
+- CHIT_PASSPHRASE: set via env (dev-local-sidecar-override in sidecar.env)
+- CHIT_REQUIRE_SIGNATURE: false (dev mode)
+- CHIT_DECRYPT_ANCHORS: false (dev mode)
+- Flip to true when compose stack is available
+
+## JetStream
+- Disabled (AGENTZERO_JETSTREAM=false) — no NATS in standalone mode
+- Enable when compose stack provides NATS bus
+
+## Network
+- Ollama: http://host.docker.internal:11434 (universal Docker host gateway)
+- Host access: code_execution_remote (CLI connector)
+- A2A: http://host.docker.internal:5080/a2a/t-TOKEN (token from Settings→MCP/A2A)
+
+## Transition to Docked Mode
+When compose stack is available:
+1. Set TOPOLOGY_MODE=docked in sidecar.env
+2. Set CHIT_REQUIRE_SIGNATURE=true
+3. Set CHIT_DECRYPT_ANCHORS=true
+4. Set AGENTZERO_JETSTREAM=true
+5. Switch to tensorzero agent profile
+6. Restart container

--- a/deploy/sidecar/README.md
+++ b/deploy/sidecar/README.md
@@ -1,0 +1,114 @@
+# PMOVES Sidecar
+
+The PMOVES Sidecar is a standalone Agent Zero container that serves as the **deployment interface** for PMOVES.AI on any system. It combines Agent Zero's agentic capabilities with the PMOVES Mini CLI to bootstrap, configure, and manage PMOVES on new devices.
+
+## How It Differs from Compose Mode
+
+| Aspect | Sidecar (Standalone) | Compose (Docked) |
+|--------|---------------------|------------------|
+| Services | Agent Zero only | Full stack (NATS, TensorZero, Supabase, etc.) |
+| LLM | Ollama local or Z.AI cloud | TensorZero routing with fallbacks |
+| Networking | host.docker.internal only | Docker compose network mesh |
+| CHIT | Dev mode (non-enforcing) | Production mode (signature + anchor) |
+| JetStream | Disabled | Enabled via NATS |
+| Use case | Deploy on new systems | Production workloads |
+
+## Prerequisites
+
+- Docker installed and running
+- (Optional) Ollama for local LLM inference
+- (Optional) nvidia-container-toolkit for GPU passthrough
+- PMOVES repo cloned on the host
+
+## Quick Start on a New Device
+
+### 1. Clone and prepare
+```bash
+git clone https://github.com/POWERFULMOVES/PMOVES.AI.git
+cd PMOVES.AI
+```
+
+### 2. Run host prep (auto-detects GPU, Ollama, ports)
+```bash
+bash scripts/sidecar-host-prep.sh
+```
+
+### 3. Start the sidecar
+Copy the printed `docker run` command from the prep script output and execute it.
+
+### 4. Verify
+```bash
+# Check container is running
+docker logs PMOVES-Sidecar --tail 20
+
+# Verify Ollama reachability (if Ollama is installed)
+docker exec PMOVES-Sidecar curl -s http://host.docker.internal:11434/api/tags
+
+# Verify PMOVES parent config
+docker exec PMOVES-Sidecar env | grep PARENT_SYSTEM
+```
+
+## Mini CLI Integration
+
+Once the sidecar is running, use Agent Zero's `code_execution_remote` to run Mini CLI commands on the host:
+
+| Command | Purpose |
+|---------|---------|
+| `python3 -m pmoves.tools.mini_cli bootstrap --accept-defaults --service agent-zero` | Bootstrap environment files |
+| `python3 -m pmoves.tools.mini_cli profile_detect` | Auto-detect hardware capabilities |
+| `python3 -m pmoves.tools.mini_cli profile_apply <id>` | Apply a hardware profile |
+| `python3 -m pmoves.tools.mini_cli credentials_fetch` | Pull secrets from GitHub |
+| `python3 -m pmoves.tools.mini_cli tailscale_authkey` | Configure Tailscale networking |
+| `python3 -m pmoves.tools.mini_cli deps check` | Verify host tooling |
+
+## Agent Profiles
+
+The sidecar ships with 4 agent profiles in `.a0proj/agents.json`:
+
+- **sidecar** (default) — Ollama local inference via `host.docker.internal:11434`
+- **tensorzero** — TensorZero routing (requires compose stack)
+- **researcher** — GLM-5-turbo via Z.AI for research tasks
+- **code-reviewer** — GLM-5-turbo via Z.AI for code review
+
+Switch profiles in Agent Zero Settings → Agent.
+
+## Environment Configuration
+
+Copy the template and customize:
+```bash
+cp deploy/sidecar/sidecar-env.template ~/agent-zero/PMOVES-Sidecar/sidecar.env
+```
+See `sidecar-env.template` for documented variables grouped by: topology, CHIT, JetStream, endpoints, Agent Zero, security.
+
+## Standalone → Docked Transition
+
+When the full PMOVES compose stack becomes available on the same host:
+
+1. Edit `sidecar.env`:
+   - `TOPOLOGY_MODE=docked`
+   - `CHIT_REQUIRE_SIGNATURE=true`
+   - `CHIT_DECRYPT_ANCHORS=true`
+   - `AGENTZERO_JETSTREAM=true`
+2. Switch to the **tensorzero** agent profile in Agent Zero
+3. Connect the container to the compose network:
+   ```bash
+   docker network connect pmoves_app PMOVES-Sidecar
+   docker network connect pmoves_bus PMOVES-Sidecar
+   ```
+4. Restart: `docker restart PMOVES-Sidecar`
+
+## GPU Passthrough
+
+GPU is optional. The host prep script auto-detects nvidia-container-runtime:
+
+- **Detected**: Adds `--gpus all` (or `--runtime=nvidia --gpus all` if not default)
+- **Not detected**: Runs CPU-only — works fine with Z.AI cloud providers
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Ollama unreachable from container | Ensure `--add-host host.docker.internal:host-gateway` is set |
+| Port 5080 already in use | Change host port mapping: `-p 5081:8080` |
+| NATS connection errors in logs | Confirm `AGENTZERO_JETSTREAM=false` in standalone mode |
+| No GPU inside container | Verify nvidia-container-toolkit: `docker info | grep nvidia` |

--- a/deploy/sidecar/sidecar-env.template
+++ b/deploy/sidecar/sidecar-env.template
@@ -1,0 +1,52 @@
+# ============================================================================
+# PMOVES Sidecar — Environment Template
+# ============================================================================
+# Copy to sidecar.env and fill in values. Do NOT commit sidecar.env to git.
+# ============================================================================
+
+# --- Topology ---
+# standalone = sidecar only, no compose services
+# docked     = connected to PMOVES compose stack
+TOPOLOGY_MODE=standalone
+DOCKED_MODE=true
+PARENT_SYSTEM=PMOVES.AI
+PARENT_VERSION=1.0.0-hardened
+
+# --- CHIT (Cryptographic Host Integrity Trust) ---
+# Dev mode: passphrase-only, no signature enforcement
+# Prod mode: set REQUIRE_SIGNATURE=true, DECRYPT_ANCHORS=true, rotate passphrase
+CHIT_PASSPHRASE=
+CHIT_REQUIRE_SIGNATURE=false
+CHIT_DECRYPT_ANCHORS=false
+
+# --- JetStream (NATS-based event bus) ---
+# Disable in standalone mode (no NATS broker reachable)
+# Enable when compose stack provides NATS at NATS_URL
+AGENTZERO_JETSTREAM=false
+# How many consecutive failures before marking JetStream unavailable
+AGENTZERO_JS_UNAVAILABLE_THRESHOLD=999
+
+# --- Endpoints (compose-prepped, unreachable in standalone) ---
+# These become live when TOPOLOGY_MODE=docked and compose is running
+NATS_URL=nats://nats:pmoves@nats:4222
+TENSORZERO_URL=http://tensorzero-gateway:3000
+SUPABASE_URL=http://supabase-kong:8000
+SUPABASE_SERVICE_ROLE_KEY=
+SUPA_REST_URL=http://supabase-kong:8000/rest/v1
+HIRAG_URL=http://hi-rag-gateway-v2:8086
+
+# --- Agent Zero ---
+AGENT_ZERO_API_BASE=http://127.0.0.1:80
+PORT=8080
+
+# --- Security: Host env leak guard ---
+# Prevent host proxy/TLS vars from leaking into container
+# Leave empty to neutralize any host-set values
+SSL_CERT_FILE=
+SSL_CERT_DIR=
+REQUESTS_CA_BUNDLE=
+CURL_CA_BUNDLE=
+NODE_EXTRA_CA_CERTS=
+HTTP_PROXY=
+HTTPS_PROXY=
+NO_PROXY=

--- a/scripts/sidecar-host-prep.sh
+++ b/scripts/sidecar-host-prep.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# PMOVES Sidecar Host Prep Script
+# Run this on ANY Linux HOST with Docker (not inside the container)
+# Usage: bash scripts/sidecar-host-prep.sh [CONTAINER_NAME]
+
+set -euo pipefail
+
+CONTAINER_NAME="${1:-PMOVES-Sidecar}"
+BASE_DIR="$HOME/agent-zero/PMOVES-Sidecar"
+
+HAS_GPU=false
+HAS_OLLAMA=false
+
+echo "=== PMOVES Sidecar Host Prep ==="
+echo "Container: $CONTAINER_NAME"
+echo "Base dir: $BASE_DIR"
+echo ""
+
+# --- Auto-detect capabilities ---
+echo "=== Phase 0: Detect capabilities ==="
+
+# GPU detection
+if docker info 2>/dev/null | grep -q 'nvidia'; then
+    HAS_GPU=true
+    DEFAULT_RT=$(docker info 2>/dev/null | grep 'Default Runtime' | awk '{print $3}')
+    if [ "$DEFAULT_RT" = "nvidia" ]; then
+        echo "OK: nvidia runtime available (default)"
+    else
+        echo "WARN: nvidia runtime available but not default (current: '$DEFAULT_RT')"
+        echo "  GPU passthrough will use --runtime=nvidia flag"
+    fi
+else
+    echo "INFO: nvidia runtime not found — CPU-only mode"
+fi
+
+# Ollama detection
+if command -v ollama &>/dev/null && ollama list &>/dev/null; then
+    HAS_OLLAMA=true
+    echo "OK: Ollama running locally ($(ollama list | wc -l) models)"
+elif curl -sf http://localhost:11434/api/tags &>/dev/null; then
+    HAS_OLLAMA=true
+    echo "OK: Ollama reachable at localhost:11434"
+else
+    echo "WARN: Ollama not detected — sidecar will run without local inference"
+fi
+
+# Port check
+for PORT in 5080 5081; do
+    if ss -tlnp 2>/dev/null | grep -q ":${PORT} "; then
+        echo "WARN: port $PORT is already in use"
+    else
+        echo "OK: port $PORT available"
+    fi
+done
+
+echo ""
+echo "=== Phase 1: Create data directories ==="
+mkdir -p "$BASE_DIR/data/{memory,knowledge,instruments,logs,runtime}"
+echo "OK: $(ls -d $BASE_DIR/data/*)"
+
+echo ""
+echo "=== Phase 2: Write sidecar.env ==="
+cat > "$BASE_DIR/sidecar.env" << 'ENVEOF'
+# === PMOVES Sidecar Configuration ===
+# Portable — works on any device with Docker
+
+# Topology
+DOCKED_MODE=true
+TOPOLOGY_MODE=standalone
+PARENT_SYSTEM=PMOVES.AI
+PARENT_VERSION=1.0.0-hardened
+
+# CHIT (dev mode -- non-enforcing)
+CHIT_PASSPHRASE=dev-local-sidecar-override
+CHIT_REQUIRE_SIGNATURE=false
+CHIT_DECRYPT_ANCHORS=false
+
+# JetStream (disabled -- NATS not reachable in standalone)
+AGENTZERO_JETSTREAM=false
+AGENTZERO_JS_UNAVAILABLE_THRESHOLD=999
+
+# Pre-staged endpoints (unreachable but ready for compose transition)
+NATS_URL=nats://nats:pmoves@nats:4222
+TENSORZERO_URL=http://tensorzero-gateway:3000
+SUPABASE_URL=http://supabase-kong:8000
+SUPABASE_SERVICE_ROLE_KEY=
+SUPA_REST_URL=http://supabase-kong:8000/rest/v1
+HIRAG_URL=http://hi-rag-gateway-v2:8086
+
+# Agent Zero
+AGENT_ZERO_API_BASE=http://127.0.0.1:80
+PORT=8080
+
+# Host env leak guard
+SSL_CERT_FILE=
+SSL_CERT_DIR=
+REQUESTS_CA_BUNDLE=
+CURL_CA_BUNDLE=
+NODE_EXTRA_CA_CERTS=
+HTTP_PROXY=
+HTTPS_PROXY=
+NO_PROXY=
+ENVEOF
+echo "OK: $(wc -l < $BASE_DIR/sidecar.env) lines written"
+
+echo ""
+echo "=== Phase 3: Stop and remove existing container ==="
+if docker ps -a --format '{{.Names}}' | grep -qxF "$CONTAINER_NAME"; then
+    docker stop "$CONTAINER_NAME" 2>/dev/null || true
+    docker rm "$CONTAINER_NAME" 2>/dev/null || true
+    echo "OK: old container removed"
+else
+    echo "OK: no existing container to remove"
+fi
+
+echo ""
+echo "=== Phase 4: Generate docker run command ==="
+GPU_FLAGS=""
+if [ "$HAS_GPU" = true ]; then
+    if [ "${DEFAULT_RT:-}" = "nvidia" ]; then
+        GPU_FLAGS="  --gpus all \\\n"
+    else
+        GPU_FLAGS="  --runtime=nvidia --gpus all \\\n"
+    fi
+fi
+
+echo ""
+echo "=== READY: Run the following to start the sidecar ==="
+echo ""
+echo "docker run -d \\\n  --name $CONTAINER_NAME \\\n${GPU_FLAGS}--restart unless-stopped \\\n  --cap-drop ALL \\\n  --cap-add NET_BIND_SERVICE --cap-add CHOWN --cap-add SETGID --cap-add SETUID \\\n  --security-opt no-new-privileges:true \\\n  -p 5080:8080 -p 5081:80 \\\n  -v $BASE_DIR/usr:/a0/usr \\\n  -v $BASE_DIR/data/memory:/a0/memory \\\n  -v $BASE_DIR/data/knowledge:/a0/knowledge \\\n  -v $BASE_DIR/data/instruments:/a0/instruments \\\n  -v $BASE_DIR/data/logs:/a0/logs \\\n  -v $BASE_DIR/data/runtime:/a0/runtime \\\n  --env-file $BASE_DIR/sidecar.env \\\n  --add-host host.docker.internal:host-gateway \\\n  agent0ai/agent-zero:latest"
+echo ""
+echo "=== After start, verify ==="
+if [ "$HAS_GPU" = true ]; then
+    echo "docker exec $CONTAINER_NAME nvidia-smi"
+fi
+if [ "$HAS_OLLAMA" = true ]; then
+    echo "docker exec $CONTAINER_NAME curl -s http://host.docker.internal:11434/api/tags"
+fi
+echo "docker exec $CONTAINER_NAME env | grep PARENT_SYSTEM"
+echo ""
+echo "=== Summary ==="
+echo "GPU: $HAS_GPU | Ollama: $HAS_OLLAMA | Container: $CONTAINER_NAME"


### PR DESCRIPTION
Portable sidecar configuration for deploying PMOVES.AI Agent Zero on any device with Docker (laptop, VPS, workstation, DGX).

## Purpose
The sidecar is the agent interface for deploying PMOVES.AI on new systems. It uses Mini CLI + code_execution_remote to orchestrate the full stack — not specific to any single hardware platform.

## Changes

### PMOVES_AI_CONFIG.promptinclude.md
- Removed all hardware-specific references (Spark, GB10, Grace-Blackwell)
- Generic: "Any device with Docker"
- Documented Mini CLI deployment commands (bootstrap, profile_detect, profile_apply, credentials_fetch, tailscale_authkey, deps_check)
- Ollama via host.docker.internal:11434 (universal Docker host gateway)
- Standalone→docked transition path preserved

### scripts/sidecar-host-prep.sh
- Auto-detects GPU availability (optional --gpus all)
- Auto-detects Ollama on host
- Parameterized container name (default: PMOVES-Sidecar)
- Port conflict detection
- Works on any Linux host with Docker

### deploy/sidecar/sidecar-env.template
- 20+ env vars documented by category
- Topology, CHIT, JetStream, compose-prepped endpoints, Agent Zero, security leak guard
- No hardcoded values — template only

### deploy/sidecar/README.md
- Standalone vs compose comparison table
- Quick start guide
- Mini CLI command reference
- Agent profiles (sidecar, tensorzero, researcher, code-reviewer)
- Standalone→docked transition steps
- GPU passthrough notes (optional)
- Troubleshooting table

## Files: 4 new, 362 insertions