### PR TITLE
fix(headscale): full config rewrite for 0.27.x compat + port bug sweep

### DIFF
--- a/.claude/context/services-catalog.md
+++ b/.claude/context/services-catalog.md
@@ -463,7 +463,7 @@ Comprehensive reference of all production services, ports, APIs, and integration
   - Route advertisement
   - ACL policy enforcement
 - **Key APIs:**
-  - `GET /healthz` - Service health
+  - `GET /health` - Service health
   - `GET /metrics` - Prometheus metrics
   - `POST /api/v1/apikey` - Create auth keys
   - `GET /api/v1/machines` - List connected nodes

--- a/pmoves/config/agent_registry.yaml
+++ b/pmoves/config/agent_registry.yaml
@@ -1335,7 +1335,7 @@ agents:
     class: utility
     primary_type: data
     secondary_type: api
-    port: 8181
+    port: 8096
     health: "/health"
     layers: [L0]
     evolution_stage: base

--- a/pmoves/config/headscale/config.yaml
+++ b/pmoves/config/headscale/config.yaml
@@ -2,28 +2,72 @@
 # PMOVES.AI Headscale Configuration
 # =============================================================================
 # Self-hosted Tailscale control server for VPN mesh networking
+# Compatible with Headscale 0.27.x (latest stable as of 2026-04-21)
 # =============================================================================
 
 # Server URL - externally accessible address for clients
+# WARNING: Must be HTTPS for DERP relay and Noise protocol to work.
+# HTTP is acceptable for tailnet-only access (Tailscale IP as server_url).
 server_url: https://headscale.pmoves.local
 
 # Listen address for the API server
 listen_addr: 0.0.0.0:8096
 
 # Metrics listen address for Prometheus scraping
+# Empty string "" disables metrics endpoint.
 metrics_listen_addr: 0.0.0.0:9090
+
+# Disable update check on startup (recommended for production)
+disable_check_updates: true
+
+# =============================================================================
+# Noise Protocol (TS2021)
+# =============================================================================
+# Required for Tailscale v2 Noise protocol. Auto-generated if missing.
+noise:
+  private_key_path: /var/lib/headscale/noise_private.key
 
 # =============================================================================
 # Database Configuration
 # =============================================================================
-db_type: sqlite3
-db_path: /var/lib/headscale/db.sqlite
+# SQLite is the default and recommended for most deployments.
+# Postgres support exists but is "highly discouraged" — legacy only.
+database:
+  type: sqlite
+  sqlite:
+    path: /var/lib/headscale/db.sqlite
+    write_ahead_log: true
 
 # =============================================================================
 # ACL Policy
 # =============================================================================
+# mode: "file" (default) reads from policy.path
+# mode: "database" reads from database (for dynamic policies)
 policy:
+  mode: file
   path: /etc/headscale/acl.yaml
+
+# =============================================================================
+# IP Allocation Prefixes
+# =============================================================================
+# MUST be subsets of CGNAT (100.64.0.0/10) and Tailscale ULA (fd7a:115c:a1e0::/48).
+# Using ranges outside these will cause undefined behaviour.
+prefixes:
+  v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48
+
+# =============================================================================
+# DNS Configuration
+# =============================================================================
+# MagicDNS is auto-enabled when base_domain is set.
+# base_domain must differ from the server_url domain.
+dns:
+  base_domain: pmoves.local
+  override_local_dns: true
+  nameservers:
+    global:
+      - 1.1.1.1
+      - 1.0.0.1
 
 # =============================================================================
 # DERP Relay Configuration
@@ -34,68 +78,24 @@ derp:
     enabled: false
   urls:
     - https://controlplane.tailscale.com/derpmap/default
-  # Optional: Override paths for specific DERP regions
-  paths:
-    - /etc/headscale/derp.yaml
+  auto_update_enabled: true
+  update_frequency: 3h
 
 # =============================================================================
-# IP Allocation
+# Node Configuration
 # =============================================================================
-# CGNAT range for Tailscale
-prefixes:
-  - fd7a:115c:a1e0::/48  # IPv6
-  - 100.64.0.0/10        # IPv4
+node:
+  expiry: 0
+  ephemeral:
+    inactivity_timeout: 30m
 
 # =============================================================================
-# DNS Configuration
-# =============================================================================
-dns:
-  # Global nameservers
-  nameservers:
-    global:
-      - 1.1.1.1
-      - 1.0.0.1
-
-  # Split DNS resolutions for specific domains
-  domains:
-    - pmoves.local
-    - pmoves-internal.local
-
-  # Magic DNS (enables <hostname>.<namespace>.headscale resolution)
-  magic_dns: true
-
-  # Base domain for MagicDNS
-  base_domain: pmoves.local
-# =============================================================================
-# Noise Protocol (Tailscale v2)
-# =============================================================================
-noise:
-  private_key_path: /var/lib/headscale/noise_private.key
-
-# =============================================================================
-# Logging Configuration
+# Logging
 # =============================================================================
 log:
-  format: text  # text or json
-  level: info   # debug, info, warn, error
+  level: info
+  format: text
 
-# =============================================================================
-# Client Configuration
-# =============================================================================
-# Randomize client port for NAT traversal
-randomize_client_port: true
-
-# Disable updates check
-disable_updates_check: false
-
-# =============================================================================
-# Security
-# =============================================================================
-# Enable/disable legacy CLI features
-ephemeral_node_inactivity_timeout: 30m
-
-# =============================================================================
-# Experimental Features
-# =============================================================================
-# Enable WireGuard requested port (for better NAT traversal)
-# wireguard_port: 0
+# Disable sending logs to Tailscale Inc.
+logtail:
+  enabled: false

