### PR TITLE
security(data-tier): bump image versions for critical CVE remediation

### DIFF
--- a/pmoves/docker-compose.core.yml
+++ b/pmoves/docker-compose.core.yml
@@ -101,7 +101,7 @@ services:
       security_opt:
       - no-new-privileges:true
 
-    image: supabase/postgres:17.6.1.079
+    image: supabase/postgres:17.6.1.108
     restart: unless-stopped
     profiles:
     - supabase-local
@@ -700,7 +700,7 @@ services:
           cpus: '1.0'
           memory: 512M
   qdrant:
-    image: qdrant/qdrant:v1.14.1
+    image: qdrant/qdrant:v1.16.0
     restart: unless-stopped
     cap_drop:
     - ALL
@@ -734,7 +734,7 @@ services:
           memory: 4G
   meilisearch:
     <<: *tier-data-hardened
-    image: getmeili/meilisearch:v1.8
+    image: getmeili/meilisearch:v1.34.1
     restart: unless-stopped
     environment:
     - MEILI_ENV=production
@@ -761,7 +761,7 @@ services:
           cpus: '2.0'
           memory: 4G
   neo4j:
-    image: neo4j:5.22
+    image: neo4j:5.26.22
     env_file:
     - env.tier-data
     cap_drop:
@@ -808,6 +808,7 @@ services:
   minio:
     <<: *tier-data-hardened
     # Pinned 2025-02-04: Latest RELEASE tag (MinIO stopped publishing to Docker Hub Oct 2025)
+    # ⚠️ WARNING: MinIO Community Edition is EOL (archived Feb 2026). Migration to SeaweedFS/Garage/Enterprise planned.
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     command: server /data --console-address ":9001"
     environment:

--- a/pmoves/docker-compose.jellyfin-ai.yml
+++ b/pmoves/docker-compose.jellyfin-ai.yml
@@ -97,7 +97,7 @@ services:
       NVIDIA_DRIVER_CAPABILITIES: ${JELLYFIN_NVIDIA_DRIVER_CAPABILITIES:-compute,video,utility}
 
   jellyfin-neo4j:
-    image: neo4j:5.15
+    image: neo4j:5.26.22
     container_name: pmoves-jellyfin-neo4j
     profiles: ["default", "jellyfin-ai"]
     environment:

--- a/pmoves/docker-compose.n8n.yml
+++ b/pmoves/docker-compose.n8n.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: ../PMOVES-n8n
       dockerfile: compose/n8n/Dockerfile
-    image: pmoves/n8n:2.1.0-runtime
+    image: pmoves/n8n:2.1.5-runtime
     container_name: pmoves-n8n
     restart: unless-stopped
     <<: *env-tier-worker
@@ -67,7 +67,7 @@ services:
       - n8n-data:/home/node/.n8n
       - ../PMOVES-n8n/workflows:/flows:ro
   n8n-runners:
-    image: n8nio/runners:2.1.0
+    image: n8nio/runners:2.1.5
     container_name: pmoves-n8n-runners
     restart: unless-stopped
     <<: *env-tier-worker

--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -548,7 +548,7 @@ services:
 
   supabase-db:
     <<: *tier-supabase-hardened
-    image: supabase/postgres:17.6.1.079
+    image: supabase/postgres:17.6.1.108
     restart: unless-stopped
     profiles:
     - supabase-local
@@ -1151,7 +1151,7 @@ services:
           cpus: '0.5'
           memory: 256M
   qdrant:
-    image: qdrant/qdrant:v1.14.1
+    image: qdrant/qdrant:v1.16.0
     restart: unless-stopped
     cap_drop:
     - ALL
@@ -1185,7 +1185,7 @@ services:
           memory: 4G
   meilisearch:
     <<: *tier-data-hardened
-    image: getmeili/meilisearch:v1.8
+    image: getmeili/meilisearch:v1.34.1
     restart: unless-stopped
     environment:
     - MEILI_ENV=production
@@ -1212,7 +1212,7 @@ services:
           cpus: '2.0'
           memory: 4G
   neo4j:
-    image: neo4j:5.22
+    image: neo4j:5.26.22
     env_file:
     - env.tier-data
     cap_drop:
@@ -1259,6 +1259,7 @@ services:
   minio:
     <<: *tier-data-hardened
     # Pinned 2025-02-04: Latest RELEASE tag (MinIO stopped publishing to Docker Hub Oct 2025)
+    # ⚠️ WARNING: MinIO Community Edition is EOL (archived Feb 2026). Migration to SeaweedFS/Garage/Enterprise planned.
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z
     command: server /data --console-address ":9001"
     environment:


### PR DESCRIPTION
# security(data-tier): bump image versions for critical CVE remediation

## Summary
Pure image version bump across 5 data-tier services to address critical vulnerabilities. **No port changes, no configuration changes — only image tag updates.** Both the monolithic `docker-compose.yml` and overlay files are updated in sync.

## Version Changes

