### PR TITLE
docs: rewrite root AGENTS.md for current project state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,296 +1,109 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-- `services/`: Python microservices (FastAPI workers, utilities). Examples: `agent-zero/`, `hi-rag-gateway/`, `retrieval-eval/`, `graph-linker/`, `publisher/`.
-- `contracts/`: Event contracts (`schemas/`) and `topics.json` mapping topics → schema paths.
-- `schemas/`: Shared domain models used across services.
-- `supabase/`, `neo4j/`, `services/*/migrations/`: DB migrations and Cypher/SQL.
-- `n8n/`, `comfyui/`: Workflow exports and ComfyUI assets.
-- `datasets/`, `docs/`: Sample data and documentation.
-- Root: `docker-compose.yml`, `Makefile`, `env.shared.example`.
+## Project Structure
 
-## Planning & Documentation Expectations
-- **Mandatory context before changes:** read `pmoves/docs/PMOVES.AI PLANS/ROADMAP.md` and `pmoves/docs/NEXT_STEPS.md` to align with the current sprint focus (M2 — Creator & Publishing). These documents spell out the active priorities, including Jellyfin refresh polish, Discord embeds, and Supabase→Discord automation; confirm your work reinforces or explicitly updates those targets before you start coding.
-- **Maintainer cadence:** when significant features ship, priorities move between columns, or we start a new sprint, refresh both `docs/ROADMAP.md` and `docs/NEXT_STEPS.md` (and adjust their `_Last updated` timestamps) so contributors always land on the latest plan.
-- **Supporting references:**
-  - `docs/MAKE_TARGETS.md` — authoritative Make targets, smoke checks, and automation entry points.
-  - `docs/README_DOCS_INDEX.md` — high-level index of the documentation set and where to find service-specific guides.
-  - Jellyfin integration runbooks live under `pmoves/docs/PMOVES.AI PLANS/` (see `JELLYFIN_BRIDGE_INTEGRATION.md`, `JELLYFIN_BACKFILL_PLAN.md`, and `Enhanced Media Stack with Advanced AudioVideo Analysis/`).
-  - Additional operational primers live alongside services (e.g., `services/**/README.md`) and should be consulted when touching those areas.
-  - `pmoves/docs/AGENTS/CODEX_OPERATOR_HOME.md`, `pmoves/docs/AGENTS/CODEX_ECOSYSTEM_TRAVERSAL.md`, `pmoves/docs/AGENTS/CODEX_RUNTIME_PROTOCOL.md`, and `pmoves/docs/AGENTS/CODEX_CLAUDE_PARITY_MAP.md` define the Codex-first production workflow; keep them aligned with `.claude/CLAUDE.md` and `.claude/commands/` whenever agent tooling or operator paths change.
-  - `.claude/context/submodules.md`, `.claude/context/submodule-workflow.md`, and `pmoves/docs/AGENTS/SUBMODULE_CODEX_HOMES/README.md` are the required submodule references before changing PMOVES forks, overlays, or gitlinks.
-  - Final-stage production rule: treat Codex parity as a release concern, not a follow-up. If you add a new operator command path, submodule overlay, or agent workflow, update both the Claude-facing and Codex-facing docs in the same PR.
+PMOVES.AI is a modular AI agent platform organized as a **submodule monorepo**.
 
-## Build, Test, and Development Commands
-- `make up`: Starts core data services and workers (qdrant, neo4j, meilisearch, hi-rag-gateway, retrieval-eval) via Docker Compose profiles, assuming Supabase CLI is already running on the `pmoves-net` network.
-- `make down`: Stops all containers.
-- `make clean`: Stops and removes volumes (destructive for local data).
-- Run a service locally (example): `python services/agent-zero/main.py` (installs deps first: `pip install -r services/agent-zero/requirements.txt`).
-- Logs: `docker compose logs -f <service>`.
+- **`pmoves/`** — Core platform: Makefile, docker-compose, configs, services, tools, tests, docs
+- **`PMOVES-*/`** — Git submodules (Agent-Zero, Archon, ClaWZ, Creator, HiRAG, YT, supabase, etc.)
+- **`pmoves/config/`** — Agent registry (`agent_registry.yaml`), model configs, TAC trees
+- **`pmoves/docs/`** — Documentation (agents, operations, services, plans, security)
+- **`pmoves/services/`** — Service forks and local service code
+- **`pmoves/tests/`** — Unit, smoke, integration, and hardening tests
+- **`deploy/`** — Deployment configs (sidecar, K8s, cloudflare, provision)
+- **`.claude/`** — Claude Code context, commands, hooks, MCP config
+- **Root** — `Makefile` (delegates to pmoves), `CLAUDE.md`, `CONTRIBUTING.md`, `SECURITY.md`
 
