### PR TITLE
fix(headscale): resolve review threads — base_domain suffix, setup script, compose comment

### DIFF
--- a/pmoves/config/headscale/config.yaml
+++ b/pmoves/config/headscale/config.yaml
@@ -60,9 +60,9 @@ prefixes:
 # DNS Configuration
 # =============================================================================
 # MagicDNS is auto-enabled when base_domain is set.
-# base_domain must differ from the server_url domain.
+# base_domain must be disjoint from server_url hostname (Headscale 0.27.x validation).
 dns:
-  base_domain: pmoves.local
+  base_domain: ts.pmoves.net
   override_local_dns: true
   nameservers:
     global:

--- a/pmoves/deploy/compose/headscale-standalone.yml
+++ b/pmoves/deploy/compose/headscale-standalone.yml
@@ -12,7 +12,7 @@
 #   - Relative volume paths resolve to /docker/{project-name}/ on VPS
 #
 # Config files (config.yaml, acl.yaml) must be uploaded separately via SSH
-# to /docker/headscale/config/ before or after compose deployment.
+# to /docker/{project-name}/config/ before or after compose deployment.
 # =============================================================================
 
 services:

--- a/pmoves/scripts/setup-remote-desktop.sh
+++ b/pmoves/scripts/setup-remote-desktop.sh
@@ -23,10 +23,19 @@ if [ ! -f "$PROJECT_ROOT/env.tier-vpn" ]; then
 fi
 
 # Generate Headscale API key if not set
-if grep -q "change-me-generated-secret" "$PROJECT_ROOT/env.tier-vpn"; then
+# Handles three cases: (1) sentinel from old example → replace,
+# (2) real key already set → skip, (3) key absent → append
+if grep -q '^HEADSCALE_API_KEY=change-me-generated-secret' "$PROJECT_ROOT/env.tier-vpn" 2>/dev/null; then
+    echo "🔑 Replacing placeholder Headscale API key..."
+    API_KEY=$(openssl rand -hex 32)
+    sed -i "s/^HEADSCALE_API_KEY=change-me-generated-secret/HEADSCALE_API_KEY=$API_KEY/" "$PROJECT_ROOT/env.tier-vpn"
+    echo "✅ API key generated and saved."
+elif grep -q '^HEADSCALE_API_KEY=' "$PROJECT_ROOT/env.tier-vpn" 2>/dev/null; then
+    echo "🔑 HEADSCALE_API_KEY already set in env.tier-vpn."
+else
     echo "🔑 Generating new Headscale API key..."
     API_KEY=$(openssl rand -hex 32)
-    sed -i "s/HEADSCALE_API_KEY=change-me-generated-secret/HEADSCALE_API_KEY=$API_KEY/" "$PROJECT_ROOT/env.tier-vpn"
+    echo "HEADSCALE_API_KEY=$API_KEY" >> "$PROJECT_ROOT/env.tier-vpn"
     echo "✅ API key generated and saved."
 fi
 


### PR DESCRIPTION
## Summary

Resolves substantive review threads from merged PRs #1340 and #1342.

### Changes

| File | Issue | Fix |
|------|-------|-----|
| `pmoves/config/headscale/config.yaml` | `base_domain: pmoves.local` is a dot-suffix of `server_url` hostname `headscale.pmoves.local` — Headscale 0.27.x rejects at startup (isSafeServerURL validation) | Changed to `ts.pmoves.net` (disjoint domain) |
| `pmoves/scripts/setup-remote-desktop.sh` | Removing `HEADSCALE_API_KEY=change-me-generated-secret` sentinel broke the grep+sed key generation flow; old env files with sentinel would be skipped | Three-way conditional: (1) sentinel present → replace, (2) real key present → skip, (3) absent → append |
| `pmoves/deploy/compose/headscale-standalone.yml` | Comment hardcoded `/docker/headscale/config/` — wrong if project name differs | Changed to `/docker/{project-name}/config/` |

### Review Threads Addressed

- **#1340 thread 1** (CodeRabbit, config.yaml): ✅ Fixed — base_domain now disjoint
- **#1340 thread 5** (CodeRabbit, env.tier-vpn.example): ✅ Fixed — setup script handles all three cases without restoring hardcoded sentinel
- **#1340 thread 7** (Codex, env.tier-vpn.example): ✅ Fixed — same as above
- **#1342 thread 2** (Codex, standalone compose): ✅ Fixed — generic path placeholder

### Review Threads Dismissed (with justification)

- **#1340 threads 2-4** (CodeRabbit, port 8096 collision): Pre-existing — cipher_memory claimed 8096 before headscale was changed. headscale 8096 is correct per docs. Separate PR needed to reassign cipher_memory port.
- **#1340 thread 6** (Codex, node: block): Incorrect — `node.ephemeral.inactivity_timeout` IS the 0.27.x nested format. The flat `ephemeral_node_inactivity_timeout` was the OLD format that causes FATAL errors.
- **#1342 thread 1** (Codex, services-catalog): Incorrect — headscale entry exists at line 457, rustdesk at line 474 of services-catalog.md.

### SPARK Pre-Push Review

Code-reviewer subordinate caught a credential handling edge case: old env files with sentinel would be incorrectly treated as "already set". Fixed with three-way conditional before push.