### PR TITLE
🔒 Data-tier authentication hardening — Qdrant API key, Neo4j APOC allowlist, Supabase H-05 isolation

### DIFF
--- a/.github/workflows/hardening-validation.yml
+++ b/.github/workflows/hardening-validation.yml
@@ -369,6 +369,9 @@ jobs:
           LOGFLARE_PRIVATE_ACCESS_TOKEN: ci-validation-placeholder
           MINIO_USER: ci-validation-placeholder
           MINIO_PASSWORD: ci-validation-placeholder
+          QDRANT__API_KEY: ci-validation-placeholder
+          NEO4J_PASSWORD: ci-validation-placeholder
+          MEILI_MASTER_KEY: ci-validation-placeholder
         run: |
           echo "Validating docker-compose files..."
 

--- a/pmoves/docker-compose.core.yml
+++ b/pmoves/docker-compose.core.yml
@@ -342,7 +342,7 @@ services:
     volumes:
     - supabase-storage-data:/var/lib/storage:ro
     networks:
-    - pmoves_data
+    - pmoves_api
 
   # ---------------------------------------------------------------------------
   # Supabase postgres-meta — database metadata API for Studio
@@ -463,7 +463,6 @@ services:
         condition: service_healthy
     networks:
     - pmoves_api
-    - pmoves_data  # reach supabase-db, supabase-analytics
 
   # ---------------------------------------------------------------------------
   # Supabase Analytics (Logflare) — log analytics backend
@@ -654,8 +653,7 @@ services:
     ports:
     - ${SUPABASE_STUDIO_BIND:-127.0.0.1}:${SUPABASE_STUDIO_PORT:-54323}:3000
     networks:
-    - pmoves_api
-    - pmoves_data  # reach supabase-meta, supabase-analytics
+    - pmoves_api  # supabase-meta and analytics reachable via kong on pmoves_api
 
   # ---------------------------------------------------------------------------
   # Supabase imgproxy — image transformation for Storage
@@ -719,6 +717,7 @@ services:
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}
     - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
+    - QDRANT__SERVICE__API_KEY=${QDRANT__API_KEY:?Set QDRANT__API_KEY in env.tier-data}
     volumes:
     - qdrant-data:/qdrant/storage
     healthcheck:
@@ -777,9 +776,15 @@ services:
     - no-new-privileges:true
     restart: unless-stopped
     environment:
-    - NEO4J_AUTH=${NEO4J_AUTH:-neo4j/${NEO4J_PASSWORD:-pm_kDhuaogcUc1oOOVeGMNCkQ}}
+    - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:?Set NEO4J_PASSWORD in env.tier-data}
     - NEO4J_dbms_security_allow__csv__import__from__file__urls=true
     - NEO4J_server_config_strict__validation_enabled=false
+    # APOC extensions with safe procedure allowlist
+    - NEO4J_apoc_export_file_enabled=true
+    - NEO4J_apoc_import_file_enabled=true
+    - NEO4J_apoc_import_file_use__neo4j__config__true=true
+    - NEO4JLABS_PLUGINS=["apoc"]
+    - NEO4J_dbms_security_procedures_unrestricted=apoc.coll.*,apoc.text.*,apoc.path.*,apoc.algo.*
     - DOCKED_MODE=${DOCKED_MODE:-true}
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}

--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -631,7 +631,6 @@ services:
     - ${SUPABASE_AUTH_BIND:-127.0.0.1}:${SUPABASE_GOTRUE_PORT:-9999}:9999
     networks:
     - pmoves_api
-    - pmoves_data
 
     deploy:
       resources:
@@ -674,7 +673,6 @@ services:
     - ${SUPABASE_REST_BIND:-127.0.0.1}:${SUPABASE_POSTGREST_PORT:-3000}:3000
     networks:
     - pmoves_api
-    - pmoves_data
 
     deploy:
       resources:
@@ -738,7 +736,6 @@ services:
     - ${KONG_ADMIN_BIND:-0.0.0.0}:${SUPABASE_KONG_ADMIN_PORT:-8001}:8001
     networks:
     - pmoves_api
-    - pmoves_data
 
     deploy:
       resources:
@@ -797,7 +794,6 @@ services:
     - ${SUPABASE_REALTIME_BIND:-127.0.0.1}:${SUPABASE_REALTIME_PORT:-4010}:4000
     networks:
     - pmoves_api
