### PR TITLE
fix(channel-monitor): enumerate @-handle channels via /videos tab

### DIFF
--- a/pmoves/services/channel-monitor/channel_monitor/monitor.py
+++ b/pmoves/services/channel-monitor/channel_monitor/monitor.py
@@ -448,6 +448,31 @@ def _extract_channel_id_from_url(url: Optional[str]) -> Optional[str]:
     return None
 
 
+def _normalize_channel_url(url: str) -> str:
+    """Append `/videos` tab to YouTube channel URLs so yt-dlp enumerates the
+    video list instead of returning tab metadata entries. Leaves playlists,
+    watch URLs, and non-YouTube URLs unchanged."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return url
+    host = (parsed.netloc or "").lower()
+    if "youtube.com" not in host and "youtu.be" not in host:
+        return url
+    parts = [segment for segment in parsed.path.split("/") if segment]
+    if not parts:
+        return url
+    is_handle = parts[0].startswith("@")
+    is_channel_path = parts[0].lower() == "channel" and len(parts) >= 2
+    if not (is_handle or is_channel_path):
+        return url
+    tab_index = 1 if is_handle else 2
+    if len(parts) > tab_index:
+        return url
+    base = url.rstrip("/")
+    return f"{base}/videos"
+
+
 def _extract_channel_handle(channel: Dict[str, Any]) -> Optional[str]:
     candidates = [
         channel.get("channel_id"),
@@ -690,12 +715,14 @@ class ChannelMonitor:
                 if playlist_target:
                     videos = await self._fetch_youtube_flat(playlist_target, cookies_path, max_videos)
             elif source_url:
-                videos = await self._fetch_youtube_flat(source_url, cookies_path, max_videos)
+                videos = await self._fetch_youtube_flat(
+                    _normalize_channel_url(source_url), cookies_path, max_videos
+                )
             else:
                 if self.config["global_settings"].get("use_rss_feed", True) and channel_id:
                     videos = await self._fetch_via_rss(channel_id)
                 elif channel_id:
-                    playlist_url = f"https://www.youtube.com/channel/{channel_id}"
+                    playlist_url = f"https://www.youtube.com/channel/{channel_id}/videos"
                     videos = await self._fetch_youtube_flat(playlist_url, cookies_path, max_videos)
         elif platform == "soundcloud" and source_url:
             videos = await self._fetch_soundcloud(source_url, cookies_path, max_videos)

--- a/pmoves/services/channel-monitor/tests/test_monitor.py
+++ b/pmoves/services/channel-monitor/tests/test_monitor.py
@@ -83,7 +83,11 @@ if "yt_dlp" not in sys.modules:
     yt_dlp_stub.YoutubeDL = _YoutubeDL  # type: ignore[attr-defined]
     sys.modules["yt_dlp"] = yt_dlp_stub
 
-from channel_monitor.monitor import ChannelMonitor, _extract_youtube_video_id  # noqa: E402
+from channel_monitor.monitor import (  # noqa: E402
+    ChannelMonitor,
+    _extract_youtube_video_id,
+    _normalize_channel_url,
+)
 
 
 def _build_monitor(tmp_path, config_name: str = "channel.json") -> ChannelMonitor:
@@ -506,6 +510,34 @@ def test_extract_youtube_video_id_allows_valid_hosts(url, expected):
 )
 def test_extract_youtube_video_id_rejects_spoofed_hosts(url):
     assert _extract_youtube_video_id(url) is None
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # Handle channels get /videos appended so yt-dlp enumerates the video
+        # list; without the tab, extract_flat returns 3 tab entries instead.
+        ("https://www.youtube.com/@ColeMedin", "https://www.youtube.com/@ColeMedin/videos"),
+        ("https://www.youtube.com/@ColeMedin/", "https://www.youtube.com/@ColeMedin/videos"),
+        # Channel-ID URLs likewise need the /videos tab.
+        (
+            "https://www.youtube.com/channel/UCMwVTLZIRRUyyVrkjDpn4pA",
+            "https://www.youtube.com/channel/UCMwVTLZIRRUyyVrkjDpn4pA/videos",
+        ),
+        # Already-tabbed or non-channel URLs pass through unchanged.
+        ("https://www.youtube.com/@ColeMedin/videos", "https://www.youtube.com/@ColeMedin/videos"),
+        ("https://www.youtube.com/@ColeMedin/shorts", "https://www.youtube.com/@ColeMedin/shorts"),
+        ("https://www.youtube.com/@ColeMedin/community", "https://www.youtube.com/@ColeMedin/community"),
+        (
+            "https://www.youtube.com/playlist?list=PLGupOT04oMfok7S8W8Js7lZZIlhM8ufc8",
+            "https://www.youtube.com/playlist?list=PLGupOT04oMfok7S8W8Js7lZZIlhM8ufc8",
+        ),
+        ("https://www.youtube.com/watch?v=abc123", "https://www.youtube.com/watch?v=abc123"),
+        ("https://soundcloud.com/darkxside", "https://soundcloud.com/darkxside"),
+    ],
+)
+def test_normalize_channel_url(url, expected):
+    assert _normalize_channel_url(url) == expected
 
 
 def test_create_youtube_control_request_persists_pending_row(tmp_path):


### PR DESCRIPTION
## Summary
- yt-dlp's `extract_flat` against `youtube.com/@Handle` (no tab suffix) returns 3 *tab* metadata entries rather than videos, producing a single pseudo-row in `pmoves.channel_monitoring` instead of the channel's video list
- 9 of 10 configured @-handle channels have been stuck since 2026-02-25 (only IndyDevDan works, because it was manually seeded via `/yt/ingest` during Session 8)
- Fix appends `/videos` to channel-root URLs (`/@handle` or `/channel/UC...`) before handing off to yt-dlp

## Root cause
`_yt_dlp_extract` at `channel_monitor/monitor.py:1102` iterates `info["entries"]`. For a channel root URL, yt-dlp returns 3 Tab entries (Home/Videos/Shorts); our loop takes `entry.get("id")` → channel UC id, `webpage_url` → `/@Handle/videos`, producing `(channel_id, video_id=UC..., url=/videos)`. With `INSERT ON CONFLICT DO NOTHING` and `max_videos_per_check=10`, this pseudo-row dedupes to itself on every subsequent check, starving the enumeration forever.

## The fix
New `_normalize_channel_url` helper:
- `/@Handle` → `/@Handle/videos`
- `/channel/UC...` → `/channel/UC.../videos`
- `/@Handle/videos` / `/shorts` / `/community` → unchanged
- `playlist?list=...`, `watch?v=...`, non-YouTube URLs → unchanged

Applied at both YouTube call sites in `check_single_channel` (`source_url` branch + `channel_id` fallback).

## Test plan
- [x] Unit tests: 9 parametrized cases in `test_normalize_channel_url` (handle/channel-ID/playlist/watch/non-YouTube, trailing-slash, already-tabbed) — all pass
- [x] Live test: rebuilt `pmoves-channel-monitor` image, restarted via env chain, triggered `/api/monitor/check-now` for all 10 stuck @-handle channels
- [x] Verified DB state: each channel now has 10 real video rows + original pseudo-row (101 new real videos total discovered across the 10 channels)
- [x] Cole Medin queue confirmed: 11 rows with real video_ids and titles (e.g. "I've Used Claude Code for 2,000+ Hours...", "The Next Evolution of AI Coding Is Harnesses...")

## Follow-ups (out of scope for this PR)
- Pre-existing bug in `scripts/channel_monitor_up.sh`: the script pre-interpolates `CHANNEL_MONITOR_DATABASE_URL` in-shell with only `env.shared` loaded (before tier overlays), passing the result as an env override that beats compose's `--env-file` chain and breaks DB auth. Workaround: source `scripts/with-env.sh` in full before running the up command.
- Clean up 10 leftover pseudo-rows (`video_id = UC...`, `url = .../videos`) from `pmoves.channel_monitoring` once it's clear nothing references them as ingested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced YouTube channel monitoring by ensuring channel URLs are consistently normalized to point to the videos tab, improving reliability when fetching video content from monitored channels.

* **Tests**
  * Added comprehensive test coverage for YouTube channel URL normalization, including verification across various URL formats, platforms, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->