-## Coding Style & Naming Conventions
-- Python 3.11+, 4‑space indentation, prefer type hints.
-- FastAPI routes: snake_case function names; path names kebab-case only in URLs.
-- Event contracts: keep `v{n}` suffix in filenames (e.g., `*.v1.schema.json`) and update `contracts/topics.json` when adding topics.
-- Keep modules small and single‑purpose; share helpers in `services/common/`.
+## Canonical Documentation
 
-## Testing Guidelines
-- Current repo has minimal automated tests. When adding tests, use `pytest` with `tests/` per service (e.g., `services/<name>/tests/test_*.py`).
-- Mock external systems (NATS, MinIO, Neo4j) and validate envelope/schema with sample payloads.
-- Suggested commands: `pip install -r services/<name>/requirements.txt pytest` then `pytest -q`.
-- Before pushing, mirror the GitHub Actions checks documented in `docs/LOCAL_CI_CHECKS.md` (pytest suites, `make chit-contract-check`, `make jellyfin-verify` when the publisher is affected, SQL policy lint, env preflight). Capture each command/output in the PR template’s Testing section.
-- If you intentionally skip one of those checks (docs-only change, etc.), record the rationale in the PR Reviewer Notes so reviewers know the risk envelope.
-- UI updates: run `make -C pmoves notebook-workbench-smoke ARGS="--thread=<uuid>"` to lint the Next.js bundle and validate Supabase connectivity. Reference `pmoves/docs/UI_NOTEBOOK_WORKBENCH.md` when collecting smoke evidence.
-- Hi-RAG gateway: after touching reranker or embedding code, run `make -C pmoves smoke-gpu`. The target now pipes the validation query through `docker compose exec` so FlagEmbedding/Qwen rerankers that only accept batch size 1 still report `"used_rerank": true` (first run downloads the 4B checkpoint).
-- Agents/Archon: for full-stack validation, follow the “All Services Up, Then Tests (Archon + Agents Flow)” section in `pmoves/docs/SMOKETESTS.md` and the Archon service guide in `pmoves/docs/services/archon/README.md`; use `make -C pmoves agents-headless-smoke`, `make -C pmoves smoke-gpu`, and (when available) `make -C pmoves verify-all`/`make -C pmoves archon-smoke` to exercise health endpoints and Supabase wiring.
+| Topic | Location |
+|-------|----------|
+| **Agents overview** | `pmoves/docs/AGENTS/README.md` — 71 agents, taxonomy v1.5.0, 7 tiers |
+| **Agent taxonomy** | `pmoves/docs/AGENTS/PMOVES_AGENT_CLASS_TAXONOMY.md` — 4 classes, evolution stages |
+| **Agent topology** | `pmoves/docs/AGENTS/PMOVES_AGENT_TOPOLOGY.md` — network topology, ClaWZ integration |
+| **Agent registry** | `pmoves/config/agent_registry.yaml` — single source of truth for all agents |
+| **Model integration** | `pmoves/docs/PMOVES_MODEL_INTEGRATION_FRAMEWORK.md` — model suits, routing |
+| **Personas** | `pmoves/docs/AGENTS/PERSONAS.md` — persona schema, 8 seed personas |
+| **Service docs matrix** | `pmoves/docs/SERVICE_DOCS_MATRIX.md` — per-service doc index |
+| **Docs index** | `pmoves/docs/README_DOCS_INDEX.md` — full documentation index |
+| **Operations** | `pmoves/docs/operations/` — smoketests, monitoring, runbooks |
+| **Security** | `pmoves/docs/security/` — CHIT, hardening, audit |
+| **Roadmap** | `pmoves/docs/PMOVES.AI PLANS/ROADMAP.md` |
+| **Claude runbook** | `.claude/CLAUDE.md` — live service map and operator guide |
+| **Codex operator** | `pmoves/docs/AGENTS/CODEX_OPERATOR_HOME.md` — Codex-first runbook |
+| **Sidecar deploy** | `deploy/sidecar/README.md` — standalone deployment on any device |
 