-    - pmoves_data
 
     deploy:
       resources:
@@ -858,7 +854,6 @@ services:
     - ${SUPABASE_STORAGE_BIND:-127.0.0.1}:${SUPABASE_STORAGE_PORT:-5000}:5000
     networks:
     - pmoves_api
-    - pmoves_data
 
     deploy:
       resources:
@@ -920,8 +915,7 @@ services:
     ports:
     - ${SUPABASE_STUDIO_BIND:-127.0.0.1}:${SUPABASE_STUDIO_PORT:-54323}:3000
     networks:
-    - pmoves_api
-    - pmoves_data  # reach supabase-meta, supabase-analytics
+    - pmoves_api  # supabase-meta and analytics reachable via kong on pmoves_api
 
   # ---------------------------------------------------------------------------
   # Supabase imgproxy — image transformation for Storage
@@ -952,7 +946,7 @@ services:
     volumes:
     - supabase-storage-data:/var/lib/storage:ro
     networks:
-    - pmoves_data
+    - pmoves_api
 
   # ---------------------------------------------------------------------------
   # Supabase postgres-meta — database metadata API for Studio
@@ -1022,8 +1016,7 @@ services:
       supabase-analytics:
         condition: service_healthy
     networks:
-    - pmoves_api
-    - pmoves_data  # reach supabase-db, supabase-analytics
+    - pmoves_api  # supabase-db and analytics reachable via kong on pmoves_api
     # Pin upstream resolvers for Deno cold-boot imports. The edge-runtime
     # image fetches https://deno.land/std@...` at worker-bootstrap time;
     # Docker's embedded DNS (127.0.0.11) intermittently fails to forward
@@ -1187,6 +1180,7 @@ services:
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}
     - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
+    - QDRANT__SERVICE__API_KEY=${QDRANT__API_KEY:?Set QDRANT__API_KEY in env.tier-data}
     volumes:
     - qdrant-data:/qdrant/storage
     healthcheck:
@@ -1245,9 +1239,15 @@ services:
     - no-new-privileges:true
     restart: unless-stopped
     environment:
-    - NEO4J_AUTH=${NEO4J_AUTH:-neo4j/${NEO4J_PASSWORD:-pm_kDhuaogcUc1oOOVeGMNCkQ}}
+    - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:?Set NEO4J_PASSWORD in env.tier-data}
     - NEO4J_dbms_security_allow__csv__import__from__file__urls=true
     - NEO4J_server_config_strict__validation_enabled=false
+    # APOC extensions with safe procedure allowlist
+    - NEO4J_apoc_export_file_enabled=true
+    - NEO4J_apoc_import_file_enabled=true
+    - NEO4J_apoc_import_file_use__neo4j__config__true=true
+    - NEO4JLABS_PLUGINS=["apoc"]
+    - NEO4J_dbms_security_procedures_unrestricted=apoc.coll.*,apoc.text.*,apoc.path.*,apoc.algo.*
     - DOCKED_MODE=${DOCKED_MODE:-true}
     - TOPOLOGY_MODE=${TOPOLOGY_MODE:-docked}
     - PARENT_SYSTEM=${PARENT_SYSTEM:-PMOVES.AI}
@@ -1323,6 +1323,7 @@ services:
     - NO_PROXY=
     - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
     - QDRANT_COLLECTION=${QDRANT_COLLECTION:-pmoves_chunks_qwen3}
+    - QDRANT__API_KEY=${QDRANT__API_KEY:?Set QDRANT__API_KEY in env.tier-data}
     - SENTENCE_MODEL=${SENTENCE_MODEL:-all-MiniLM-L6-v2}
     - HIRAG_HTTP_PORT=${HIRAG_HTTP_PORT:-8086}
     - GRAPH_BOOST=${GRAPH_BOOST:-0.15}
