### PR TITLE
fix(headscale): replace deprecated acl_policy_path with policy.path

### DIFF
--- a/pmoves/config/headscale/config.yaml
+++ b/pmoves/config/headscale/config.yaml
@@ -22,7 +22,8 @@ db_path: /var/lib/headscale/db.sqlite
 # =============================================================================
 # ACL Policy
 # =============================================================================
-acl_policy_path: /etc/headscale/acl.yaml
+policy:
+  path: /etc/headscale/acl.yaml
 
 # =============================================================================
 # DERP Relay Configuration


### PR DESCRIPTION
## Problem

Latest Headscale image (ghcr.io/juanfont/headscale:latest) removed the `acl_policy_path` config key. Container FATALs on startup:

```
FATAL: The "acl_policy_path" configuration key is deprecated.
Please use "policy.path" instead. "acl_policy_path" has been removed.
```

This was discovered during VPS redeploy — the container entered a crash loop until the config was corrected.

## Fix

Replace deprecated flat key with nested YAML:

```diff
- acl_policy_path: /etc/headscale/acl.yaml
+ policy:
+   path: /etc/headscale/acl.yaml
```

## Files Changed
- `pmoves/config/headscale/config.yaml` — line 25

## Verification
- Container starts successfully with corrected config
- ACL policy is loaded at the same path (`/etc/headscale/acl.yaml`)
- No other config keys affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Headscale configuration structure for Access Control List policy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->