-- Storage unified to Supabase Storage S3 endpoint. Ensure in `pmoves/env.shared`:
-  - `MINIO_ENDPOINT=http://host.docker.internal:65421/storage/v1/s3`
-  - `MINIO_REGION=local`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` from `make -C pmoves supa-status`.
-- Invidious bound to `127.0.0.1:3005` (stats 200). Companion/HMAC keys stamped in `pmoves/.env`.
-- Hi‑RAG v2: GPU on `:8087`, CPU on `:8086`. Health path is `/hirag/admin/stats`.
-- Core smoke: PASS. GPU rerank re‑enabled; run strict check with `GPU_SMOKE_STRICT=true make -C pmoves smoke-gpu`.
-- Jellyfin: server 8096 OK; bridge 8093 OK.
-- Monitoring: Prometheus/Grafana OK; Loki config upgrade pending.
+## Build & Development Commands
 
-## What Should Be Running Now (single-env, Supabase Storage only)
-- Supabase REST (CLI stack) on 65421 — `docker network create pmoves-net || true`; `make -C pmoves supa-start` then `make -C pmoves supabase-bootstrap` so `pmoves_core`/`pmoves_kb` exist. Status: `make -C pmoves supa-status`.
-- Core stack — `SUPABASE_RUNTIME=cli make -C pmoves up` (data + workers). Seeds: `make -C pmoves bootstrap-data` (Supabase/Neo4j/Qdrant/Meili).
-- Hi‑RAG v2 CPU/GPU — `curl http://localhost:8086/hirag/admin/stats` and `curl http://localhost:8087/hirag/admin/stats` return JSON.
-- Channel Monitor — `GET /healthz`, `GET /api/monitor/status`, `GET /api/monitor/stats` → 200.
-- Archon API/UI — `GET http://localhost:8091/healthz` 200; UI at http://localhost:3737.
-- Monitoring — Prometheus :9090, Grafana :3002, Blackbox :9115 (cAdvisor when `MON_INCLUDE_CADVISOR=true`).
-- Invidious :3005 (127.0.0.1 bind), Jellyfin :8096, Notebook :8503.
+All make targets live in `pmoves/Makefile`. Run with `make -C pmoves <target>`.
 
-### Quick verification commands
-- `make -C pmoves smoke` (core) and `GPU_SMOKE_STRICT=true make -C pmoves smoke-gpu` (strict rerank).
-- `make -C pmoves up-monitoring && make -C pmoves monitoring-report`.
-- `curl -s http://localhost:8097/api/monitor/status ; echo`.
+### Common targets
+- `make -C pmoves up` — Start core stack (data + workers) via Docker Compose
+- `make -C pmoves down` — Stop all containers
+- `make -C pmoves supa-start` — Start Supabase CLI stack
+- `make -C pmoves supabase-bootstrap` — Run migrations and seed data
+- `make -C pmoves bootstrap-data` — Seed Neo4j, Qdrant, MeiliSearch, Supabase demo data
+- `make -C pmoves smoke` — Core smoketest suite
+- `make -C pmoves smoke-gpu` — GPU rerank validation (`GPU_SMOKE_STRICT=true` for strict)
+- `make -C pmoves up-agents-published` — Start Agent Zero + Archon from published images
+- `make -C pmoves env-setup` — Configure environment from `env.shared`
+- `make -C pmoves env-check` — Validate environment configuration
+- `make -C pmoves preflight` — Tooling sanity check
+- `make -C pmoves flight-check` — Runtime sanity check
 
-### Operator quick links
-- Supabase Studio: http://127.0.0.1:65433  • REST: http://127.0.0.1:65421/rest/v1
-- Hi‑RAG v2 GPU: http://localhost:8087/hirag/admin/stats
-- Invidious: http://127.0.0.1:3005
-- Jellyfin: http://localhost:8096 • Bridge API: http://localhost:8093
-- Grafana: http://localhost:3002 • Prometheus: http://localhost:9090
+### Bring-up sequence
+1. `docker network create pmoves-net || true`
+2. `cp pmoves/env.shared.example pmoves/env.shared` → fill secrets
+3. `make -C pmoves env-setup && make -C pmoves env-check`
+4. `make -C pmoves supa-start && make -C pmoves supabase-bootstrap`
+5. `SUPABASE_RUNTIME=cli make -C pmoves up`
+6. `make -C pmoves bootstrap-data`
+7. `make -C pmoves smoke`
 
-### Next actions
-- Finish Loki config and confirm `/ready` 200.
-- Re‑enable GPU rerank and add an integration smoke.
-- Force offline transcript provider (`YT_TRANSCRIPT_PROVIDER=qwen2-audio`) in smoketest IDs; broaden fallback detection.
+## Coding Style
+- Python 3.11+, 4-space indentation, type hints preferred
+- FastAPI routes: snake_case functions; kebab-case in URL paths only
+- Event contracts: `v{n}` suffix in filenames (e.g., `*.v1.schema.json`)
+- Keep modules small and single-purpose
 
