### PR TITLE
fix: harden deploy scripts from draft PR review (#1316-#1319)

### DIFF
--- a/deploy/provision/autoinstall/pve-cluster-node.toml
+++ b/deploy/provision/autoinstall/pve-cluster-node.toml
@@ -63,6 +63,7 @@ zfs.copies = 1
 # --node-type=pve-member. The host will NOT install Docker (enforced by that
 # branch of the setup script).
 source = "from-url"
+# TODO: Add cert_fingerprint or fetch over Tailscale SSH for supply-chain safety
 url = "https://raw.githubusercontent.com/POWERFULMOVES/PMOVES.AI/main/deploy/provision/pve-first-boot.sh"
 # NOTE: hash pinning recommended in production. Omit for now; build-usb.sh
 # will inject the expected cert fingerprint via substitution.

--- a/deploy/provision/build-usb.sh
+++ b/deploy/provision/build-usb.sh
@@ -146,7 +146,11 @@ fi
 if grep -q "REPLACE_WITH_STRONG_RANDOM_AT_BUILD_TIME" "$answer_file"; then
   if [[ "$GEN_ROOT_PASSWORD" == "true" ]] && [[ -z "$ROOT_PASSWORD" ]]; then
     ROOT_PASSWORD="$(openssl rand -base64 32 | tr -d '=+/' | cut -c1-24)"
-    log "Generated random root password (24 chars). SAVE THIS: $ROOT_PASSWORD"
+    ROOT_PASSWORD_FILE="${OUTPUT_DIR}/root-password-$(date +%Y%m%d-%H%M%S).txt"
+    echo "$ROOT_PASSWORD" > "$ROOT_PASSWORD_FILE"
+    chmod 600 "$ROOT_PASSWORD_FILE"
+    log "Root password saved to: $ROOT_PASSWORD_FILE"
+    log_warn "DELETE this file after recording the password!"
   fi
   if [[ -z "$ROOT_PASSWORD" ]]; then
     err "Answer file has root password placeholder. Pass --root-password=STRING or --generate-root-password."

--- a/deploy/provision/hostinger-kvm-setup.sh
+++ b/deploy/provision/hostinger-kvm-setup.sh
@@ -78,7 +78,7 @@ autodetect_node_type() {
 # Validate node type
 validate_node_type() {
     case "$NODE_TYPE" in
-        kvm4-1|kvm4-2|kvm2|gpu-5090|rdna4-workstation|dgx-spark|pve-member) ;;
+        kvm4-1|kvm4-2|kvm2|gpu-5090|rdna4-workstation|dgx-spark|pve-member|pve-member-fresh) ;;
         *)
             log_error "Invalid node type: '$NODE_TYPE'"
             echo "Usage: $0 <node-type>"
@@ -93,6 +93,7 @@ validate_node_type() {
             echo "  rdna4-workstation AMD Ryzen 9850X3D + dual R9700 (ROCm 7.1 + llama.cpp HIP)"
             echo "  dgx-spark         NVIDIA DGX Spark ARM64 overlay (Ollama + fleet agent)"
             echo "  pve-member        Proxmox VE 9 cluster member (no Docker-on-host; VMs only)"
+            echo "  pve-member-fresh  Bare Debian box — install PVE then join as cluster member"
             echo ""
             echo "  auto              Detect via deploy/provision/glances-autodetect.sh"
             echo ""
@@ -108,7 +109,7 @@ check_env() {
 
     # GITHUB_PAT required for any node that will run a GitHub Actions runner.
     # pve-member runs NO runner on the hypervisor (VMs do), so skip the check.
-    if [ "$NODE_TYPE" != "pve-member" ]; then
+    if [ "$NODE_TYPE" != "pve-member" ] && [ "$NODE_TYPE" != "pve-member-fresh" ]; then
         if [ -z "${GITHUB_PAT:-}" ]; then
             log_error "GITHUB_PAT not set. Generate at: https://github.com/settings/tokens/new"
             exit 1
@@ -199,7 +200,7 @@ harden_system() {
             ufw allow 11434/tcp comment "Ollama"
             ufw allow 8200/tcp comment "GPU Orchestrator"
             ;;
-        pve-member)
+        pve-member|pve-member-fresh)
             # Proxmox cluster member — PVE web UI + corosync cluster ports
             ufw allow 8006/tcp comment "PVE Web UI"
             ufw allow 5404:5412/udp comment "Corosync cluster membership"
@@ -240,7 +241,7 @@ EOF
 install_docker() {
     log_section "Step 2: Installing Docker..."
 
-    if [ "$NODE_TYPE" = "pve-member" ]; then
+    if [ "$NODE_TYPE" = "pve-member" ] || [ "$NODE_TYPE" = "pve-member-fresh" ]; then
         log_info "Skipping Docker — PVE cluster members run containers inside VMs/LXCs, not on the host."
         log_info "See pmoves/docs/infrastructure/docker_proxmox_integration.md"
         return 0
@@ -320,7 +321,7 @@ EOF
         dgx-spark)
             ts_args+=(--tag=tag:pmoves --tag=tag:gpu --tag=tag:spark --tag=tag:arm64 --tag=tag:production)
             ;;
-        pve-member)
+        pve-member|pve-member-fresh)
             ts_args+=(--tag=tag:pmoves --tag=tag:pve --tag=tag:cluster --tag=tag:production)
             ;;
         *)
