### PR TITLE
fix(conch): 3 P1s on chit_backend.py — runtime crash + docstring + schema version

### DIFF
--- a/pmoves/tools/chit_backend.py
+++ b/pmoves/tools/chit_backend.py
@@ -87,10 +87,20 @@ def compute_spectrum(projs: list[float], bins: int) -> list[float]:
 
 
 def compute_mhep(projs: list[float]) -> float:
-    """Mean Harmonic Embedding Perplexity: avg of 1/sum(softmax(projs)) per constellation.
+    """Mean Harmonic Embedding Perplexity — inverse of the shifted-softmax denominator.
 
-    For a single constellation, MHEP = 1 / sum(softmax(projs)).
-    Returns 0.0 if no projections.
+    For a single constellation, MHEP = 1 / sum(exp(projs - max(projs))). This is
+    equivalent to the softmax temperature-1 normalizer evaluated in max-shifted
+    log-space (numerical stability), NOT 1/sum(softmax(projs)) — the latter is
+    always 1.0 by definition of softmax.
+
+    Interpretation: MHEP is bounded in (0, 1]. MHEP → 1.0 as one projection
+    dominates (peaked); MHEP → 1/N as projections are equal (flat). For example:
+      - compute_mhep([0.0]) == 1.0           (single projection)
+      - compute_mhep([1.0, 1.0]) == 0.5      (flat, N=2 → 1/2)
+      - compute_mhep([10.0, 0.0, 0.0]) ≈ 1.0 (peaked)
+
+    Returns 0.0 if no projections (edge case for empty constellations).
     """
     if not projs:
         return 0.0
@@ -114,7 +124,7 @@ def build_cgp(
     categories = sorted(category_groups.keys())
     num_cats = len(categories)
     if num_cats == 0:
-        return {"spec": "chit.cgp.v0.1", "super_nodes": []}
+        return {"spec": "chit.cgp.v1.0", "super_nodes": []}
 
     radius = 1.0
     now = datetime.now(timezone.utc).isoformat()
@@ -257,7 +267,7 @@ def build_cgp(
     avg_mhep = float(np.mean(mhep_values)) if mhep_values else 0.0
 
     cgp = {
-        "spec": "chit.cgp.v0.1",
+        "spec": "chit.cgp.v1.0",
         "created_at": now,
         "updated_at": now,
         "summary": f"CGP auto-mapped from {sum(len(v) for v in category_groups.values())} chunks "
@@ -353,7 +363,7 @@ def main():
     # 3. Load model
     eprint(f"Loading model '{args.backend}'...")
     model = SentenceTransformer(args.backend)
-    eprint(f"  Model loaded, embedding dim: {model.get_embedding_dimension()}")
+    eprint(f"  Model loaded, embedding dim: {model.get_sentence_embedding_dimension()}")
 
     # 4. Encode all chunks per category
     eprint("Encoding chunks per category...")


### PR DESCRIPTION
## Summary

Three P1 fixes from local review on `chit_backend.py` that missed the #1315 merge window.

### Critical: runtime crash

`model.get_embedding_dimension()` is called at line ~356 in the main flow. **`SentenceTransformer` does not expose this method** — canonical is `get_sentence_embedding_dimension()`. Would raise `AttributeError` on the first real model load during deployment. Tests use pre-computed embedding fixtures that bypass this code path, so CI didn't catch it.

### Docstring vs code: MHEP math

`compute_mhep` docstring claims MHEP = 1/sum(softmax(projs)). That expression is always 1.0 by definition of softmax. Actual code computes `1/sum(exp(shifted))` — the correct max-shifted normalizer. Tests assert the code's real behavior. Docstring rewritten.

### Schema version: v0.1 → v1.0

Canonical format per `.claude/CLAUDE.md` is `chit.cgp.v{major}.{minor}`. The validator loads `cgp.v1.schema.json` (v1.x), so emitting `v0.1` created a mismatch. Legacy aliases still map to v1.0.

## Test plan

- [x] `py_compile` passes
- [x] Existing tests unchanged — the fixture-based assertions of compute_mhep behavior (e.g. `[1,1] == 0.5`) already match code's actual output
- [ ] First real model load on deployment confirms the get_sentence_embedding_dimension path works
- [ ] CI gates pass

Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)