-### Console & Personas
-- Console dev helpers: `make -C pmoves ui-dev-start` (port 3001, auto-loads env and boot JWT), `ui-dev-stop`, and `ui-dev-logs`.
-- Personas (v5.12): `pmoves_core.personas` is created and seeded with the `Archon` persona. To reapply schema/seeds: `make -C pmoves supabase-bootstrap`. Verify with:
-  ```bash
-  supadb=$(docker ps --format '{{.Names}}' | grep -m1 '^supabase_db_');
-  docker exec -it "$supadb" psql -U postgres -d postgres -c "select name,version from pmoves_core.personas;"
-  ```
-- JetStream drift can surface as `nats: JetStream.Error cannot create queue subscription…` in the Agent Zero container logs. Rebuild with `docker compose build agent-zero && docker compose up -d agent-zero` so the pull-subscribe controller code ships and the consumer metadata is recreated automatically.
+## Testing
+- Framework: `pytest` — tests per service in `pmoves/tests/` (unit, smoke, integration, hardening)
+- Mock external systems (NATS, Supabase, Neo4j); validate with sample payloads
+- Run: `pytest -q pmoves/tests/unit/` or per-service paths
+- Local CI checks: `docs/LOCAL_CI_CHECKS.md`
+- Before pushing: run relevant smoke targets and document results in PR
 
-### Secrets handling (everyone)
-- Never commit secrets. Keep personal scratch in ignored files only, and store shared credentials in GitHub Actions secrets (with environment scoping for dev/prod), Docker/compose secrets via `*_FILE` envs, and the team vault for human retrieval.
-- Approved secret names and onboarding steps live in `docs/SECRETS_ONBOARDING.md`.
-- Single-env + branded defaults: integrations run against one environment bundle. Keep branded login defaults/API tokens in GitHub secrets and the vault; avoid committing real secrets in `pmoves/env.shared` (rotate and load through secrets for production values).
-- Quick start (local): `cp pmoves/env.shared.example pmoves/env.shared`, fill values, `make env-setup`, `make env-check`, then `./pmoves/tools/push-gh-secrets.sh --repo POWERFULMOVES/PMOVES.AI --env Dev` to mirror into GitHub Secrets.
+## Commit & PR Guidelines
+- Conventional Commits: `feat(scope): description`, `fix(scope): description`, `docs(scope): description`
+- PRs: clear description, linked issues, affected services, testing evidence
+- Keep changes atomic; update docs/schemas when interfaces change
 
-#### Health badges and custom endpoints
+## Secrets
+- Never commit secrets. Copy `pmoves/env.shared.example` → `pmoves/env.shared`
+- Shared defaults in `env.shared`, machine-specific in `.env.local`
+- Production secrets in GitHub Actions secrets and team vault
+- Onboarding: `docs/SECRETS_ONBOARDING.md`
 
-The console Quick Links probe Agent Zero and Archon using `/healthz` by default. If your forks expose different health endpoints, set:
+## Submodule Workflow
+- Consult `.claude/context/submodules.md` and `pmoves/docs/AGENTS/SUBMODULE_CODEX_HOMES/README.md` before submodule changes
+- Work in the submodule directory, land the commit there, then update the PMOVES.AI gitlink
+- Run `make -C pmoves submodule-integrity` after pointer changes
 
-- `NEXT_PUBLIC_AGENT_ZERO_HEALTH_PATH` (default `/healthz`)
-- `NEXT_PUBLIC_ARCHON_HEALTH_PATH` (default `/healthz`)
+## Deployment
 
-Personas page fallback when Supabase CLI REST hides `pmoves_core`:
+### Sidecar (standalone)
+Agent Zero container for deploying PMOVES on any device. See `deploy/sidecar/README.md`.
+- Quick start: `bash scripts/sidecar-host-prep.sh` → run printed `docker run` command
+- LLM: Ollama local (`host.docker.internal:11434`) or Z.AI cloud
+- Mini CLI: `python3 -m pmoves.tools.mini_cli <command>` via `code_execution_remote`
 
-- Start a PostgREST bound to the CLI DB: `docker compose -p pmoves up -d postgrest-cli` (host `http://localhost:3011`).
-- Personas page now uses Supabase REST by default. Ensure the Supabase CLI stack is running (REST on `http://host.docker.internal:65421/rest/v1`). Only set `POSTGREST_URL=http://localhost:3011` if you explicitly bring up the legacy compose PostgREST fallback.
+### Compose (production)
+Full stack with NATS, TensorZero, Supabase, monitoring. See `pmoves/docker-compose.yml`.
+- Images pinned in `pmoves/env.shared` (`AGENT_ZERO_IMAGE`, `ARCHON_IMAGE`, etc.)
+- GHCR workflow builds multi-arch images: `.github/workflows/self-hosted-builds-hardened.yml`
 
