### PR TITLE
fix(security): remove hardcoded minioadmin from tracked env file

### DIFF
--- a/pmoves/.gitignore
+++ b/pmoves/.gitignore
@@ -47,3 +47,4 @@ env.tier-vpn
 env.tier-worker
 env.tier-supabase.urlencoded
 env.z890
+env.presign.additions

--- a/pmoves/env.presign.additions.example
+++ b/pmoves/env.presign.additions.example
@@ -1,14 +1,15 @@
 # Managed by pmoves/scripts/bootstrap_env.py
-# Generated at 2026-02-28T18:09:56.633763+00:00Z
+# Template — copy to env.presign.additions and fill in real values
+# env.presign.additions is gitignored; never commit secrets
 
 MINIO_ENDPOINT=minio:9000
-MINIO_ACCESS_KEY=minioadmin
-MINIO_SECRET_KEY=minioadmin
+MINIO_ACCESS_KEY=your_minio_access_key_here
+MINIO_SECRET_KEY=your_minio_secret_key_here
 MINIO_SECURE=false
 AWS_DEFAULT_REGION=us-east-1
 ALLOWED_BUCKETS=cataclysm-assets,cataclysm-outputs
 
 # Preserved entries (not managed by bootstrap):
-PRESIGN_SHARED_SECRET=change_me
+PRESIGN_SHARED_SECRET=your_presign_shared_secret_here
 # Presign microservice (MinIO/S3)
 # Plain values only — ${VAR:-default} shell expansion does NOT work in Docker env_file


### PR DESCRIPTION
## Summary

PMOVES hard rule violation: **no hardcoded credential fallbacks (changeme, minioadmin)**.

`env.presign.additions` was tracked in git with plaintext `minioadmin` credentials.

### Changes
- Remove `env.presign.additions` from git tracking (file remains on disk, untracked)
- Add `env.presign.additions` to `.gitignore`
- Create `env.presign.additions.example` with `your_X_here` placeholder pattern

### Verification
- `post-merge-verify.sh` check 9 no longer flags minioadmin
- Consistent with `env.tier-data.example` placeholder pattern (PR #1334)