--- a/pmoves/configs/agent-teams.yaml
+++ b/pmoves/configs/agent-teams.yaml
@@ -126,7 +126,7 @@ teams:
     agents:
       - mesh_agent        # Node announcer
       - container_agent   # Port 8111 — Docker networking diagnostics + sidecar bridge
-      - headscale         # Port 8181 — Mesh VPN
+      - headscale         # Port 8096 — Mesh VPN
       - vps_fleet_manager # Hostinger KVM orchestration
       - nemoclaw          # Jetson edge GPU agent (hybrid: Kilo Code + Agent Zero subordinate)
 

--- a/pmoves/configs/claws/claude-md/kvm2.md
+++ b/pmoves/configs/claws/claude-md/kvm2.md
@@ -23,7 +23,7 @@ You may NOT: run docker, access databases, manage agents, or modify application 
 
 | Service | Port | Purpose |
 |---------|------|---------|
-| Headscale | 8181 | Mesh VPN control plane |
+| Headscale | 8096 | Mesh VPN control plane |
 | Cloudflared | — | Cloudflare tunnel daemon |
 | Tailscale | — | Mesh networking |
 

--- a/pmoves/configs/tac_trees/agent-teams-taxonomy.tac.yaml
+++ b/pmoves/configs/tac_trees/agent-teams-taxonomy.tac.yaml
@@ -391,7 +391,7 @@ root:
           task: "Agent roster"
           context: |
             mesh_agent        — No HTTP port — Node announcer (NATS every 15s)
-            headscale         — Port 8181 — Mesh VPN coordination
+            headscale         — Port 8096 — Mesh VPN coordination
             vps_fleet_manager — Hostinger KVM orchestration
           agent_hint: codex
 

--- a/pmoves/docker-compose.remote.yml
+++ b/pmoves/docker-compose.remote.yml
@@ -57,7 +57,7 @@ services:
     profiles:
       - remote
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8096/metrics"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:8096/health"]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/pmoves/docs/AGENTS/PMOVES_AGENT_TOPOLOGY.md
+++ b/pmoves/docs/AGENTS/PMOVES_AGENT_TOPOLOGY.md
@@ -109,7 +109,7 @@ graph TD
         grafana["Grafana<br/>:3000"]:::utility
         loki["Loki<br/>:3100"]:::utility
         n8n_wf["n8n<br/>:5678"]:::utility
-        headscale["Headscale<br/>:8181"]:::utility
+         headscale["Headscale<br/>:8096"]:::utility
         rustdesk["RustDesk<br/>:21115"]:::utility
         invidious["Invidious<br/>:3333"]:::utility
     end

--- a/pmoves/docs/TAC/TAC_TAILSCALE.md
+++ b/pmoves/docs/TAC/TAC_TAILSCALE.md
@@ -10,7 +10,7 @@
 | **Control Plane** | Tailscale Cloud (Headscale planned) |
 | **Ports** | — (overlay network, no dedicated port) |
 | **Health** | `tailscale status` / `tailscale ping <host>` |
-| **Metrics** | Headscale: `GET :8181/metrics` (when deployed) |
+| **Metrics** | Headscale: `GET :8096/metrics` (when deployed) |
 | **Submodules** | [`PMOVES-Tailscale`](../../PMOVES-Tailscale/), [`PMOVES-Headscale`](../../PMOVES-Headscale/) |
 | **Docker Profile** | Standalone (`docker-compose.tailscale.yml`) |
 | **Tier** | api (cross-cutting infrastructure) |

--- a/pmoves/env.tier-vpn.example
+++ b/pmoves/env.tier-vpn.example
@@ -15,7 +15,7 @@
 HEADSCALE_SERVER_URL=https://headscale.pmoves.local
 HEADSCALE_PORT=8096
 # Generate with: openssl rand -hex 32
-HEADSCALE_API_KEY=change-me-generated-secret
+# HEADSCALE_API_KEY must be set in env.tier-vpn (not committed)
 HEADSCALE_ADDR=headscale:8096
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Headscale 0.27.x removed ALL flat config keys. Our config.yaml had 4 FATAL issues that crash on startup. Additionally, port 8181 was incorrectly referenced in 6 files (actual port is 8096).

## Config Fixes (FATAL — crash on 0.27.x)

| Old (FATAL) | New (0.27.x) |
|-------------|---------------|
| db_type: sqlite3 | database.type: sqlite |
| db_path: ... | database.sqlite.path: ... |
| prefixes: [list] | prefixes.v4: / prefixes.v6: |
| dns.domains: [...] | dns.base_domain: |
| acl_policy_path | policy.path (fixed in PR #1339) |

Full rewrite to nested schema per https://headscale.net/stable/ref/configuration/

## Port Bug Sweep (8181 → 8096)

- agent_registry.yaml
- agent-teams.yaml
- agent-teams-taxonomy.tac.yaml
- PMOVES_AGENT_TOPOLOGY.md
- TAC_TAILSCALE.md
- kvm2.md
- services-catalog.md (/healthz → /health)

## Other Fixes
- docker-compose.remote.yml: healthcheck /metrics → /health
- env.tier-vpn.example: removed HEADSCALE_API_KEY=change-me (hard rule #7)

## Files Changed (10)

## Research Basis

Based on 809-line research report covering: latest config schema, Docker best practices, Hostinger API compatibility, security analysis, and upgrade path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated Headscale service port from 8181 to 8096 across all configurations and documentation.
  * Corrected health check endpoint to use the appropriate Headscale health API.

* **Configuration**
  * Upgraded Headscale configuration schema to align with newer version requirements.
  * Improved security by requiring API key configuration through environment setup rather than default values.

* **Documentation**
  * Updated topology diagrams and service documentation to reflect new port assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->