### PR TITLE
fix(config): raise claude-sonnet max_output_tokens from 16K to 64K

### DIFF
--- a/pmoves/configs/model-suits/claude-sonnet.yaml
+++ b/pmoves/configs/model-suits/claude-sonnet.yaml
@@ -15,7 +15,7 @@ model_config:
   endpoint: https://openrouter.ai/api/v1
   api_key_env: OPENROUTER_API_KEY
   context_window: 200000
-  max_output_tokens: 16384
+  max_output_tokens: 65536
   temperature: 0.5
   top_p: 0.9
 


### PR DESCRIPTION
Claude Sonnet 4 supports up to 64K output tokens. Previous 16K cap was likely cost-control holdover.

**Change:** `pmoves/configs/model-suits/claude-sonnet.yaml` L18: `16384` → `65536`

**Refs:** post-merge review follow-up #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased maximum output length for Claude Sonnet model, enabling longer and more comprehensive responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->