@@ -350,7 +351,7 @@ EOF
 install_runner() {
     log_section "Step 4: Installing GitHub Actions runner..."
 
-    if [ "$NODE_TYPE" = "pve-member" ]; then
+    if [ "$NODE_TYPE" = "pve-member" ] || [ "$NODE_TYPE" = "pve-member-fresh" ]; then
         log_info "Skipping runner install — GitHub Actions runners live inside PVE VMs, not on the hypervisor."
         return 0
     fi
@@ -505,7 +506,7 @@ install_dgx_spark_overlay() {
     cat >/etc/systemd/system/ollama.service.d/override.conf <<'EOF'
 [Service]
 Environment="OLLAMA_HOST=0.0.0.0:11434"
-Environment="OLLAMA_ORIGINS=*"
+Environment="OLLAMA_ORIGINS=http://100.64.0.0/10,http://127.0.0.1:*"
 EOF
     systemctl daemon-reload
     systemctl enable --now ollama || true
@@ -515,7 +516,7 @@ EOF
 
 # Step 5d: PVE cluster-member helper (Tailscale join + cluster prep notes)
 install_pve_member_prep() {
-    if [ "$NODE_TYPE" != "pve-member" ]; then
+    if [ "$NODE_TYPE" != "pve-member" ] && [ "$NODE_TYPE" != "pve-member-fresh" ]; then
         return 0
     fi
 
@@ -584,7 +585,7 @@ INFERENCE_BACKEND=ollama-arm64
 EOF
             fi
             ;;
-        pve-member)
+        pve-member|pve-member-fresh)
             # PVE host keeps env minimal — services live in VMs
             :
             ;;
@@ -676,7 +677,7 @@ show_summary() {
             echo "  3. Smoke test: curl http://localhost:11434/api/tags"
             echo "  4. Ensure Tailscale tag:spark is approved in ACL"
             ;;
-        pve-member)
+        pve-member|pve-member-fresh)
             echo "  1. Join PVE cluster: pvecm add <controller-tailscale-hostname>"
             echo "  2. Verify membership: pvecm status"
             echo "  3. Configure storage (ZFS or Ceph): see deploy/proxmox/cluster/ (Phase G)"