| Service | File(s) | Before | After | CVE / Reason | Severity |
|---------|---------|--------|-------|--------------|----------|
| **n8n** | `docker-compose.n8n.yml` | `pmoves/n8n:2.1.0-runtime` | `pmoves/n8n:2.1.5-runtime` | CVE-2026-21858 (unauthenticated RCE, CISA KEV) | CVSS 10.0 Critical |
| **n8n runners** | `docker-compose.n8n.yml` | `n8nio/runners:2.1.0` | `n8nio/runners:2.1.5` | Same n8n release train | — |
| **Supabase PostgreSQL** | `docker-compose.yml`, `docker-compose.core.yml` | `supabase/postgres:17.6.1.079` | `supabase/postgres:17.6.1.108` | CVE-2025-8713 (RLS bypass via pg_stats) | CVSS 8.8 High |
| **Meilisearch** | `docker-compose.yml`, `docker-compose.core.yml` | `getmeili/meilisearch:v1.8` | `getmeili/meilisearch:v1.34.1` | Authenticated blind SSRF (CVE Request 1975471) | Critical |
| **Neo4j** | `docker-compose.yml`, `docker-compose.core.yml` | `neo4j:5.22` | `neo4j:5.26.22` | Multiple CVEs, recommended upgrade | High |
| **Neo4j (jellyfin-ai)** | `docker-compose.jellyfin-ai.yml` | `neo4j:5.15` | `neo4j:5.26.22` | Same — was lagging 7 minor versions behind | High |
| **Qdrant** | `docker-compose.yml`, `docker-compose.core.yml` | `qdrant/qdrant:v1.14.1` | `qdrant/qdrant:v1.16.0` | CVE-2026-25628 (arbitrary file write → RCE via `/logger`) | Critical |
| **MinIO** | `docker-compose.yml`, `docker-compose.core.yml` | *No change* | *No change* | EOL — see note below | — |

## Notes

### ⚠️ Meilisearch Major Version Jump (v1.8 → v1.34.1)
This is a significant version jump spanning ~26 minor releases. Review [Meilisearch changelog](https://github.com/meilisearch/meilisearch/releases) for potential API changes. Security posture outweighs convenience here — the blind SSRF enables lateral movement across the `pmoves_data` network. Test workflows that interact with Meilisearch after upgrade.

### ⚠️ MinIO Community Edition — EOL (No Image Change)
MinIO Community Edition GitHub repo was **archived February 2026**. No future patches will be released. Added `# ⚠️ WARNING` comment in both compose files. Active CVEs remain unpatched (CVE-2025-31489, CVE-2025-62506, CVE-2023-28432). Migration to SeaweedFS, Garage, or MinIO Enterprise is planned — tracked separately.

### Qdrant v1.14.1 Status
Qdrant v1.14.1 **is vulnerable** to CVE-2026-25628 (affected range: v1.9.3–v1.15.x). Upgraded to v1.16.0 which contains the fix. Note: CVE-2025-8941 (libpam in Debian Trixie base image) affects the v1.16.0 Docker image specifically but is lower severity — monitor for v1.16.1+ image rebuild.

### Supabase PostgreSQL 17.7 Not Yet Available
The `supabase/postgres` 17.7.x image has not been published to Docker Hub as of 2026-04-20 (git tag exists on GitHub but no Docker build). Upgraded to latest available 17.6.x (`17.6.1.108`) as interim. The pg_stats REVOKE from PR #1331 remains the primary mitigation for CVE-2025-8713 until 17.7 images are available. A follow-up PR will bump to 17.7.x once published.

### PMOVES-n8n Submodule
The `PMOVES-n8n` submodule Dockerfile (`compose/n8n/Dockerfile`) has been updated to `FROM n8nio/n8n:2.1.5`. This submodule commit is local — a **companion PR to PMOVES-n8n** is needed to push the Dockerfile change. The custom `pmoves/n8n:2.1.5-runtime` image must be rebuilt after merging.

## Files Modified
- `pmoves/docker-compose.yml` (monolithic — sync with overlays)
- `pmoves/docker-compose.core.yml` (overlay)
- `pmoves/docker-compose.n8n.yml` (n8n-specific)
- `pmoves/docker-compose.jellyfin-ai.yml` (Neo4j version alignment)
- `PMOVES-n8n/compose/n8n/Dockerfile` (submodule — companion PR needed)

## Verification
```bash
# No old vulnerable tags remain
grep -rn '2.1.0-runtime\|17.6.1.079\|meilisearch:v1.8\|neo4j:5.22\|neo4j:5.15\|qdrant:v1.14.1' pmoves/docker-compose*.yml
# → (empty)

# All new tags present
grep -rn '2.1.5-runtime\|17.6.1.108\|meilisearch:v1.34\|neo4j:5.26\|qdrant:v1.16' pmoves/docker-compose*.yml
# → 10 matches across 4 files

# No port changes
git diff HEAD -- pmoves/docker-compose*.yml | grep '^[-+].*ports:'
# → (empty)
```
