### PR TITLE
fix: rename chit_decoder → chit_verify + add Linux k6 install

### DIFF
--- a/pmoves/docs/operations/FLEET_CAPACITY_ANALYSIS.md
+++ b/pmoves/docs/operations/FLEET_CAPACITY_ANALYSIS.md
@@ -214,6 +214,7 @@ No load test exists today. Add one of:
 # Install (one-off, host-side)
 choco install k6   # Windows
 # or: brew install k6
+sudo apt install -y k6  # Debian/Ubuntu (Hostinger KVMs)
 
 # 100 req/s × 10 min against Hi-RAG v2
 k6 run --vus 20 --duration 10m - <<'EOF'

--- a/pmoves/tools/chit_verify.py
+++ b/pmoves/tools/chit_verify.py
@@ -5,9 +5,9 @@ Decodes a CGP JSON payload back to structured chunk references (exact mode)
 or reconstructs text from geometric encoding using a corpus JSONL (geometry mode).
 
 Usage:
-    python pmoves/tools/chit_decoder.py --cgp geometry_payload.json --mode exact
-    python pmoves/tools/chit_decoder.py --cgp geometry_payload.json --mode geometry --corpus chunks.jsonl --compute-metrics
-    python pmoves/tools/chit_decoder.py --cgp geometry_payload.json --compute-metrics --output report.json
+    python pmoves/tools/chit_verify.py --cgp geometry_payload.json --mode exact
+    python pmoves/tools/chit_verify.py --cgp geometry_payload.json --mode geometry --corpus chunks.jsonl --compute-metrics
+    python pmoves/tools/chit_verify.py --cgp geometry_payload.json --compute-metrics --output report.json
 
 Standalone tool — no PMOVES-internal imports.
 """

--- a/pmoves/tools/test_chit_tools.py
+++ b/pmoves/tools/test_chit_tools.py
@@ -18,8 +18,8 @@ _TOOLS_DIR = str(Path(__file__).resolve().parent)
 if _TOOLS_DIR not in sys.path:
     sys.path.insert(0, _TOOLS_DIR)
 
-# chit_decoder only needs numpy — safe to import unconditionally
-import chit_decoder  # noqa: E402
+# chit_verify only needs numpy — safe to import unconditionally
+import chit_verify  # noqa: E402
 
 # chit_backend pulls heavy deps; gate behind importorskip
 chit_backend = pytest.importorskip("chit_backend")  # noqa: E402
@@ -67,23 +67,23 @@ class TestKlDivergenceSpectrum:
 
     def test_uniform_distribution_near_zero(self):
         """Uniform spectrum → KL ≈ 0."""
-        result = chit_decoder.kl_divergence_spectrum([1.0, 1.0, 1.0, 1.0], bins=4)
+        result = chit_verify.kl_divergence_spectrum([1.0, 1.0, 1.0, 1.0], bins=4)
         assert result < 1e-4
 
     def test_peaked_distribution_positive(self):
         """Peaked [100,1,1,1] → KL > 0."""
-        result = chit_decoder.kl_divergence_spectrum([100.0, 1.0, 1.0, 1.0], bins=4)
+        result = chit_verify.kl_divergence_spectrum([100.0, 1.0, 1.0, 1.0], bins=4)
         assert result > 0.5
 
     def test_single_bin_zero(self):
         """Single bin: p=u=1, log(1)=0."""
-        result = chit_decoder.kl_divergence_spectrum([1.0], bins=1)
+        result = chit_verify.kl_divergence_spectrum([1.0], bins=1)
         assert result < 1e-4
 
     def test_known_two_bin_value(self):
         """[3,1] bins=2: p≈[0.75,0.25], u=[0.5,0.5].
         KL = 0.75*ln(1.5) + 0.25*ln(0.5) ≈ 0.1308."""
-        result = chit_decoder.kl_divergence_spectrum([3.0, 1.0], bins=2)
+        result = chit_verify.kl_divergence_spectrum([3.0, 1.0], bins=2)
         assert abs(result - 0.1308) < 0.01
 
 


### PR DESCRIPTION
## Summary

- Renames `pmoves/tools/chit_decoder.py` → `pmoves/tools/chit_verify.py` to eliminate name collision with `pmoves/tools/chit/chit_decoder.py` (production faiss-backed decoder)
- Updates test imports in `test_chit_tools.py`
- Adds `sudo apt install -y k6` to FLEET_CAPACITY_ANALYSIS.md §9.2 alongside existing Windows choco command

## Context

PR #1315 introduced a lightweight CGP verification CLI that landed at `pmoves/tools/chit_decoder.py`, colliding with the existing production decoder at `pmoves/tools/chit/chit_decoder.py`. The new tool serves a different purpose (standalone verification, numpy-only, no faiss) and should have a distinct name. The original decoder remains the canonical API via `__init__.py`.