### PR TITLE
feat(conch): build CGP tools and update execution guide

### DIFF
--- a/pmoves/docs/PMOVESCHIT/PMOVES-CONCHexecution_guide.md
+++ b/pmoves/docs/PMOVESCHIT/PMOVES-CONCHexecution_guide.md
@@ -3,9 +3,11 @@
 > Execution guide for the Consciousness Harvest (CONCH) pipeline. Builds on CHIT encoding to transform consciousness research datasets into grounded personas via CGP packets. Prerequisites: Layer 1 protocol docs.
 
 # PMOVES Consciousness Integration • Execution Guide
-_Last updated: 2025-12-09_
+_Last updated: 2026-04-19_
 
 This guide operationalizes the consciousness knowledge harvest and its transformation into grounded personas via the PMOVES stack (Supabase, Geometry Bus, CHIT playback, Hi-RAG v2, Evo Swarm).
+> **Note:** The "325" in this pipeline refers to 325 consciousness **theories** from Robert Lawrence Kuhn's *Landscape of Consciousness* (Closer to Truth), **not** personas. The pipeline transforms theories → CGP → grounded personas.
+
 
 ---
 
@@ -44,13 +46,16 @@ Persona Grounding (consciousness shapes → combinations → LLM selection)
 | Component | Status | Notes |
 |-----------|--------|-------|
 | Directory structure | ✅ Created | 10 theory categories |
-| Research papers | ✅ 3 files | ~2MB HTML content |
-| RAG schema | ✅ SQL exists | consciousness-schema.sql |
-| Theory content | ❌ Empty | Needs harvest scripts |
+| Research papers | ✅ 3 files + taxonomy | kuhn_full_taxonomy.json (325 theories) |
+| RAG schema | ✅ SQL exists | consciousness-schema.sql + grounded personas SQL |
+| Theory content | ✅ Populated | 216 chunks from taxonomy + papers |
 | Website mirror | ❌ Empty | Needs Selenium scraper |
-| Embeddings JSONL | ⚠️ Minimal | Only 3 chunks |
-| CGP mapper | ❌ Missing | Needs implementation |
-| Persona eval gates | ❌ Not wired | Schema only |
+| Embeddings JSONL | ✅ 216 chunks | consciousness-chunks.jsonl |
+| CGP payload | ✅ Generated | geometry_payload.json — 10 super-nodes |
+| CGP mapper | ✅ Built | chit_backend.py (sentence-transformers + KMeans) |
+| CGP decoder | ✅ Built | chit_decoder.py (exact + geometry modes) |
+| Persona eval gates | ⚠️ SQL only | Schema exists in v5_12_grounded_personas.sql, not wired |
+| Video ingestion | ❌ Broken | PMOVES.YT submodule empty — P0 blocker |
 
 ---
 
@@ -58,13 +63,14 @@ Persona Grounding (consciousness shapes → combinations → LLM selection)
 
 ```bash
 # Core infrastructure
-make env-setup
 make supa-start
-make up
-make up-agents
+make overlay-up-core
+
+# Or start tiers individually
+make up-data-tier up-bus up-agents
 
 # Verify services are healthy
-make verify-all
+make overlay-up-core
 ```
 
 **Optional services:**
@@ -277,7 +283,8 @@ make ingest-consciousness-yt ARGS="--max 5"
    - `ingest.file.added.v1`
    - `ingest.transcript.ready.v1`
 
----
+> ⚠️ **PMOVES.YT submodule is broken** — the submodule directory is empty (22-line exec shim pointing to an uninitialized submodule). Video ingestion is **non-functional** until the submodule is re-initialized with actual content. This is a P0 blocker for Phase 3.
+
 
 ## Phase 4: CGP Generation & Geometry Publication (1-2 hours)
 
@@ -520,9 +527,8 @@ python pmoves/tools/chit_decoder.py \
 ```bash
 python pmoves/tools/chit_decoder.py \
   --cgp pmoves/data/consciousness/geometry_payload.json \
-  --corpus pmoves/data/consciousness/.../consciousness-chunks.jsonl \
   --mode geometry \
-  --compute-metrics
+  --corpus pmoves/data/consciousness/Constellation-Harvest-Regularization/processed-for-rag/embeddings-ready/consciousness-chunks.jsonl \
 ```
 
 **Expected metrics:**
@@ -530,14 +536,10 @@ python pmoves/tools/chit_decoder.py \
 - Coverage > 0.8
 - Per-constellation fidelity reports
 
-### 7.3 Test Multimodal Decode (if video content)
+### 7.3 Multimodal Decode (future work)
 
-```bash
-python pmoves/tools/chit_decoder_mm.py \
-  --cgp pmoves/data/consciousness/geometry_payload.json \
-  --image-corpus ./images/ \
-  --mode clip
-```
+> `chit_decoder_mm.py` is not yet built. Planned for CLIP-based image+geometry decoding when video/image corpus is available.
+
 
 ---
 
@@ -615,7 +617,7 @@ docker logs hi-rag-gateway-v2 2>&1 | grep -i shape
 
 | Task | Command |
 |------|---------|
-| Stack status | `make verify-all` |
+| Stack status | `make overlay-up-core` |
 | Harvest consciousness | `make -C pmoves harvest-consciousness` |
 | Apply schema | `make supa-migrate` |
 | Publish geometry | `make mesh-handshake FILE=...` |
@@ -632,12 +634,16 @@ docker logs hi-rag-gateway-v2 2>&1 | grep -i shape
 
 ## Missing Components (TODO)
 