@@ -1330,9 +1331,10 @@ services:
     - ENTITY_CACHE_MAX=${ENTITY_CACHE_MAX:-10000}
     - USE_MEILI=${USE_MEILI:-true}
     - MEILI_URL=${MEILI_URL:-http://meilisearch:7700}
+    - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?Set MEILI_MASTER_KEY in env.tier-data}
     - NEO4J_URL=${NEO4J_URL:-bolt://neo4j:7687}
     - NEO4J_USER=${NEO4J_USER:-neo4j}
-    - NEO4J_PASSWORD=${NEO4J_PASSWORD:-pm_kDhuaogcUc1oOOVeGMNCkQ}
+    - NEO4J_PASSWORD=${NEO4J_PASSWORD:?Set NEO4J_PASSWORD in env.tier-data}
     - NEO4J_DICT_REFRESH_SEC=${NEO4J_DICT_REFRESH_SEC:-300}
     - NEO4J_DICT_LIMIT=${NEO4J_DICT_LIMIT:-1000}
     - TAILSCALE_ONLY=${TAILSCALE_ONLY:-false}
@@ -1535,6 +1537,7 @@ services:
     - HTTPS_PROXY=
     - NO_PROXY=
     - MEILI_URL=${MEILI_URL:-http://meilisearch:7700}
+    - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?Set MEILI_MASTER_KEY in env.tier-data}
     - SUPA_REST_URL=${SUPA_REST_URL:-http://supabase-kong:8000/rest/v1}
     - SUPA_REST_INTERNAL_URL=${SUPA_REST_INTERNAL_URL:-http://supabase-kong:8000/rest/v1}
     ports:
@@ -2023,6 +2026,7 @@ services:
     - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
     - QDRANT_COLLECTION=${QDRANT_COLLECTION:-pmoves_chunks_qwen3}
     - QDRANT_RECREATE_ON_DIM_MISMATCH=${QDRANT_RECREATE_ON_DIM_MISMATCH:-false}
+    - QDRANT__API_KEY=${QDRANT__API_KEY:?Set QDRANT__API_KEY in env.tier-data}
     - SENTENCE_MODEL=${SENTENCE_MODEL:-all-MiniLM-L6-v2}
     - INDEXER_NAMESPACE=${INDEXER_NAMESPACE:-pmoves}
     - QUERY_NAMESPACE=${QUERY_NAMESPACE:-*}
@@ -2034,9 +2038,10 @@ services:
     - RERANK_FUSION=${RERANK_FUSION:-mul}
     - USE_MEILI=true
     - MEILI_URL=${MEILI_URL:-http://meilisearch:7700}
+    - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?Set MEILI_MASTER_KEY in env.tier-data}
     - NEO4J_URL=${NEO4J_URL:-bolt://neo4j:7687}
     - NEO4J_USER=${NEO4J_USER:-neo4j}
-    - NEO4J_PASSWORD=${NEO4J_PASSWORD:-pm_kDhuaogcUc1oOOVeGMNCkQ}
+    - NEO4J_PASSWORD=${NEO4J_PASSWORD:?Set NEO4J_PASSWORD in env.tier-data}
     - EMBEDDING_BACKEND=${EMBEDDING_BACKEND:-tensorzero}
     - USE_OLLAMA_EMBED=${USE_OLLAMA_EMBED:-false}
     - OLLAMA_URL=${OLLAMA_URL:-http://pmoves-ollama:11434}
@@ -2115,6 +2120,7 @@ services:
     - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
     - QDRANT_COLLECTION=${QDRANT_COLLECTION:-pmoves_chunks_qwen3}
     - QDRANT_RECREATE_ON_DIM_MISMATCH=${QDRANT_RECREATE_ON_DIM_MISMATCH:-false}
+    - QDRANT__API_KEY=${QDRANT__API_KEY:?Set QDRANT__API_KEY in env.tier-data}
     - SENTENCE_MODEL=${SENTENCE_MODEL:-all-MiniLM-L6-v2}
     - HIRAG_HTTP_PORT=${HIRAG_HTTP_PORT:-8086}
     - GRAPH_BOOST=${GRAPH_BOOST:-0.15}
@@ -2122,9 +2128,10 @@ services:
     - ENTITY_CACHE_MAX=${ENTITY_CACHE_MAX:-10000}
     - USE_MEILI=${USE_MEILI:-true}
     - MEILI_URL=${MEILI_URL:-http://meilisearch:7700}
+    - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:?Set MEILI_MASTER_KEY in env.tier-data}
     - NEO4J_URL=${NEO4J_URL:-bolt://neo4j:7687}
     - NEO4J_USER=${NEO4J_USER:-neo4j}
-    - NEO4J_PASSWORD=${NEO4J_PASSWORD:-pm_kDhuaogcUc1oOOVeGMNCkQ}
+    - NEO4J_PASSWORD=${NEO4J_PASSWORD:?Set NEO4J_PASSWORD in env.tier-data}
     - NEO4J_DICT_REFRESH_SEC=${NEO4J_DICT_REFRESH_SEC:-300}
     - NEO4J_DICT_LIMIT=${NEO4J_DICT_LIMIT:-1000}
     - TAILSCALE_ONLY=${TAILSCALE_ONLY:-false}
@@ -2201,6 +2208,7 @@ services:
     - NO_PROXY=
     - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
     - QDRANT_COLLECTION=${QDRANT_COLLECTION:-pmoves_chunks_qwen3}
+    - QDRANT__API_KEY=${QDRANT__API_KEY:?Set QDRANT__API_KEY in env.tier-data}
     - SENTENCE_MODEL=${SENTENCE_MODEL:-all-MiniLM-L6-v2}
     - INDEXER_NAMESPACE=${INDEXER_NAMESPACE:-pmoves}
     - QUERY_NAMESPACE=${QUERY_NAMESPACE:-*}

--- a/pmoves/env.tier-data.example
+++ b/pmoves/env.tier-data.example
@@ -5,29 +5,40 @@
 # Scope: Infrastructure credentials ONLY (no external API keys)
 #
 # Copy to `env.tier-data` and fill in real values. The file is gitignored.
+# All values below are REQUIRED — services fail-closed if missing.
+# Generate secrets with: openssl rand -hex 32
 # =============================================================================
 
-# Meilisearch (Full-text Search)
-# REQUIRED: Generate with `openssl rand -hex 32`
-MEILI_MASTER_KEY=changeme
+# Qdrant (Vector Database)
+# REQUIRED: API key for all read/write operations
+# Generate with `openssl rand -hex 32`
+QDRANT__API_KEY=
 
-# MinIO Credentials (S3-compatible Object Storage)
-# Standardized across all tiers for consistency
-MINIO_ROOT_USER=minioadmin
-MINIO_ROOT_PASSWORD=minioadmin
-MINIO_USER=minioadmin
-MINIO_PASSWORD=minioadmin
+# Meilisearch (Full-text Search)
+# REQUIRED: Master key for all API operations
+# Generate with `openssl rand -hex 32`
+MEILI_MASTER_KEY=
 
 # Neo4j Credentials (Knowledge Graph)
-NEO4J_AUTH=neo4j/changeme
-NEO4J_PASSWORD=changeme
+# REQUIRED: Password for bolt:// authentication
+# Generate with `openssl rand -hex 24`
+NEO4J_PASSWORD=
 
-# PostgreSQL Credentials (pgvector)
+# MinIO Credentials (S3-compatible Object Storage)
+# REQUIRED: Generate unique credentials — never use defaults
+MINIO_ROOT_USER=
+MINIO_ROOT_PASSWORD=
+MINIO_USER=
+MINIO_PASSWORD=
+
+# PostgreSQL Credentials (pgvector — set in env.tier-supabase)
+# NOTE: Supabase Postgres credentials are managed via env.tier-supabase
+# These vars are only used by non-Supabase Postgres consumers
 POSTGRES_DB=pmoves
 POSTGRES_HOSTNAME=supabase-db
-POSTGRES_PASSWORD=changeme
 POSTGRES_PORT=5432
 POSTGRES_USER=pmoves
+POSTGRES_PASSWORD=
 
 # Service Admin Credentials (optional)
 SERVICE_PASSWORD_ADMIN=


### PR DESCRIPTION
## 🔒 Data-Tier Authentication Hardening

**Follow-up to PR #1332** — images are patched, now we lock the doors.

### Problem
After the CVE image upgrades (PR #1332), 3 of 4 data-tier services on `pmoves_data` Docker network had **NO authentication**: a single compromised app service could laterally reach all data stores.

### Changes

| Service | Before | After |
|---------|--------|-------|
| **Qdrant** v1.16.0 | No API key — open read/write | `QDRANT__SERVICE__API_KEY` (fail-closed, `${QDRANT__API_KEY:?...}`) |
| **Meilisearch** v1.34.1 | ✅ Already has `MEILI_MASTER_KEY` (fail-closed) | No change — verified correct |
| **Neo4j** v5.26.22 | Auth with hardcoded password fallback | Fail-closed `NEO4J_PASSWORD`, APOC plugin + safe procedure allowlist |
| **Supabase internals** | Kong/PostgREST/GoTrue/Realtime/Storage/Studio/ImgProxy/EdgeFunctions on `pmoves_data` | Isolated to `pmoves_api` only — no direct data-tier access |
| **env.tier-data.example** | Hardcoded `changeme` / `minioadmin` credentials | Empty placeholders with generation instructions (PMOVES fail-closed rule) |

### Files Modified

#### `pmoves/docker-compose.yml` (monolithic)
- **qdrant**: Added `QDRANT__SERVICE__API_KEY=${QDRANT__API_KEY:?Set QDRANT__API_KEY in env.tier-data}`
- **neo4j**: Replaced fallback `NEO4J_AUTH` with fail-closed `${NEO4J_PASSWORD:?...}`, added APOC extensions (`NEO4JLABS_PLUGINS`), safe procedure allowlist (`apoc.coll.*`, `apoc.text.*`, `apoc.path.*`, `apoc.algo.*`)
- **hi-rag-gateway**: Added `QDRANT__API_KEY`, `MEILI_MASTER_KEY`, fail-closed `NEO4J_PASSWORD`
- **hi-rag-gateway-v2**: Same auth key additions
- **hi-rag-gateway-gpu**: Same auth key additions
- **extract-worker**: Added `QDRANT__API_KEY`, `MEILI_MASTER_KEY`
- **Supabase H-05**: Removed `pmoves_data` from kong, postgrest, gotrue, realtime, storage, studio, imgproxy, edge-functions networks

#### `pmoves/docker-compose.core.yml` (overlay)
- Same qdrant and neo4j changes as monolithic
- Same Supabase H-05 network isolation

#### `pmoves/env.tier-data.example`
- Removed all `changeme` and `minioadmin` hardcoded defaults (PMOVES hard rule violation)
- Added `QDRANT__API_KEY` placeholder
- Added `openssl rand -hex 32` generation instructions

### APOC Procedure Allowlist Rationale
Only safe read-only/data procedures are unrestricted:
- `apoc.coll.*` — collection operations (no file/system access)
- `apoc.text.*` — text manipulation (no side effects)
- `apoc.path.*` — graph traversal (read-only)
- `apoc.algo.*` — algorithm procedures (read-only)

**Explicitly blocked**: `apoc.load.*` (SSRF risk), `apoc.export.*` (data exfil), `apoc.import.*` (data injection), `apoc.systemdb.*` (hash extraction), `apoc.config.*` (secret leak).

### Network Isolation (H-05)
Supabase internal services now only on `pmoves_api`:
- `supabase-kong` → API gateway, routes through postgrest
- `supabase-postgrest` → REST API, connects to DB via internal Docker DNS
- `supabase-gotrue` → Auth, connects to DB directly
- `supabase-realtime` → WebSocket, connects to DB directly
- `supabase-storage` → S3-compatible, connects to DB via postgrest
- `supabase-studio` → UI, connects via kong
- `supabase-imgproxy` → Image transform, data via volume mount
- `supabase-edge-functions` → Deno runtime, connects via kong

**Still on `pmoves_data`** (need direct DB access): `supabase-db`, `supabase-meta`, `supabase-analytics`, `supabase-vector`, `supabase-pooler`

### n8n Submodule
The `PMOVES-n8n/` submodule is empty in this shallow clone. The base image was already bumped to `n8n:2.1.5` in PR #1332, but the custom `pmoves/n8n:2.1.5-runtime` image needs to be rebuilt. **Separate follow-up required** for submodule update.

### Migration Steps
1. Generate secrets: `openssl rand -hex 32` (Qdrant, Meilisearch), `openssl rand -hex 24` (Neo4j)
2. Add to `env.tier-data` (gitignored):
   ```
   QDRANT__API_KEY=<generated>
   MEILI_MASTER_KEY=<generated>
   NEO4J_PASSWORD=<generated>
   ```
3. `docker compose up -d` — services will fail-closed if secrets missing
4. Verify: `curl -H "api-key: $QDRANT__API_KEY" http://localhost:6333/collections`

### Breaking Change
⚠️ **Yes** — existing deployments without `QDRANT__API_KEY` and `NEO4J_PASSWORD` in `env.tier-data` will fail to start (by design — fail-closed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced data processing capabilities with expanded database query functions.

* **Security**
  * Enforced required credentials for API keys and database passwords instead of defaults.
  * Improved service network isolation for better security boundaries.

* **Chores**
  * Updated infrastructure configuration to align with security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->