### PR TITLE
fix(supabase): Studio HOSTNAME bind + Edge Functions DNS resolvers

### DIFF
--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -893,6 +893,14 @@ services:
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}
     - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
+    # Bind Studio's Next.js server to all interfaces without a DNS lookup.
+    # Next.js 16+ reads HOSTNAME to pick its listen address; Docker sets
+    # HOSTNAME to the container's short ID by default, and Next.js then
+    # resolves that ID as a DNS name before binding. Resolution fails with
+    # `getaddrinfo EAI_AGAIN` (the short ID isn't registered in Docker's
+    # embedded DNS) and the server exits, kicking the container into a
+    # restart loop. Pinning to 0.0.0.0 skips the lookup entirely.
+    - HOSTNAME=0.0.0.0
     # Healthcheck: External check (Next.js 16 binds to container hostname, not localhost)
     # Note: Official Supabase uses node -e fetch but their image has different network config
     # We rely on container being started successfully (logs show "Ready in Xms")
@@ -1016,6 +1024,15 @@ services:
     networks:
     - pmoves_api
     - pmoves_data  # reach supabase-db, supabase-analytics
+    # Pin upstream resolvers for Deno cold-boot imports. The edge-runtime
+    # image fetches https://deno.land/std@...` at worker-bootstrap time;
+    # Docker's embedded DNS (127.0.0.11) intermittently fails to forward
+    # external queries on Docker Desktop Windows, leaving the worker stuck
+    # in `failed to lookup address information: Temporary failure in name
+    # resolution`. Explicit resolvers avoid the flap.
+    dns:
+    - 1.1.1.1
+    - 8.8.8.8
 
   # ---------------------------------------------------------------------------
   # Supabase Analytics (Logflare) — log analytics backend


### PR DESCRIPTION
## Summary

- Pin `HOSTNAME=0.0.0.0` on `supabase-studio` so Next.js 16 binds without a DNS lookup on its own container short-ID (failure mode: `getaddrinfo EAI_AGAIN 8e7b7f2fa242`)
- Pin upstream DNS `[1.1.1.1, 8.8.8.8]` on `supabase-edge-functions` so Deno cold-boot imports from `https://deno.land/...` succeed on Docker Desktop Windows (failure mode: `Temporary failure in name resolution`)
- Fixes the two remaining Supabase crash loops from the Phase 9C session close-out

## Root cause

Both services were `Restarting (1)` indefinitely across multiple `supa-restart` cycles:

**Studio** — Next.js 16+ reads `process.env.HOSTNAME` for its bind address. Docker sets it to the container short ID by default, and Next.js then resolves the short ID as a DNS name before binding. Docker's embedded DNS (`127.0.0.11`) has no record for that ID, so `getaddrinfo` returns `EAI_AGAIN` and the server exits.

**Edge Functions** — `supabase/edge-runtime` fetches Deno std library modules at worker bootstrap. Docker Desktop on Windows has intermittent forwarding failures in the embedded DNS, and external `deno.land` lookups fail with `Temporary failure in name resolution`.

## Test plan

- [x] `make -C pmoves supa-restart` — confirm completes exit 0
- [x] `docker ps --filter name=pmoves-supabase-studio-1` shows `healthy` (was `Restarting (1)`)
- [x] `docker ps --filter name=pmoves-supabase-edge-functions-1` shows `healthy`
- [x] `docker logs pmoves-supabase-studio-1 --tail 5` shows `Ready in N ms` (no EAI_AGAIN)
- [x] `docker logs pmoves-supabase-edge-functions-1 --tail 5` shows `Listening on ...`
- [x] All 11 previously-healthy Supabase services still healthy (no regression)
- [x] YAML validates: `python -c "import yaml; yaml.safe_load(open('pmoves/docker-compose.yml'))"`

## Context

Follow-up from the Phase 9C infra-hardening session (commits `c373bf1c35` through `d26b955f1f` on `main`). Those 13 session commits restored 10/13 Supabase services to healthy; Studio and Edge Functions were diagnosed but the fix was deferred to this targeted PR. See `pmoves/docs/AGENTS/AGNOTE4482.md` 2026-04-20 entry for session background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