-1. **CGP Auto-Mapper**: Transform consciousness_theories → CGP packets automatically
+~~1. **CGP Auto-Mapper**~~ → ✅ **DONE** — `pmoves/tools/chit_backend.py`
 2. **Retrieval-Eval Dataset**: 50-100 labeled queries for persona gates
 3. **Persona Publish Gate Service**: Async evaluator for metric thresholds
 4. **Geometry Service Endpoints**: `/v0/geometry/*` REST API
 5. **Consciousness Metadata Schema**: Extended fields (author, epistemology, relations)
+6. `chit_decoder_mm.py` — Multimodal CGP decoder (future work)
+7. **Fix PMOVES.YT submodule** — P0 blocker for video ingestion (Phase 3)
 
 ---
+
+> **Clarification:** The "325" in this pipeline refers to 325 consciousness **theories** from Robert Lawrence Kuhn's *Landscape of Consciousness* (Closer to Truth), **not** personas. The pipeline transforms theories → CGP → grounded personas.
 
 Keep this guide updated as ingestion scripts, CGP mappers, or automation targets evolve.

--- a/pmoves/tools/chit_backend.py
+++ b/pmoves/tools/chit_backend.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""CHIT CGP Auto-Mapper — transforms consciousness-chunks JSONL into a CGP geometry packet.
+
+Reads a consciousness-chunks.jsonl file, embeds chunk content with sentence-transformers,
+clusters embeddings per category into constellations via KMeans, and emits a validated
+CGP v1 JSON packet matching cgp.v1.schema.json.
+
+Usage:
+    python pmoves/tools/chit_backend.py \
+        --input consciousness-chunks.jsonl \
+        --output geometry_payload.json \
+        --K 3 --bins 8 --backend all-MiniLM-L6-v2
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+from jsonschema import Draft202012Validator, validate as jsonschema_validate
+from sentence_transformers import SentenceTransformer
+from sklearn.cluster import KMeans
+
+
+def eprint(*args, **kwargs):
+    """Print to stderr."""
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def load_chunks(path: Path) -> list[dict]:
+    """Load JSONL file, returning list of parsed dicts."""
+    chunks: list[dict] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                chunks.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                eprint(f"WARN: skipping malformed line {line_num}: {exc}")
+    return chunks
+
+
+def group_by_category(chunks: list[dict]) -> dict[str, list[dict]]:
+    """Group chunks by their 'category' field."""
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for chunk in chunks:
+        cat = chunk.get("category", "unknown")
+        groups[cat].append(chunk)
+    return dict(groups)
+
+
+def encode_chunks(model: SentenceTransformer, chunks: list[dict]) -> np.ndarray:
+    """Encode chunk content fields to embedding vectors."""
+    texts = [c.get("content", "") for c in chunks]
+    eprint(f"  Encoding {len(texts)} chunks...")
+    embeddings = model.encode(texts, show_progress_bar=False, normalize_embeddings=True)
+    return np.asarray(embeddings, dtype=np.float64)
+
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    """Cosine similarity between two vectors (assumed pre-normalized or not)."""
+    dot = np.dot(a, b)
+    norm_a = np.linalg.norm(a)
+    norm_b = np.linalg.norm(b)
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return float(dot / (norm_a * norm_b))
+
+
+def compute_spectrum(projs: list[float], bins: int) -> list[float]:
+    """Normalized histogram of projection values."""
+    if not projs:
+        return [0.0] * bins
+    arr = np.array(projs)
+    counts, _ = np.histogram(arr, bins=bins, range=(0.0, 1.0))
+    total = counts.sum()
+    if total == 0:
+        return [0.0] * bins
+    return (counts / total).tolist()
+
+
+def compute_mhep(projs: list[float]) -> float:
+    """Mean Harmonic Embedding Perplexity: avg of 1/sum(softmax(projs)) per constellation.
+
+    For a single constellation, MHEP = 1 / sum(softmax(projs)).
+    Returns 0.0 if no projections.
+    """
+    if not projs:
+        return 0.0
+    arr = np.array(projs, dtype=np.float64)
+    # softmax with temperature=1
+    shifted = arr - arr.max()
+    exp_vals = np.exp(shifted)
+    softmax_sum = exp_vals.sum()
+    if softmax_sum == 0.0:
+        return 0.0
+    return float(1.0 / softmax_sum)
+
+
+def build_cgp(
+    category_groups: dict[str, list[dict]],
+    embeddings_per_cat: dict[str, np.ndarray],
+    k: int,
+    bins: int,
+) -> dict:
+    """Build the full CGP packet from grouped chunks and their embeddings."""
+    categories = sorted(category_groups.keys())
+    num_cats = len(categories)
+    if num_cats == 0:
+        return {"spec": "chit.cgp.v0.1", "super_nodes": []}
+
+    radius = 1.0
+    now = datetime.now(timezone.utc).isoformat()
+
+    all_constellations: list[dict] = []
+    all_points: list[dict] = []
+    super_nodes: list[dict] = []
+
+    for i, cat in enumerate(categories):
+        chunks = category_groups[cat]
+        embs = embeddings_per_cat[cat]
+        n = len(chunks)
+
+        # Super-node position on circle
+        angle = 2.0 * math.pi * i / num_cats
+        sx = round(radius * math.cos(angle), 6)
+        sy = round(radius * math.sin(angle), 6)
+
+        # Determine actual K (reduce if fewer chunks than K)
+        actual_k = min(k, n)
+        if actual_k < 1:
+            actual_k = 1
+
+        eprint(f"  Category '{cat}': {n} chunks, K={actual_k}")
+
+        # Cluster embeddings
+        if n <= 1:
+            # Single chunk — one cluster, centroid is the embedding itself
+            labels = np.array([0])
+            centroids = embs.reshape(1, -1) if n == 1 else np.zeros((1, embs.shape[1]))
+        else:
+            km = KMeans(n_clusters=actual_k, random_state=42, n_init=10)
+            labels = km.fit_predict(embs)
+            centroids = km.cluster_centers_
+
+        cat_constellations: list[dict] = []
+        cat_points: list[dict] = []
+
+        for c_idx in range(actual_k):
+            # Find chunks in this cluster
+            mask = labels == c_idx
+            cluster_indices = np.where(mask)[0]
+            cluster_embs = embs[mask]
+            cluster_chunks = [chunks[j] for j in cluster_indices]
+
+            if len(cluster_chunks) == 0:
+                continue
+
+            # Centroid normalized
+            centroid = centroids[c_idx]
+            norm = np.linalg.norm(centroid)
+            if norm > 0:
+                centroid_normed = centroid / norm
+            else:
+                centroid_normed = centroid
+
+            # Anchor: [x, y] from first 2 dims of normalized centroid
+            anchor_x = float(centroid_normed[0])
+            anchor_y = float(centroid_normed[1]) if centroid_normed.shape[0] > 1 else 0.0
+
+            constellation_id = f"{cat}-c{c_idx}"
+
+            points: list[dict] = []
+            projs: list[float] = []
+
+            for p_idx, (chunk, emb) in enumerate(zip(cluster_chunks, cluster_embs)):
+                chunk_id = chunk.get("id", f"{constellation_id}-p{p_idx}")
+                content = chunk.get("content", "")
+                proj_val = cosine_similarity(emb, centroid_normed)
+                projs.append(proj_val)
+
+                # Relative 2D position: first 2 dims of (embedding - centroid)
+                diff = emb - centroid_normed
+                px = float(diff[0]) if diff.shape[0] > 0 else 0.0
+                py = float(diff[1]) if diff.shape[0] > 1 else 0.0
+
+                point = {
+                    "id": chunk_id,
+                    "ref_id": chunk_id,
+                    "modality": "text",
+                    "text": content[:512],
+                    "proj": round(proj_val, 6),
+                    "conf": round(proj_val, 6),
+                    "x": round(px, 6),
+                    "y": round(py, 6),
+                    "char_len": len(content),
+                    "word_count": len(content.split()),
+                    "summary": chunk.get("title", ""),
+                    "meta": {
+                        "category": cat,
+                        "namespace": chunk.get("namespace", "pmoves.consciousness"),
+                    },
+                }
+                # Only include source_ref if url is present (schema requires string, not null)
+                if chunk.get("url"):
+                    point["source_ref"] = chunk["url"]
+                # Optional ts from chunk
+                if chunk.get("created_at"):
+                    point["ts"] = chunk["created_at"]
+
+                points.append(point)
+
+            # Spectrum
+            spectrum = compute_spectrum(projs, bins)
+
+            # Radial minmax from projection values
+            if projs:
+                radial_minmax = [round(min(projs), 6), round(max(projs), 6)]
+            else:
+                radial_minmax = [0.0, 0.0]
+
+            constellation = {
+                "id": constellation_id,
+                "points": points,
+                "anchor": [anchor_x, anchor_y],
+                "spectrum": spectrum,
+                "radial_minmax": radial_minmax,
+            }
+
+            cat_constellations.append(constellation)
+            cat_points.extend(points)
+
+        super_node = {
+            "id": f"super-{cat}",
+            "label": cat,
+            "x": sx,
+            "y": sy,
+            "r": radius,
+            "constellations": cat_constellations,
+        }
+        super_nodes.append(super_node)
+        all_constellations.extend(cat_constellations)
+        all_points.extend(cat_points)
+
+    # Compute top-level MHEP across all constellations
+    mhep_values = []
+    for con in all_constellations:
+        con_projs = [p.get("proj", 0.0) for p in con.get("points", [])]
+        mhep_values.append(compute_mhep(con_projs))
+    avg_mhep = float(np.mean(mhep_values)) if mhep_values else 0.0
+
+    cgp = {
+        "spec": "chit.cgp.v0.1",
+        "created_at": now,
+        "updated_at": now,
+        "summary": f"CGP auto-mapped from {sum(len(v) for v in category_groups.values())} chunks "
+                   f"across {num_cats} categories, {len(all_constellations)} constellations",
+        "meta": {
+            "mhep": round(avg_mhep, 6),
+            "total_chunks": sum(len(v) for v in category_groups.values()),
+            "categories": categories,
+            "K": k,
+            "bins": bins,
+        },
+        "super_nodes": super_nodes,
+        "constellations": all_constellations,
+        "points": all_points,
+    }
+
+    return cgp
+
+
+def load_schema() -> dict:
+    """Load CGP v1 schema from contracts directory."""
+    schema_path = (
+        Path(__file__).resolve().parents[1]
+        / "contracts"
+        / "schemas"
+        / "geometry"
+        / "cgp.v1.schema.json"
+    )
+    if not schema_path.exists():
+        eprint(f"WARN: schema not found at {schema_path} — skipping validation")
+        return {}
+    with open(schema_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_cgp(cgp: dict, schema: dict) -> bool:
+    """Validate CGP packet against schema. Returns True if valid."""
+    if not schema:
+        eprint("WARN: no schema loaded, skipping validation")
+        return True
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(cgp), key=lambda e: list(e.path))
+    if not errors:
+        eprint("  Schema validation: PASSED")
+        return True
+    eprint(f"  Schema validation: FAILED ({len(errors)} error(s))")
+    for err in errors:
+        path = ".".join(str(p) for p in err.absolute_path) or "(root)"
+        eprint(f"    {path}: {err.message}")
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CHIT CGP Auto-Mapper: consciousness-chunks JSONL → CGP geometry packet",
+    )
+    parser.add_argument("--input", required=True, help="Path to consciousness-chunks.jsonl")
+    parser.add_argument("--output", required=True, help="Path to output CGP JSON file")
+    parser.add_argument("--K", type=int, default=3, help="Constellations per super-node (default: 3)")
+    parser.add_argument("--bins", type=int, default=8, help="Spectrum resolution bins (default: 8)")
+    parser.add_argument(
+        "--backend",
+        default="all-MiniLM-L6-v2",
+        help="Sentence-transformers model name (default: all-MiniLM-L6-v2)",
+    )
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        default=False,
+        help="Disable schema validation (default: validate)",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    if not input_path.exists():
+        eprint(f"ERROR: input file not found: {input_path}")
+        sys.exit(1)
+
+    # 1. Load chunks
+    eprint(f"Loading chunks from {input_path}...")
+    chunks = load_chunks(input_path)
+    if not chunks:
+        eprint("ERROR: no valid chunks found in input file")
+        sys.exit(1)
+    eprint(f"  Loaded {len(chunks)} chunks")
+
+    # 2. Group by category
+    category_groups = group_by_category(chunks)
+    eprint(f"  Found {len(category_groups)} categories: {', '.join(sorted(category_groups.keys()))}")
+
+    # 3. Load model
+    eprint(f"Loading model '{args.backend}'...")
+    model = SentenceTransformer(args.backend)
+    eprint(f"  Model loaded, embedding dim: {model.get_embedding_dimension()}")
+
+    # 4. Encode all chunks per category
+    eprint("Encoding chunks per category...")
+    embeddings_per_cat: dict[str, np.ndarray] = {}
+    for cat in sorted(category_groups.keys()):
+        cat_chunks = category_groups[cat]
+        embeddings_per_cat[cat] = encode_chunks(model, cat_chunks)
+
+    # 5. Build CGP
+    eprint("Building CGP packet...")
+    cgp = build_cgp(category_groups, embeddings_per_cat, args.K, args.bins)
+
+    sn_count = len(cgp["super_nodes"])
+    con_count = len(cgp.get("constellations", []))
+    pt_count = len(cgp.get("points", []))
+    eprint(f"  Built: {sn_count} super-nodes, {con_count} constellations, {pt_count} points")
+
+    # 6. Validate
+    if not args.no_validate:
+        eprint("Validating against schema...")
+        schema = load_schema()
+        if not validate_cgp(cgp, schema):
+            eprint("ERROR: schema validation failed")
+            sys.exit(1)
+    else:
+        eprint("Schema validation disabled (--no-validate)")
+
+    # 7. Write output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(cgp, f, indent=2, ensure_ascii=False)
+    eprint(f"Written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pmoves/tools/chit_decoder.py
+++ b/pmoves/tools/chit_decoder.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""CGP Decoder CLI — playback verification for CHIT Cognitive Geometry Packets.
+
+Decodes a CGP JSON payload back to structured chunk references (exact mode)
+or reconstructs text from geometric encoding using a corpus JSONL (geometry mode).
+
+Usage:
+    python pmoves/tools/chit_decoder.py --cgp geometry_payload.json --mode exact
+    python pmoves/tools/chit_decoder.py --cgp geometry_payload.json --mode geometry --corpus chunks.jsonl --compute-metrics
+    python pmoves/tools/chit_decoder.py --cgp geometry_payload.json --compute-metrics --output report.json
+
+Standalone tool — no PMOVES-internal imports.
+"""
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from difflib import SequenceMatcher
+from pathlib import Path
+
+import numpy as np
+
+
+def load_cgp(path: str) -> dict:
+    """Load and validate CGP JSON."""
+    p = Path(path)
+    if not p.exists():
+        print(f"ERROR: CGP file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(p, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        print("ERROR: CGP root must be a JSON object", file=sys.stderr)
+        sys.exit(1)
+    if "super_nodes" not in data:
+        print("WARNING: CGP has no 'super_nodes' field", file=sys.stderr)
+    return data
+
+
+def load_corpus(path: str) -> dict:
+    """Load corpus JSONL into a dict keyed by 'id'."""
+    p = Path(path)
+    if not p.exists():
+        print(f"ERROR: Corpus file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    corpus = {}
+    with open(p, "r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as e:
+                print(f"WARNING: Skipping malformed JSONL line {line_num}: {e}", file=sys.stderr)
+                continue
+            rid = record.get("id")
+            if rid is not None:
+                corpus[rid] = record
+    print(f"Loaded {len(corpus)} corpus chunks from {path}", file=sys.stderr)
+    return corpus
+
+
+def kl_divergence_spectrum(spectrum: list, bins: int) -> float:
+    """Compute KL(p || uniform) for a constellation spectrum.
+
+    KL(p || u) = sum(p_i * log(p_i / u_i)) where u_i = 1/bins.
+    Small epsilon added to avoid log(0).
+    """
+    eps = 1e-10
+    p = np.array(spectrum, dtype=np.float64) + eps
+    p = p / p.sum()
+    u = np.full_like(p, 1.0 / bins)
+    return float(np.sum(p * np.log(p / u)))
+
+
+def decode_exact(cgp: dict) -> dict:
+    """Decode CGP in exact mode — structure only, no corpus needed."""
+    super_nodes_out = []
+    for sn in cgp.get("super_nodes", []):
+        constellations_out = []
+        for constellation in sn.get("constellations", []):
+            points = constellation.get("points", [])
+            projections = [pt.get("proj", 0.0) for pt in points]
+            point_ids = [pt.get("id") or pt.get("ref_id", "") for pt in points]
+            mean_proj = round(float(statistics.mean(projections)), 4) if projections else None
+            std_proj = round(float(statistics.stdev(projections)), 4) if len(projections) > 1 else 0.0
+            constellations_out.append({
+                "id": constellation.get("id", ""),
+                "point_count": len(points),
+                "points": point_ids,
+                "mean_proj": mean_proj,
+                "std_proj": std_proj,
+            })
+        super_nodes_out.append({
+            "id": sn.get("id", ""),
+            "label": sn.get("label", ""),
+            "constellation_count": len(constellations_out),
+            "constellations": constellations_out,
+        })
+    return {"super_nodes": super_nodes_out}
+
+
+def decode_geometry(cgp: dict, corpus: dict) -> tuple:
+    """Decode CGP in geometry mode — resolve point text against corpus.
+
+    Returns:
+        decode dict (same shape as exact) and a list of orphaned point refs.
+    """
+    orphaned = []
+    super_nodes_out = []
+    for sn in cgp.get("super_nodes", []):
+        constellations_out = []
+        for constellation in sn.get("constellations", []):
+            points = constellation.get("points", [])
+            projections = []
+            point_ids = []
+            for pt in points:
+                ref_id = pt.get("ref_id") or pt.get("id", "")
+                point_ids.append(ref_id)
+                projections.append(pt.get("proj", 0.0))
+                if ref_id not in corpus:
+                    orphaned.append({
+                        "point_id": ref_id,
+                        "constellation_id": constellation.get("id", "")
+                    })
+            mean_proj = round(float(statistics.mean(projections)), 4) if projections else None
+            std_proj = round(float(statistics.stdev(projections)), 4) if len(projections) > 1 else 0.0
+            constellations_out.append({
+                "id": constellation.get("id", ""),
+                "point_count": len(points),
+                "points": point_ids,
+                "mean_proj": mean_proj,
+                "std_proj": std_proj,
+            })
+        super_nodes_out.append({
+            "id": sn.get("id", ""),
+            "label": sn.get("label", ""),
+            "constellation_count": len(constellations_out),
+            "constellations": constellations_out,
+        })
+    return {"super_nodes": super_nodes_out}, orphaned
+
+
+def compute_metrics(cgp: dict, mode: str, corpus: dict = None) -> dict:
+    """Compute fidelity metrics: KL divergence, coverage, per-constellation fidelity."""
+    meta = cgp.get("meta", {})
+    bins = meta.get("bins", 8)
+
+    # Gather all constellations from flat list, fall back to nested
+    all_constellations = cgp.get("constellations", [])
+    if not all_constellations:
+        for sn in cgp.get("super_nodes", []):
+            all_constellations.extend(sn.get("constellations", []))
+
+    # KL divergence
+    kl_values = []
+    for constellation in all_constellations:
+        spectrum = constellation.get("spectrum", [])
+        if spectrum:
+            kl_values.append(kl_divergence_spectrum(spectrum, bins))
+    kl_mean = round(float(np.mean(kl_values)), 4) if kl_values else None
+    kl_max = round(float(np.max(kl_values)), 4) if kl_values else None
+
+    # Coverage
+    coverage = None
+    if corpus is not None:
+        cgp_ref_ids = set()
+        for sn in cgp.get("super_nodes", []):
+            for constellation in sn.get("constellations", []):
+                for pt in constellation.get("points", []):
+                    rid = pt.get("ref_id") or pt.get("id", "")
+                    if rid:
+                        cgp_ref_ids.add(rid)
+        for pt in cgp.get("points", []):
+            rid = pt.get("ref_id") or pt.get("id", "")
+            if rid:
+                cgp_ref_ids.add(rid)
+        total_corpus = len(corpus)
+        matched = sum(1 for rid in cgp_ref_ids if rid in corpus)
+        coverage = round(matched / total_corpus, 4) if total_corpus > 0 else 0.0
+        print(f"Coverage: {matched}/{total_corpus} = {coverage}", file=sys.stderr)
+
+    # Per-constellation fidelity
+    fidelity_list = []
+    for constellation in all_constellations:
+        points = constellation.get("points", [])
+        projections = [pt.get("proj", 0.0) for pt in points]
+        orphaned_count = 0
+        text_similarities = []
+        for pt in points:
+            ref_id = pt.get("ref_id") or pt.get("id", "")
+            if corpus is not None and ref_id not in corpus:
+                orphaned_count += 1
+            if mode == "geometry" and corpus is not None and ref_id in corpus:
+                point_text = pt.get("text", "") or ""
+                corpus_content = corpus[ref_id].get("content", "") or ""
+                if point_text and corpus_content:
+                    ratio = SequenceMatcher(None, point_text, corpus_content).ratio()
+                    text_similarities.append(ratio)
+        mean_sim = round(float(statistics.mean(text_similarities)), 4) if text_similarities else None
+        mean_proj = round(float(statistics.mean(projections)), 4) if projections else None
+        std_proj = round(float(statistics.stdev(projections)), 4) if len(projections) > 1 else 0.0
+        fidelity_list.append({
+            "id": constellation.get("id", ""),
+            "mean_proj": mean_proj,
+            "std_proj": std_proj,
+            "point_count": len(points),
+            "orphaned_count": orphaned_count,
+            "text_similarity": mean_sim,
+        })
+
+    return {
+        "kl_divergence": {"mean": kl_mean, "max": kl_max},
+        "coverage": coverage,
+        "constellation_fidelity": fidelity_list,
+    }
+
+
+def count_points(cgp: dict) -> int:
+    """Count total points across all super_nodes/constellations."""
+    total = 0
+    for sn in cgp.get("super_nodes", []):
+        for constellation in sn.get("constellations", []):
+            total += len(constellation.get("points", []))
+    return total
+
+
+def count_constellations(cgp: dict) -> int:
+    """Count total constellations across all super_nodes."""
+    total = 0
+    for sn in cgp.get("super_nodes", []):
+        total += len(sn.get("constellations", []))
+    return total
+
+
+def format_human(report: dict) -> str:
+    """Format report as human-readable text."""
+    lines = []
+    lines.append("CGP Decoder Report")
+    lines.append("=" * 60)
+    lines.append(f"Mode:           {report['mode']}")
+    lines.append(f"CGP Spec:       {report.get('cgp_spec', 'N/A')}")
+    lines.append(f"Summary:        {report.get('cgp_summary', 'N/A')}")
+    lines.append(f"Super Nodes:    {report.get('super_node_count', 0)}")
+    lines.append(f"Constellations: {report.get('constellation_count', 0)}")
+    lines.append(f"Points:         {report.get('point_count', 0)}")
+    lines.append("")
+    decode = report.get("decode", {})
+    for sn in decode.get("super_nodes", []):
+        lines.append(f"\n[{sn['label']}] (id={sn['id']})")
+        lines.append(f"  Constellations: {sn['constellation_count']}")
+        for const in sn.get("constellations", []):
+            lines.append(f"  \u2514 {const['id']}: {const['point_count']} pts, "
+                         f"mean_proj={const['mean_proj']}, std_proj={const['std_proj']}")
+            if const["points"]:
+                for pid in const["points"]:
+                    lines.append(f"      - {pid}")
+    metrics = report.get("metrics")
+    if metrics:
+        lines.append(f"\n{'=' * 60}")
+        lines.append("METRICS")
+        lines.append("=" * 60)
+        kl = metrics.get("kl_divergence", {})
+        lines.append(f"KL Divergence:  mean={kl.get('mean', 'N/A')}, max={kl.get('max', 'N/A')}")
+        lines.append(f"Coverage:       {metrics.get('coverage', 'N/A')}")
+        lines.append("")
+        lines.append("Per-constellation fidelity:")
+        for fid in metrics.get("constellation_fidelity", []):
+            sim_str = str(fid["text_similarity"]) if fid["text_similarity"] is not None else "N/A"
+            lines.append(f"  {fid['id']}: proj={fid['mean_proj']}±{fid['std_proj']}, "
+                         f"pts={fid['point_count']}, orphaned={fid['orphaned_count']}, "
+                         f"sim={sim_str}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CGP Decoder — playback verification for CHIT Cognitive Geometry Packets",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Examples:\n"
+                "  %(prog)s --cgp geometry_payload.json --mode exact\n"
+                "  %(prog)s --cgp geometry_payload.json --mode geometry --corpus chunks.jsonl --compute-metrics\n"
+                "  %(prog)s --cgp geometry_payload.json --compute-metrics --output report.json\n",
+    )
+    parser.add_argument("--cgp", required=True, help="Path to CGP JSON file")
+    parser.add_argument("--corpus", default=None, help="Path to corpus JSONL file (required for geometry mode)")
+    parser.add_argument("--mode", choices=["exact", "geometry"], default="exact",
+                        help="Decode mode (default: exact)")
+    parser.add_argument("--compute-metrics", action="store_true",
+                        help="Compute fidelity metrics")
+    parser.add_argument("--output", default=None,
+                        help="Path to output JSON report file (prints to stdout if not set)")
+    args = parser.parse_args()
+
+    # Load CGP
+    print(f"Loading CGP from {args.cgp}...", file=sys.stderr)
+    cgp = load_cgp(args.cgp)
+    print(f"CGP spec: {cgp.get('spec', 'N/A')}", file=sys.stderr)
+    sn_count = len(cgp.get("super_nodes", []))
+    const_count = count_constellations(cgp)
+    pt_count = count_points(cgp)
+    print(f"Super nodes: {sn_count}, Constellations: {const_count}, Points: {pt_count}", file=sys.stderr)
+    if pt_count == 0:
+        print("WARNING: CGP contains zero points", file=sys.stderr)
+
+    # Validate geometry mode requirements
+    corpus = None
+    if args.mode == "geometry":
+        if not args.corpus:
+            print("ERROR: --corpus is required for geometry mode", file=sys.stderr)
+            sys.exit(1)
+        corpus = load_corpus(args.corpus)
+
+    # Decode
+    print(f"Decoding in {args.mode} mode...", file=sys.stderr)
+    if args.mode == "exact":
+        decode = decode_exact(cgp)
+    else:
+        decode, orphaned = decode_geometry(cgp, corpus)
+        if orphaned:
+            print(f"WARNING: {len(orphaned)} orphaned points (ref_id not in corpus)", file=sys.stderr)
+            for o in orphaned[:10]:
+                print(f"  orphaned: {o['point_id']} (in {o['constellation_id']})", file=sys.stderr)
+            if len(orphaned) > 10:
+                print(f"  ... and {len(orphaned) - 10} more", file=sys.stderr)
+
+    # Build report
+    report = {
+        "mode": args.mode,
+        "cgp_spec": cgp.get("spec", ""),
+        "cgp_summary": cgp.get("summary", ""),
+        "super_node_count": sn_count,
+        "constellation_count": const_count,
+        "point_count": pt_count,
+        "decode": decode,
+    }
+
+    # Metrics
+    if args.compute_metrics:
+        print("Computing metrics...", file=sys.stderr)
+        report["metrics"] = compute_metrics(cgp, args.mode, corpus)
+
+    # Output
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(format_human(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/pmoves/tools/chit_decoder.py
+++ b/pmoves/tools/chit_decoder.py
@@ -198,7 +198,7 @@ def compute_metrics(cgp: dict, mode: str, corpus: dict = None) -> dict:
                 point_text = pt.get("text", "") or ""
                 corpus_content = corpus[ref_id].get("content", "") or ""
                 if point_text and corpus_content:
-                    ratio = SequenceMatcher(None, point_text, corpus_content).ratio()
+                    ratio = SequenceMatcher(None, point_text, corpus_content[:512]).ratio()
                     text_similarities.append(ratio)
         mean_sim = round(float(statistics.mean(text_similarities)), 4) if text_similarities else None
         mean_proj = round(float(statistics.mean(projections)), 4) if projections else None

--- a/pmoves/tools/requirements-lite.txt
+++ b/pmoves/tools/requirements-lite.txt
@@ -1,3 +1,6 @@
 PyYAML>=6.0
 rich>=13.7.0
+sentence-transformers>=2.0.0
+scikit-learn>=1.3.0
+jsonschema>=4.0.0
 psutil>=5.9.8

--- a/pmoves/tools/test_chit_tools.py
+++ b/pmoves/tools/test_chit_tools.py
@@ -1,0 +1,171 @@
+"""Tests for CHIT tools — compute_mhep, kl_divergence_spectrum, CGP integration.
+
+Run from repo root:
+    pytest pmoves/tools/test_chit_tools.py -v
+
+Requires: numpy (always), sentence-transformers + scikit-learn + jsonschema (for integration).
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Ensure sibling modules are importable regardless of cwd
+_TOOLS_DIR = str(Path(__file__).resolve().parent)
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+# chit_decoder only needs numpy — safe to import unconditionally
+import chit_decoder  # noqa: E402
+
+# chit_backend pulls heavy deps; gate behind importorskip
+chit_backend = pytest.importorskip("chit_backend")  # noqa: E402
+
+
+# =============================================================================
+# Unit: compute_mhep
+# =============================================================================
+
+
+class TestComputeMhep:
+    """Mean Harmonic Embedding Perplexity tests."""
+
+    def test_empty_projections(self):
+        """No projections → 0.0."""
+        assert chit_backend.compute_mhep([]) == 0.0
+
+    def test_single_projection(self):
+        """Single proj: softmax([0]) = [1], MHEP = 1/1 = 1.0."""
+        assert abs(chit_backend.compute_mhep([0.0]) - 1.0) < 1e-6
+
+    def test_identical_projections(self):
+        """[1, 1]: shifted=[0,0], softmax sum=2, MHEP = 1/2 = 0.5."""
+        assert abs(chit_backend.compute_mhep([1.0, 1.0]) - 0.5) < 1e-6
+
+    def test_known_three_values(self):
+        """[2, 1, 0]: shifted=[0,-1,-2], sum=1+e^-1+e^-2≈1.5032, MHEP≈0.6652."""
+        expected = 1.0 / (1.0 + math.exp(-1) + math.exp(-2))
+        result = chit_backend.compute_mhep([2.0, 1.0, 0.0])
+        assert abs(result - expected) < 1e-6
+
+    def test_peaked_distribution_high_perplexity(self):
+        """One dominant projection → softmax_sum≈1, MHEP≈1.0."""
+        result = chit_backend.compute_mhep([10.0, 0.0, 0.0])
+        assert result > 0.99
+
+
+# =============================================================================
+# Unit: kl_divergence_spectrum
+# =============================================================================
+
+
+class TestKlDivergenceSpectrum:
+    """KL(p || uniform) spectrum tests."""
+
+    def test_uniform_distribution_near_zero(self):
+        """Uniform spectrum → KL ≈ 0."""
+        result = chit_decoder.kl_divergence_spectrum([1.0, 1.0, 1.0, 1.0], bins=4)
+        assert result < 1e-4
+
+    def test_peaked_distribution_positive(self):
+        """Peaked [100,1,1,1] → KL > 0."""
+        result = chit_decoder.kl_divergence_spectrum([100.0, 1.0, 1.0, 1.0], bins=4)
+        assert result > 0.5
+
+    def test_single_bin_zero(self):
+        """Single bin: p=u=1, log(1)=0."""
+        result = chit_decoder.kl_divergence_spectrum([1.0], bins=1)
+        assert result < 1e-4
+
+    def test_known_two_bin_value(self):
+        """[3,1] bins=2: p≈[0.75,0.25], u=[0.5,0.5].
+        KL = 0.75*ln(1.5) + 0.25*ln(0.5) ≈ 0.1308."""
+        result = chit_decoder.kl_divergence_spectrum([3.0, 1.0], bins=2)
+        assert abs(result - 0.1308) < 0.01
+
+
+# =============================================================================
+# Integration: CGP output structure
+# =============================================================================
+
+
+@pytest.fixture
+def fixture_chunks():
+    """3-line JSONL-style data: 2 in 'awareness', 1 in 'practice'."""
+    return [
+        {"id": "chunk-1", "content": "Consciousness is the state of being aware.", "category": "awareness"},
+        {"id": "chunk-2", "content": "Awareness expands through meditation practice.", "category": "awareness"},
+        {"id": "chunk-3", "content": "Meditation deepens the connection to inner self.", "category": "practice"},
+    ]
+
+
+@pytest.fixture
+def fake_embeddings():
+    """Pre-computed 4-dim fake embeddings matching fixture_chunks."""
+    return {
+        "awareness": np.array([
+            [0.1, 0.2, 0.3, 0.4],
+            [0.15, 0.25, 0.35, 0.45],
+        ], dtype=np.float64),
+        "practice": np.array([
+            [0.8, 0.7, 0.6, 0.5],
+        ], dtype=np.float64),
+    }
+
+
+class TestCgpIntegration:
+    """Integration: build_cgp from fixture → verify CGP structure."""
+
+    def test_required_top_level_keys(self, fixture_chunks, fake_embeddings):
+        groups = chit_backend.group_by_category(fixture_chunks)
+        cgp = chit_backend.build_cgp(groups, fake_embeddings, k=2, bins=8)
+        for key in ("spec", "created_at", "updated_at", "summary", "meta",
+                    "super_nodes", "constellations", "points"):
+            assert key in cgp, f"Missing top-level key: {key}"
+
+    def test_meta_categories_and_counts(self, fixture_chunks, fake_embeddings):
+        groups = chit_backend.group_by_category(fixture_chunks)
+        cgp = chit_backend.build_cgp(groups, fake_embeddings, k=2, bins=8)
+        meta = cgp["meta"]
+        assert set(meta["categories"]) == {"awareness", "practice"}
+        assert meta["total_chunks"] == 3
+        assert "mhep" in meta
+        assert meta["K"] == 2
+        assert meta["bins"] == 8
+
+    def test_super_nodes_match_categories(self, fixture_chunks, fake_embeddings):
+        groups = chit_backend.group_by_category(fixture_chunks)
+        cgp = chit_backend.build_cgp(groups, fake_embeddings, k=2, bins=8)
+        assert len(cgp["super_nodes"]) == 2
+        labels = {sn["label"] for sn in cgp["super_nodes"]}
+        assert labels == {"awareness", "practice"}
+        for sn in cgp["super_nodes"]:
+            assert "id" in sn
+            assert isinstance(sn["constellations"], list)
+
+    def test_constellations_have_required_fields(self, fixture_chunks, fake_embeddings):
+        groups = chit_backend.group_by_category(fixture_chunks)
+        cgp = chit_backend.build_cgp(groups, fake_embeddings, k=2, bins=8)
+        total_points = 0
+        for con in cgp["constellations"]:
+            for field in ("id", "points", "spectrum", "anchor", "radial_minmax"):
+                assert field in con, f"Constellation missing field: {field}"
+            assert isinstance(con["spectrum"], list)
+            total_points += len(con["points"])
+        assert total_points == 3
+
+    def test_points_text_truncated_to_512(self, fixture_chunks, fake_embeddings):
+        """Every point's text field must be ≤ 512 chars (backend truncation invariant)."""
+        groups = chit_backend.group_by_category(fixture_chunks)
+        cgp = chit_backend.build_cgp(groups, fake_embeddings, k=2, bins=8)
+        for pt in cgp["points"]:
+            assert "text" in pt
+            assert "proj" in pt
+            assert "id" in pt
+            assert "ref_id" in pt
+            assert len(pt["text"]) <= 512, (
+                f"Point {pt['id']} text length {len(pt['text'])} exceeds 512"
+            )


### PR DESCRIPTION
## Summary

Builds two missing CONCH pipeline tools and updates the execution guide to reflect actual project state.

### New Tools

- **`pmoves/tools/chit_backend.py`** — CGP Auto-Mapper: transforms consciousness-chunks JSONL → CGP packets validated against `cgp.v1.schema.json`. Uses sentence-transformers + KMeans clustering per category, computes MHEP and spectrum histograms. Tested against real 216-chunk dataset.

- **`pmoves/tools/chit_decoder.py`** — CGP Decoder: supports `exact` mode (structural decode) and `geometry` mode (corpus lookup with text similarity). Computes KL divergence, coverage, and per-constellation fidelity metrics.

### Guide Updates (`PMOVES-CONCHexecution_guide.md`)

- Updated date to 2026-04-19
- Added "325 = consciousness theories (Kuhn), not personas" clarification
- Current State Assessment: reflects reality (216 chunks, CGP payload exists, tools built, PMOVES.YT broken)
- Phase 0: fixed stale `make` commands → `make supa-start`, `make overlay-up-core`
- Phase 3: added ⚠️ warning that PMOVES.YT submodule is broken (P0 blocker)
- Phase 4: references `chit_backend.py` with actual CLI usage
- Phase 7: references `chit_decoder.py` with actual CLI usage; marked `chit_decoder_mm.py` as future work
- TODO section: marked CGP Auto-Mapper as DONE, added `chit_decoder_mm.py` and PMOVES.YT fix as new TODOs

### Files Changed
- `pmoves/tools/chit_backend.py` (new)
- `pmoves/tools/chit_decoder.py` (new)
- `pmoves/docs/PMOVESCHIT/PMOVES-CONCHexecution_guide.md` (updated)