-See also: `pmoves/docs/SERVICE_HEALTH_ENDPOINTS.md`.
-
-### Agents UIs one‑click bring‑up
-
-- Published images (default):
-  - `make -C pmoves up-agents-ui` — starts NATS, Agent Zero API, Archon API, and the Archon UI. Open the UIs:
-    - Agent Zero UI: `${NEXT_PUBLIC_AGENT_ZERO_UI_URL:-http://localhost:8081}`
-    - Archon UI: `${NEXT_PUBLIC_ARCHON_UI_URL:-http://localhost:3737}` (uses the Vite proxy to reach the Archon API on the Docker alias `archon-server`; keep `ARCHON_UI_API_URL` unset unless you explicitly need to point the UI at a remote/hosted Archon instance)
-
-### MCP (Agent‑to‑Agent) wiring
-
-- Register MCP servers for Agent Zero with `A0_MCP_SERVERS` in `pmoves/env.shared`. Example:
-
-```
-A0_MCP_SERVERS=
-  fs: "mcp://filesystem?roots=/data";
-  archon: "mcp://http?endpoint=http://archon-server:8051";
-  neo4j: "mcp://neo4j?url=bolt://neo4j:7687&user=neo4j&password=${NEO4J_PASSWORD}";
-  supabase: "mcp://supabase?url=${SUPABASE_URL}&key=${SUPABASE_SERVICE_ROLE_KEY}";
-```
-
-- Seed the runtime mapping file for Agent Zero (writes to `pmoves/data/agent-zero/runtime/mcp/servers.env`):
-
-```
-make -C pmoves a0-mcp-seed
-```
-
-- Quick MCP smoke for Archon’s bridge (port only, 404 acceptable):
-
-```
-make -C pmoves archon-mcp-smoke
-```
-
-Archon runs headless for orchestrations (Agent Zero → Archon via MCP) while the Archon UI can also issue MCP requests to the same headless bridge.
-- From your forks (integrations workspace):
-  - `make -C pmoves agents-integrations-clone` (once)
-  - `make -C pmoves build-agents-integrations`
-  - `make -C pmoves up-agents-integrations`
-
-### Agent tooling context (Claude + Codex)
-- Always read `.claude/CLAUDE.md`, `pmoves/docs/AGENTS/CODEX_OPERATOR_HOME.md`, and `pmoves/docs/AGENTS/CODEX_ECOSYSTEM_TRAVERSAL.md` before tooling; `.claude/CLAUDE.md` is the live service map, while the Codex docs define the command-first production runbook and ecosystem traversal path.
-- Use `pmoves/docs/AGENTS/CODEX_RUNTIME_PROTOCOL.md`, `pmoves/docs/AGENTS/CODEX_CLAUDE_PARITY_MAP.md`, and `pmoves/docs/AGENTS/KRISS_KROSS_ACCORD.md` when Codex and Claude overlap on the same branch, release lane, or operator workflow.
-- For submodule work, consult `.claude/context/submodules.md`, `.claude/context/submodule-workflow.md`, and `pmoves/docs/AGENTS/SUBMODULE_CODEX_HOMES/README.md` first; work in the submodule, land the submodule commit, then update the PMOVES.AI gitlink.
-- Slash commands live in `.claude/commands/` (e.g., `/agents:status`, `/search:hirag`, `/yt:*`). Reuse these when adding workflows so doc/automation stay in sync. Quick uptime probe: `.claude/commands/health/quick.md` (pings core services + GPU stats).
-- Hooks: `.claude/hooks/pre-tool.sh` blocks destructive shell (e.g., `rm -rf /`, `DROP DATABASE`); `.claude/hooks/post-tool.sh` publishes `claude.code.tool.executed.v1` to NATS for observability. Keep new scripts compliant.
-- If you add or move services/endpoints, mirror the change in `.claude/context/services-catalog.md`, `pmoves/docs/AGENTS/CODEX_CLAUDE_PARITY_MAP.md`, and any impacted `pmoves/docs/AGENTS/SUBMODULE_CODEX_HOMES/*.md` overlay so Claude and Codex stay in parity.
-
-### Hardening status (in-flight)
-- Hardened CI now builds/scans multi-arch images (amd64+arm64) for exposed services; Trivy gates on HIGH/CRITICAL in `.github/workflows/self-hosted-builds-hardened.yml`.
-- Arm/Jetson path: `pmoves/docker-compose.arm64.override.yml` wires GPU/CUDA flags for edge nodes; keep `DOCKER_DEFAULT_PLATFORM` unset when building native arm64.
-- Dependency freshness: weekly yt-dlp bump workflow (`.github/workflows/yt-dlp-bump.yml`) keeps PMOVES.YT extractors current; image pins in `pmoves/env.shared.example` warn if `:pmoves-latest` is used.
-- High-priority follow-ups: finalize hashed locks on Python 3.11 (agent-zero, media-video), finish Loki `/ready` 200, and extend StepSecurity egress allowlists per workflow job. Track in `docs/hardening/PMOVES-hardening-tracker.md` and `docs/PMOVES.AI-Edition-Hardened-Full.md` status section.
-
-### Security & code-scanning triage
-- CodeQL alerts (HIGH/CRITICAL) block hardened builds via Trivy; triage by reproducing locally: `make -C pmoves smoke` then `GPU_SMOKE_STRICT=true make -C pmoves smoke-gpu` when GPU is available.
-- For code scanning regressions, prefer patching in-service requirements locks; regenerate with `uv pip compile --generate-hashes -o requirements.lock requirements.txt` on Python 3.11.
-- Secrets: onboarding + rotation steps live in `docs/SECRETS_ONBOARDING.md`; avoid keeping real values in `pmoves/env.shared`.
-
-### Reproducible integration images (GHCR)
-
-The GHCR workflow (`.github/workflows/integrations-ghcr.yml`) builds/publishes multi‑arch images nightly and on demand for:
-
-- Agent Zero API (`pmoves-agent-zero`)
-- Archon API (`pmoves-archon`)
-- Archon UI (`pmoves-archon-ui`)
-- Open Notebook (`pmoves-open-notebook`)
-- Jellyfin (`pmoves-jellyfin`)
-- Firefly III (`pmoves-firefly-iii`)
-- Wger (`pmoves-health-wger`)
-- PMOVES.YT (`pmoves-yt`)
-
-Pin images by setting `AGENT_ZERO_IMAGE`, `ARCHON_IMAGE`, `ARCHON_UI_IMAGE`, and `PMOVES_YT_IMAGE` in `pmoves/env.shared`.
-
-## Bring-Up Sequence (CLI on pmoves-net)
-- Prefer `make first-run` (see `docs/FIRST_RUN.md`) to bootstrap secrets, start Supabase CLI, seed data, and run smokes.
-- Manual flow:
-  1) `docker network create pmoves-net || true`
-  2) `cp pmoves/env.shared.example pmoves/env.shared` → fill secrets
-  3) `make -C pmoves env-setup`
-  4) `make -C pmoves supa-start` then `make -C pmoves supabase-bootstrap`
- 5) `SUPABASE_RUNTIME=cli make -C pmoves up`
- 6) Agents (published images, no local builds): `SUPABASE_RUNTIME=cli make -C pmoves up-agents-published`
-  7) `make -C pmoves bootstrap-data` (Neo4j/Qdrant/Meili/Supabase demo data)
- 8) Optional: `make -C pmoves up-external[-firefly|-wger|-jellyfin|-on]`, `make -C pmoves up-n8n`, `make -C pmoves up-invidious`, `make -C pmoves up-jellyfin-ai`
- 9) Smokes: `make -C pmoves smoke`; `GPU_SMOKE_STRICT=true make -C pmoves smoke-gpu`
-
-### Agents images and custom overlays
-- Default: published images set in `pmoves/env.shared` (`AGENT_ZERO_IMAGE`, `ARCHON_IMAGE`, `DEEPRESEARCH_IMAGE`, `SUPASERCH_IMAGE`). Use `up-agents-published` to pull and run them.
-- Custom code: build a thin overlay FROM the published image, copy only your changes, tag it (e.g., `my/archon:dev`), set the corresponding `*_IMAGE` in `pmoves/env.shared`, then rerun `up-agents-published`. Pin tags only when a new upstream release breaks you.
-
-## Smoketests & Diagnostics
-- Full harness: `make smoke`
-- Discord publisher: `make discord-smoke` (requires `DISCORD_WEBHOOK_URL` in `env.shared`/`.env.local`; host port 8094).
-- Geometry web UI: `make web-geometry`
-- Health checks: `make health-agent-zero`, `make health-publisher-discord`, `make health-jellyfin-bridge`
-- External integrations: `make smoke-wger`, `make smoke-presign-put`, `make yt-jellyfin-smoke` (pmoves.yt ingest + Jellyfin playback; ensure `make up`, `make up-yt`, `make up-invidious`, and `make up-jellyfin` are running, and keep the overlay `JELLYFIN_API_KEY` in sync so the bridge can mint playback URLs) or `make jellyfin-smoke` (playback-only; the target now attempts `/jellyfin/map-by-title` first and, if that misses, links the newest Jellyfin library item through `/jellyfin/link` before requesting a playback URL). Keep `SUPA_REST_URL`/`SUPA_REST_INTERNAL_URL` pointed at the active Supabase REST host — `http://host.docker.internal:65421/rest/v1` when the CLI stack is running, and set `HIRAG_URL`/`HIRAG_GPU_URL` to `http://hi-rag-gateway-v2-gpu:8086` so CGPs land in the GPU ShapeStore before falling back to `HIRAG_CPU_URL`.
-- Creative CGP demos: `make demo-health-cgp`, `make demo-finance-cgp`, plus manual WAN/Qwen/VibeVoice webhook triggers (see `pmoves/creator/README.md`).
-- Environment sanity: `make preflight` (tooling) and `make flight-check` (runtime)
-
-### UI Quickstart & Links
-- Supabase Studio → http://127.0.0.1:65433 (`make -C pmoves supa-start`; status via `make -C pmoves supa-status`).
-- Notebook Workbench → http://localhost:4482/notebook-workbench (`npm run dev` in `pmoves/ui`; the launcher now layers `env.shared` + `.env.local` automatically; smoke with `make -C pmoves notebook-workbench-smoke`).
-- TensorZero Playground → http://localhost:4000 (`make -C pmoves up-tensorzero`; this target now launches ClickHouse, the gateway/UI, and `pmoves-ollama` so embeddings resolve on http://localhost:3030). If you’re on Jetson/arm64 or delegating inference, point `TENSORZERO_BASE_URL` at a remote gateway instead.
-- Firefly Finance → http://localhost:8082 (`make -C pmoves up-external-firefly`; configure `FIREFLY_*` secrets).
-- Wger Coach Portal → http://localhost:8000 (`make -C pmoves up-external-wger`; brand defaults apply automatically).
-- Jellyfin Media Hub → http://localhost:8096 (`make -C pmoves up-external-jellyfin`; run `make -C pmoves jellyfin-folders` and drop media into `pmoves/data/jellyfin` if you need the legacy stack).
-- Jellyfin AI Overlay → http://localhost:9096 (`make -C pmoves up-jellyfin-ai`; exposes API gateway on http://localhost:8300 and dashboard on http://localhost:8400; seed a sample asset with `python scripts/seed_jellyfin_media.py` so smoketests have something to link).
-- Invidious + Companion → http://127.0.0.1:3000 / http://127.0.0.1:8282 (`make -C pmoves up-invidious`; provides YouTube fallback for pmoves.yt).
-- Open Notebook UI → http://localhost:8503 (`docker start cataclysm-open-notebook` or `make -C pmoves notebook-up`; keep password/token aligned).
-- n8n Automation → http://localhost:5678 (`make -C pmoves up-n8n`; flows sync from `pmoves/integrations`).
-
-## Commit & Pull Request Guidelines
-- Prefer Conventional Commits (e.g., `feat(hi-rag): hybrid search option`).
-- PRs should include: clear description, linked issues, affected services, run/rollback notes, and screenshots for UI/flows (e.g., retrieval-eval dashboard).
-- When opening a PR, start from `STARTER_PR_BODY.md` (repo root) and adjust sections as needed.
-- Keep changes atomic; update docs/schemas when interfaces change.
-
-## Security & Configuration Tips
-- Copy `env.shared.example` → `env.shared`; never commit secrets. Keep shared defaults in `env.shared` and machine-specific overrides in `.env.local`. Key envs: `PMOVES_CONTRACTS_DIR` for schema resolution.
-- Branded Open Notebook deployments reuse the UI password as the API bearer token; keep `OPEN_NOTEBOOK_API_TOKEN` aligned with `OPEN_NOTEBOOK_PASSWORD` so ingestion helpers and agents authenticate successfully.
-- When working with Open Notebook, populate `OPEN_NOTEBOOK_SURREAL_URL` / `OPEN_NOTEBOOK_SURREAL_ADDRESS` (or the legacy `SURREAL_*` aliases) so the Streamlit UI can reach SurrealDB inside Compose.
-- To keep embeddings local, launch your provider (e.g., `ollama`) and set `OLLAMA_API_BASE` before running `make notebook-seed-models`; the seeder will add `ollama`-backed models so Notebook never calls external APIs unless you want it to.
-- Use Compose profiles (`data`, `workers`) to scope what runs locally.
-- Validate payloads against schemas before publishing events (`services/common/events.py`).
-
-
-## Environment Bootstrap (Codex + Local)
-
-- Preferred Python: Conda 3.11+ (env name: `PMOVES.AI` or `pmoves-ai`). A ready-to-use `environment.yml` is at the repo root.
-- One‑time setup on Windows (PowerShell 7+):
-  - Install GNU Make (Chocolatey): `choco install make -y` (requires admin PowerShell).
-  - Create/refresh Conda env: `conda env create -f environment.yml -n PMOVES.AI` (or use the default name inside the file).
-  - Install service deps: `pwsh -File scripts/install_all_requirements.ps1 -CondaEnvName PMOVES.AI`.
-- Linux/macOS:
-  - `conda env create -f environment.yml -n pmoves-ai`
-  - `bash scripts/install_all_requirements.sh pmoves-ai`
-
-### Codex VM / Profiles
-
-- For maximum autonomy, use a Codex profile with:
-  - `approval_policy = "never"` (auto-approve),
-  - `sandbox_mode = "danger-full-access"`,
-  - `network_access = true`.
-- When opening this repo, run the bootstrap:
-  - Windows: `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/codex_bootstrap.ps1 -CondaEnvName PMOVES.AI`
-  - Linux/macOS: `bash scripts/codex_bootstrap.sh PMOVES.AI`
-- See `docs/codex_full_config_bundle/README-Codex-MCP-Full.md` for a complete `config.toml` with sensible profiles.
-
-### Notes
-
-- The bootstrap prefers `uv pip` if available (faster); otherwise falls back to `python -m pip`.
-- The scripts install requirements from `services/*/requirements.txt` and `tools/*/requirements.txt`. Pass `-IncludeDocs` (PowerShell) or `INCLUDE_DOCS=1` (Bash) to include `docs/**/requirements.txt`.
-
-
-<!-- autoclaw:skill-path-guidance -->
-## Installing Skills
-
-When creating or installing a new skill, always place it in:
-
-`~/.openclaw-autoclaw/skills/<skill-name>/SKILL.md`
-
-This is the managed skills directory. The agent will automatically discover
-any skill placed here — no extra configuration needed. Do NOT install skills
-into `~/.agents/skills/` (that directory is shared with other tools).
-<!-- /autoclaw:skill-path-guidance -->
-
-
-<!-- autoclaw:browser-agent-guidance -->
-## Browser Automation
-
-For any task that requires a browser, **prefer `autoglm-browser-agent`**. Use it as the first choice.
-
-- ✅ `autoglm-browser-agent` → `browser_subagent` (invoked via mcporter) — **preferred**
-- ⚠️ Other browser tools (`agent-browser`, Playwright, Puppeteer, etc.) — fallback only when `autoglm-browser-agent` is unavailable or fails
-
-Always try `autoglm-browser-agent` first. Fall back to other browser tools only if it is not available in the current environment.
-<!-- /autoclaw:browser-agent-guidance -->
-
-<!-- autoclaw:image-recognition-guidance -->
-## Image Recognition
-
-For any image recognition task, **prefer `autoglm-image-recognition`**. Use it as the first choice.
-
-- ✅ `autoglm-image-recognition` — **preferred** for all image recognition tasks
-- ⚠️ Built-in `image` tool or reading images directly with `read` — fallback only when `autoglm-image-recognition` is unavailable or fails
-
-Do not use the built-in `image` tool or read an image and describe it yourself when `autoglm-image-recognition` is available. Always try `autoglm-image-recognition` first.
-<!-- /autoclaw:image-recognition-guidance -->
+## Security
+- CHIT (Cryptographic Handshake for Identity & Trust): `pmoves/docs/security/`
+- Hardening tracker: `docs/hardening/PMOVES-hardening-tracker.md`
+- Trivy scans gate on HIGH/CRITICAL in CI
+- CodeQL for code scanning regressions