@@ -697,6 +698,19 @@ main() {
     log_section "========================================="
     log_section "PMOVES.AI KVM Provisioning: $NODE_TYPE"
     log_section "========================================="
+
+    # pve-member-fresh: bare Debian box needs PVE installed first
+    if [ "$NODE_TYPE" = "pve-member-fresh" ]; then
+        log_section "Installing Proxmox VE on bare Debian..."
+        if [ -x "${SCRIPT_DIR:-.}/pve_on_debian13.sh" ]; then
+            bash "${SCRIPT_DIR:-.}/pve_on_debian13.sh"
+        else
+            log_error "pve_on_debian13.sh not found in ${SCRIPT_DIR:-.} — cannot provision pve-member-fresh"
+            exit 1
+        fi
+        log_info "PVE installed. Continuing as pve-member..."
+    fi
+
     echo ""
 
     harden_system

--- a/deploy/provision/rdna4-gpu-install.sh
+++ b/deploy/provision/rdna4-gpu-install.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 # Configuration
 # ------------------------------------------------------------------
 ROCM_VERSION="${ROCM_VERSION:-7.1}"
+LLAMA_CPP_PIN="a6e76c64dd525a1bd7726fa1d1145954cef375a8"
 LLAMA_CPP_REPO="${LLAMA_CPP_REPO:-https://github.com/tlee933/llama.cpp-rdna4-gfx1201}"
 LLAMA_CPP_DIR="${LLAMA_CPP_DIR:-/opt/llama.cpp-rdna4}"
 LLAMA_SERVER_PORT="${LLAMA_SERVER_PORT:-8080}"
@@ -144,7 +145,7 @@ build_llama_cpp() {
     git -C "${LLAMA_CPP_DIR}" reset --hard origin/HEAD
   else
     log "Cloning llama.cpp RDNA4 fork"
-    git clone --depth 1 "${LLAMA_CPP_REPO}" "${LLAMA_CPP_DIR}"
+    git clone --depth 1 "${LLAMA_CPP_REPO}" "${LLAMA_CPP_DIR}" && git -C "${LLAMA_CPP_DIR}" checkout "${LLAMA_CPP_PIN}"
   fi
 
   log "Building llama.cpp with HIP target ${GPU_TARGETS}"
@@ -170,6 +171,12 @@ build_llama_cpp() {
 # Systemd llama-server
 # ------------------------------------------------------------------
 install_llama_server_unit() {
+  log_section "Creating llama system user..."
+  if ! id llama &>/dev/null; then
+      useradd -r -M -d /opt/llama.cpp -s /usr/sbin/nologin llama
+  fi
+  usermod -aG render,video llama
+
   log "Installing llama-server systemd unit"
 
   mkdir -p "${LLAMA_MODELS_DIR}"
@@ -196,15 +203,18 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+User=llama
+Group=llama
 EnvironmentFile=/etc/default/llama-server
 ExecStart=/bin/sh -c '/usr/local/bin/llama-server --model $LLAMA_MODEL_PATH --host $LLAMA_HOST --port $LLAMA_PORT --ctx-size $LLAMA_CONTEXT_SIZE $LLAMA_EXTRA_ARGS'
 Restart=on-failure
 RestartSec=5s
-User=root
 
 [Install]
 WantedBy=multi-user.target
 EOF
+
+  chown -R llama:llama /opt/llama.cpp
 
   systemctl daemon-reload
   systemctl enable llama-server.service

--- a/pmoves/config/provider_catalog.yaml
+++ b/pmoves/config/provider_catalog.yaml
@@ -678,16 +678,16 @@ providers:
             weight: 0.0
         strength_ref: null
         vram_mb: 36000                 # FP16 weights sit in unified LPDDR5X
-      ollama_spark_nemotron3_super_120b_fp8:
+      ollama_spark_nemotron3_super_120b_nvfp4:
         # HF: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 (verified via HF API 2026-04-19)
         # License: NVIDIA Open Model License (OML). Spark-only — RDNA4 gfx1201
         # has no FP8/NVFP4 kernels in ROCm 7.1 as of this date.
         model_name: "nemotron-3-super-120b-nvfp4"
-        tz_model_key: ollama_spark_nemotron3_super_120b_fp8
+        tz_model_key: ollama_spark_nemotron3_super_120b_nvfp4
         status: staging
         serves:
           - function: agent_zero
-            variant_name: ollama_spark_nemotron3_super_120b_fp8
+            variant_name: ollama_spark_nemotron3_super_120b_nvfp4
             role: secondary
             weight: 0.0
         strength_ref: null

--- a/pmoves/configs/flare-model-namespace.yaml
+++ b/pmoves/configs/flare-model-namespace.yaml
@@ -144,7 +144,7 @@ mappings:
     # HF: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 (verified 2026-04-19)
     # Spark-only; NOT viable on RDNA4 gfx1201 (no FP8/FP4 kernels).
     model_id: "nemotron-3-super-120b-nvfp4"
-    tensorzero_variant: "ollama_spark_nemotron3_super_120b_fp8"
+    tensorzero_variant: "ollama_spark_nemotron3_super_120b_nvfp4"
     lane: "local"
     nodes: [dgx-spark]
 

--- a/pmoves/supabase/initdb/12_model_registry_seed.sql
+++ b/pmoves/supabase/initdb/12_model_registry_seed.sql
@@ -1817,7 +1817,7 @@ BEGIN
   INSERT INTO pmoves_core.models (provider_id, name, model_id, model_type, capabilities, vram_mb, context_length, description, active)
   VALUES (
     v_spark_id,
-    'ollama_spark_nemotron3_super_120b_fp8',
+    'ollama_spark_nemotron3_super_120b_nvfp4',
     'nemotron-3-super-120b-nvfp4',
     'chat',
     '["chat", "function_calling", "json_mode", "tool_use", "agentic_reasoning"]'::jsonb,

--- a/pmoves/tensorzero/config/tensorzero.toml
+++ b/pmoves/tensorzero/config/tensorzero.toml
@@ -463,10 +463,10 @@ api_key_location = "none"
 # HF: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 (verified HF API 2026-04-19)
 # License: NVIDIA Open Model License (OML). Spark-only — RDNA4 gfx1201 lacks
 # FP8/NVFP4 kernels in ROCm 7.1 as of this date.
-[models.ollama_spark_nemotron3_super_120b_fp8]
+[models.ollama_spark_nemotron3_super_120b_nvfp4]
 routing = ["ollama_spark"]
 
-[models.ollama_spark_nemotron3_super_120b_fp8.providers.ollama_spark]
+[models.ollama_spark_nemotron3_super_120b_nvfp4.providers.ollama_spark]
 type = "openai"
 api_base = "http://pmoves-gb10-spark:11434/v1"
 model_name = "nemotron-3-super-120b-nvfp4"
@@ -787,9 +787,9 @@ model = "ollama_spark_gemma4_31b_fp16"
 weight = 0.0
 
 # Nemotron-3-Super 120B-A12B NVFP4 on DGX Spark (heavyweight reasoning)
-[functions.agent_zero.variants.ollama_spark_nemotron3_super_120b_fp8]
+[functions.agent_zero.variants.ollama_spark_nemotron3_super_120b_nvfp4]
 type = "chat_completion"
-model = "ollama_spark_nemotron3_super_120b_fp8"
+model = "ollama_spark_nemotron3_super_120b_nvfp4"
 weight = 0.0
 
 # Gemma 4 31B Q4_K_M on single R9700 (llama.cpp HIP)


### PR DESCRIPTION
## Summary

Post-merge hardening for 4 draft PRs merged into Proxmox migration series.

### Critical fixes
- **C1**: Pin llama.cpp fork to commit `a6e76c6` (supply-chain safety) — `rdna4-gpu-install.sh`
- **C2**: Run llama-server as non-root `llama` system user with `render,video` groups — `rdna4-gpu-install.sh`
- **C3**: Add `pve-member-fresh` to `validate_node_type` and all case branches — `hostinger-kvm-setup.sh`
- **C4**: Write root password to `chmod 600` file instead of stdout — `build-usb.sh`

### Important fixes
- **I2**: Restrict `OLLAMA_ORIGINS` from `*` to `http://100.64.0.0/10,http://127.0.0.1:*` (Tailscale CGNAT + localhost) — `hostinger-kvm-setup.sh`
- **I3**: Add TODO comment for first-boot URL cert fingerprint pinning — `pve-cluster-node.toml`
- **I4**: Rename Nemotron `fp8` suffixes to `nvfp4` (correct quantization label) across 4 files: `flare-model-namespace.yaml`, `12_model_registry_seed.sql`, `tensorzero.toml`, `provider_catalog.yaml`

### Deferred (target files not present in `deploy/provision/`)
- **I1**: `pve_on_debian13.sh` only exists at legacy `CATACLYSM_STUDIOS_INC/` path — needs to be promoted to `deploy/provision/` first
- **I5**: No `pip install` / `--break-system-packages` line found in `glances-autodetect.sh` — may already use system package

### Files changed (8)
| File | Change |
|------|--------|
| `deploy/provision/rdna4-gpu-install.sh` | C1 pin + C2 non-root user |
| `deploy/provision/hostinger-kvm-setup.sh` | C3 pve-member-fresh + I2 CORS |
| `deploy/provision/build-usb.sh` | C4 password to file |
| `deploy/provision/autoinstall/pve-cluster-node.toml` | I3 TODO |
| `pmoves/config/provider_catalog.yaml` | I4 nvfp4 rename |
| `pmoves/configs/flare-model-namespace.yaml` | I4 nvfp4 rename |
| `pmoves/supabase/initdb/12_model_registry_seed.sql` | I4 nvfp4 rename |
| `pmoves/tensorzero/config/tensorzero.toml` | I4 nvfp4 rename |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `pve-member-fresh` node type in deployment provisioning.

* **Bug Fixes**
  * Improved root password security by writing to file instead of logging plaintext.
  * Restricted Ollama CORS origins from wildcard to explicit allowlist.
  * Changed llama.cpp service to run under dedicated user instead of root for enhanced security.

* **Chores**
  * Updated Ollama Spark Nemotron-3-Super 120B model to NVFP4 variant across configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->