### PR TITLE
fix(tensorzero): disable OTLP trace export by default

### DIFF
--- a/pmoves/tensorzero/config/tensorzero.toml
+++ b/pmoves/tensorzero/config/tensorzero.toml
@@ -9,9 +9,14 @@
 enabled = true
 async_writes = true
 
-# OTLP export — re-enabled P7 P0.2 (OTel collector in docker-compose.tracing.yml)
+# OTLP export — disabled by default so the gateway boots without the tracing
+# overlay. P7 P0.2 enabled this against docker-compose.tracing.yml, but the
+# tracing stack isn't part of the default bring-up; TensorZero 2026.1.8 panics
+# with "invalid URI . Reason empty string" when enabled=true and the
+# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT env var is unset. Re-enable together
+# with the tracing overlay and a populated endpoint.
 [gateway.export.otlp.traces]
-enabled = true
+enabled = false
 format = "opentelemetry"
 
 # --- Chat models: Agent Zero orchestration (local GPU and edge) ------------


### PR DESCRIPTION
## Summary
- TensorZero 2026.1.8 gateway panics at startup with `invalid URI . Reason empty string` whenever `[gateway.export.otlp.traces] enabled = true` AND the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env var resolves to an empty string
- Default compose sets that env var to `${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-}` (empty by default), so the default bring-up hits the panic and enters a restart loop
- P7 P0.2 ([3ad81f1684](https://github.com/POWERFULMOVES/PMOVES.AI/commit/3ad81f1684)) enabled OTLP against the `docker-compose.tracing.yml` overlay, which is opt-in — toml and default bring-up drifted

## Downstream damage
TZ restart-looping drops its Docker DNS entry. Hi-RAG v2 tries to resolve `tensorzero-gateway` for embedding calls and gets NXDOMAIN. Embeddings fail. Hi-RAG indexes 0 chunks. Queries return 0 hits — **exactly the Session 8 carry-forward** "Hi-RAG v2 query returns 0 hits despite content being in Qdrant".

## The fix
Flip `enabled = true → false` in `pmoves/tensorzero/config/tensorzero.toml`. Comment documents that re-enabling requires both the tracing overlay and a populated endpoint env var.

Config is bind-mounted `:ro` into the container, so `docker restart pmoves-tensorzero-gateway-1` picks up the change without a rebuild.

## Test plan
- [x] Container boots clean: startup log ends with `OpenTelemetry: disabled` (previously: `Exiting.`)
- [x] TZ healthy via `docker ps` and healthcheck
- [x] Hi-RAG v2 no longer sees `NameResolutionError` on embedding calls
- [x] `POST /yt/emit` for Cole Medin video `XSmI7OYd7iM` returned `{"chunks": 33, "upserted": 33, "lexical_indexed": 33}` (previously hung indefinitely)
- [x] Qdrant point count: 75 → 108 (+33 Cole Medin chunks)
- [x] `POST /hirag/query` with `{"query":"Pi coding agent Archon","top_k":5}` returns 10 ranked hits with scores ~0.42-0.45 and relevant content

## Follow-ups
- Re-enable OTLP export together with the `docker-compose.tracing.yml` overlay and a populated `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (track P7 P0.2 regression)
- Consider a compose-level gate: only inject `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` when non-empty, instead of passing empty string that panics the gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)