### PR DESCRIPTION
## Summary

Rewrites the root `AGENTS.md` (296 → 109 lines) to reflect the current project state.

## Changes

- **Removed stale references:** `services/` directory structure (now submodules), sprint M2 focus, `services/common/` helper dir, `STARTER_PR_BODY.md`, autoclaw/browser/image-recognition injection blocks
- **Fixed broken doc paths:** `docs/MAKE_TARGETS.md` and `docs/README_DOCS_INDEX.md` now correctly point to `pmoves/docs/`
- **Fixed make commands:** Replaced bare `make up`/`make down`/`make clean` with correct `make -C pmoves <target>` format
- **Added canonical documentation table:** Points to `pmoves/docs/AGENTS/` as the agent docs hub with key files (taxonomy, topology, registry, personas)
- **Reflected current architecture:** Submodule monorepo structure, sidecar deployment, compose deployment
- **Removed BoTZ-era references:** BoTZ Gateway integration, Codex parity as release concern, BoTZ JWT fail-open

## What was removed

All operational details that belong in `pmoves/docs/operations/` (bring-up sequences, service ports, health badges, monitoring, UI quickstart, MCP wiring, agent UIs, smoketest commands, etc.) — those live in their canonical locations now.

## Verification

All doc paths referenced in the new file were verified to exist in the repo.