### PR TITLE
fix(ports): reassign cipher_memory from 8096 to 8105 — source of truth files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,11 +62,11 @@ PMOVES.AI is a **production-ready multi-agent orchestration platform** featuring
 - Triggers ingestion when new content detected
 - Posts to PMOVES.YT `/yt/ingest` endpoint
 
-**Cipher Memory** [Port 8096]
+**Cipher Memory** [Port 8105]
 - Knowledge-graph memory for Claude Code and agents (Neo4j backend)
 - MCP bridge at `pmoves-cipher-mcp/` (stdio transport)
-- API: `POST http://localhost:8096/api/memory`, `GET /api/memory/search?q=...`
-- Health: `GET http://localhost:8096/health`
+- API: `POST http://localhost:8105/api/memory`, `GET /api/memory/search?q=...`
+- Health: `GET http://localhost:8105/health`
 - **Use for:** Persistent agent memory, reasoning traces, pattern storage
 - **MCP tools:** `pmoves_cipher_store`, `pmoves_cipher_search`, `pmoves_cipher_store_reasoning`, `pmoves_cipher_reasoning_patterns`
 
@@ -656,7 +656,7 @@ docker compose --profile agents --profile workers up -d
 - Available for custom integrations
 
 **Configured local MCP servers** (`.claude/mcp.json`)
-- `pmoves-cipher` (SSE on `http://localhost:8096/sse`) for persistent memory lookups and writes
+- `pmoves-cipher` (SSE on `http://localhost:8105/sse`) for persistent memory lookups and writes
 - `docker` (`mcp/docker`) for container inspection through the local Docker socket
 - `hostinger-mcp` for Hostinger API tasks via `HOSTINGER_API_KEY`
 - `tailscale` for tailnet inventory, stale-node cleanup, tag inspection, and ACL operations via `TAILSCALE_API_KEY` + `TAILSCALE_TAILNET`

--- a/.claude/commands/cipher/reasoning.md
+++ b/.claude/commands/cipher/reasoning.md
@@ -11,7 +11,7 @@ Do NOT let a connection failure interrupt your workflow.
 ### Step 1: Health check (silent, non-blocking)
 
 ```bash
-curl -sf --max-time 3 http://localhost:8096/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
+curl -sf --max-time 3 http://localhost:8105/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
 ```
 
 ---

--- a/.claude/commands/cipher/search.md
+++ b/.claude/commands/cipher/search.md
@@ -11,7 +11,7 @@ Do NOT let a connection failure interrupt your workflow.
 ### Step 1: Health check (silent, non-blocking)
 
 ```bash
-curl -sf --max-time 3 http://localhost:8096/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
+curl -sf --max-time 3 http://localhost:8105/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
 ```
 
 ### Step 2a: Search via MCP tool (primary — if CIPHER_UP)

--- a/.claude/commands/cipher/store.md
+++ b/.claude/commands/cipher/store.md
@@ -11,7 +11,7 @@ Do NOT let a connection failure interrupt your workflow.
 ### Step 1: Health check (silent, non-blocking)
 
 ```bash
-curl -sf --max-time 3 http://localhost:8096/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
+curl -sf --max-time 3 http://localhost:8105/health > /dev/null 2>&1 && echo "CIPHER_UP" || echo "CIPHER_DOWN"
 ```
 
 ### Step 2a: Store via MCP tool (primary — if CIPHER_UP)

--- a/.claude/context/services-catalog.md
+++ b/.claude/context/services-catalog.md
@@ -502,7 +502,7 @@ Comprehensive reference of all production services, ports, APIs, and integration
 - **CI Pipeline:** `build-images` (amd64, manual dispatch — via PMOVES-BoTZ submodule)
 
 ### Cipher Memory API (cipher-api)
-- **Port:** 8096 (remapped from internal 3000 to avoid Grafana conflict)
+- **Port:** 8105 (remapped from internal 3000 to avoid Grafana conflict)
 - **Purpose:** Knowledge-graph memory service for Claude Code and agents
 - **Backend:** Node.js + Neo4j
 - **API Endpoints:**
@@ -521,7 +521,7 @@ Comprehensive reference of all production services, ports, APIs, and integration
 - **Dependencies:** Neo4j (shared), NATS
 - **Compose Profile:** `agents`
 - **CI Pipeline:** `local-build-only` (compose `build:` directive)
-- **Health:** `GET http://localhost:8096/health`
+- **Health:** `GET http://localhost:8105/health`
 
 ## CHIT & Geometry Services
 

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -4,7 +4,7 @@
       "command": "uv",
       "args": ["--directory", "./pmoves-cipher-mcp", "run", "python", "-m", "cipher_mcp.server"],
       "env": {
-        "CIPHER_URL": "http://localhost:8096",
+        "CIPHER_URL": "http://localhost:8105",
         "NATS_URL": "nats://nats:pmoves@nats:4222"
       }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,7 @@
     8055,
     8080,
     8086,
-    8096,
+    8105,
     9090
   ],
   "portsAttributes": {
@@ -57,7 +57,7 @@
     "8055": { "label": "Flute Voice Gateway", "onAutoForward": "silent" },
     "8080": { "label": "Agent Zero Orchestrator", "onAutoForward": "silent" },
     "8086": { "label": "Hi-RAG v2 Knowledge Search", "onAutoForward": "notify" },
-    "8096": { "label": "Cipher Memory", "onAutoForward": "silent" },
+    "8105": { "label": "Cipher Memory", "onAutoForward": "silent" },
     "9090": { "label": "Prometheus Metrics", "onAutoForward": "silent" }
   },
   "postCreateCommand": "bash .devcontainer/post-create.sh",

--- a/deploy/scripts/verify-services.sh
+++ b/deploy/scripts/verify-services.sh
@@ -38,7 +38,7 @@ SERVICES=(
   "notebook-sync     8095 /healthz"
   "publisher-discord 8094 /healthz"
   "render-webhook    8085 /healthz"
-  "cipher-memory     8096 /health"
+  "cipher-memory     8105 /health"
   "pmoves-yt         8077 /healthz"
   "nats              8222 /varz"
   "meilisearch       7700 /health"

--- a/pmoves/config/agent_registry.yaml
+++ b/pmoves/config/agent_registry.yaml
@@ -887,7 +887,7 @@ agents:
     class: specialized
     primary_type: data
     secondary_type: agent
-    port: 8096
+    port: 8105
     health: "/health"
     layers: [L0, L5]
     evolution_stage: base
@@ -2005,5 +2005,5 @@ agents:
       Level 11 Cipher Gateway Specialist. Extracts sonic fingerprints via ffprobe/ffmpeg
       lavfi (ebur128 R128 loudness, aspectralstats spectral analysis). Clusters DARKXSIDE
       beats into named sonic constellations, writes M3U8 playlists, checkpoints to Cipher
-      Memory at :8096, emits geometry events to the NATS Geometry Bus for Holographic
+      Memory at :8105, emits geometry events to the NATS Geometry Bus for Holographic
       CHIT Block generation. Monitored live via Glances REST API.

--- a/pmoves/docker-compose.agents.yml
+++ b/pmoves/docker-compose.agents.yml
@@ -197,7 +197,7 @@ services:
     environment:
     - PORT=${GATEWAY_AGENT_PORT:-8111}
     - AGENT_ZERO_URL=${AGENT_ZERO_URL:-http://agent-zero:8080}
-    - CIPHER_URL=${CIPHER_URL:-http://cipher-api:8096}
+    - CIPHER_URL=${CIPHER_URL:-http://cipher-api:8105}
     - TENSORZERO_URL=${TENSORZERO_URL:-http://tensorzero-gateway:3000}
     - SUPABASE_URL=${SUPABASE_URL:-http://supabase-kong:8000}
     - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
@@ -653,7 +653,7 @@ services:
     - CIPHER_API_TOKEN=${CIPHER_API_TOKEN:-}
     command: ["node", "dist/src/app/index.cjs", "--mode", "api", "--port", "3000", "--host", "0.0.0.0", "--agent", "/app/memAgent/cipher.yml", "--mcp-transport-type", "sse"]
     ports:
-    - "${CIPHER_BIND:-0.0.0.0}:${CIPHER_PORT:-8096}:3000"
+    - "${CIPHER_BIND:-0.0.0.0}:${CIPHER_PORT:-8105}:3000"
     depends_on:
       neo4j:
         condition: service_healthy

--- a/pmoves/docker-compose.media.yml
+++ b/pmoves/docker-compose.media.yml
@@ -618,7 +618,7 @@ services:
     - LLAMA_SERVER_HOST=127.0.0.1
     - LLAMA_RESULTS_DIR=/results
     - NATS_URL=${NATS_URL:-nats://nats:pmoves@nats:4222}
-    - CIPHER_MEMORY_URL=${CIPHER_MEMORY_URL:-http://cipher-api:8096}
+    - CIPHER_MEMORY_URL=${CIPHER_MEMORY_URL:-http://cipher-api:8105}
     - GPU_ORCHESTRATOR_URL=http://gpu-orchestrator:8200
     - METRICS_PORT=8201
     volumes:

--- a/pmoves/docker-compose.vps.override.yml
+++ b/pmoves/docker-compose.vps.override.yml
@@ -74,7 +74,7 @@ services:
     environment:
       - PORT=8100
       - AGENT_ZERO_URL=http://agent-zero:8080
-      - CIPHER_URL=http://cipher-api:8096
+      - CIPHER_URL=http://cipher-api:8105
       - TENSORZERO_URL=http://tensorzero:3000
       - SUPABASE_URL=${SUPABASE_URL:-http://supabase-kong:8000}
       - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}

--- a/pmoves/docker-compose.yml
+++ b/pmoves/docker-compose.yml
@@ -2553,7 +2553,7 @@ services:
     - CIPHER_API_TOKEN=${CIPHER_API_TOKEN:-}
     command: ["node", "dist/src/app/index.cjs", "--mode", "api", "--port", "3000", "--host", "0.0.0.0", "--agent", "/app/memAgent/cipher.yml", "--mcp-transport-type", "sse"]
     ports:
-    - "${CIPHER_BIND:-0.0.0.0}:${CIPHER_PORT:-8096}:3000"
+    - "${CIPHER_BIND:-0.0.0.0}:${CIPHER_PORT:-8105}:3000"
     depends_on:
       neo4j:
         condition: service_healthy
@@ -3759,7 +3759,7 @@ services:
     environment:
     - PORT=${GATEWAY_AGENT_PORT:-8111}
     - AGENT_ZERO_URL=${AGENT_ZERO_URL:-http://agent-zero:8080}
-    - CIPHER_URL=${CIPHER_URL:-http://cipher-api:8096}
+    - CIPHER_URL=${CIPHER_URL:-http://cipher-api:8105}
     - TENSORZERO_URL=${TENSORZERO_URL:-http://tensorzero-gateway:3000}
     - SUPABASE_URL=${SUPABASE_URL:-http://supabase-kong:8000}
     - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}
@@ -4066,7 +4066,7 @@ services:
     - LLAMA_SERVER_HOST=127.0.0.1
     - LLAMA_RESULTS_DIR=/results
     - NATS_URL=${NATS_URL:-nats://nats:pmoves@nats:4222}
-    - CIPHER_MEMORY_URL=${CIPHER_MEMORY_URL:-http://cipher-api:8096}
+    - CIPHER_MEMORY_URL=${CIPHER_MEMORY_URL:-http://cipher-api:8105}
     - GPU_ORCHESTRATOR_URL=http://gpu-orchestrator:8200
     - METRICS_PORT=8201
     volumes:

--- a/pmoves/services/gateway-agent/README.md
+++ b/pmoves/services/gateway-agent/README.md
@@ -226,7 +226,7 @@ gateway-agent:
   ports: ["8100:8100"]
   environment:
     - AGENT_ZERO_URL=http://agent-zero:8080
-    - CIPHER_URL=http://cipher-api:8096
+    - CIPHER_URL=http://cipher-api:8105
     - TENSORZERO_URL=http://tensorzero-gateway:3030
   profiles: ["agents", "gateway"]
 ```
@@ -242,7 +242,7 @@ docker run -d \
   --name pmoves-gateway-agent \
   -p 8100:8100 \
   -e AGENT_ZERO_URL=http://agent-zero:8080 \
-  -e CIPHER_URL=http://cipher-api:8096 \
+  -e CIPHER_URL=http://cipher-api:8105 \
   pmoves/gateway-agent:latest
 ```
 

--- a/pmoves/services/gateway-agent/app.py
+++ b/pmoves/services/gateway-agent/app.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 # Configuration
 AGENT_ZERO_URL = os.environ.get("AGENT_ZERO_URL", "http://agent-zero:8080")
-CIPHER_URL = os.environ.get("CIPHER_URL", "http://cipher-api:8096")
+CIPHER_URL = os.environ.get("CIPHER_URL", "http://cipher-api:8105")
 TENSORZERO_URL = os.environ.get("TENSORZERO_URL", "http://tensorzero-gateway:3000")
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "")
 SUPABASE_SERVICE_KEY = os.environ.get("SUPABASE_SERVICE_KEY", "")

--- a/pmoves/services/showtime-api/health_probe.py
+++ b/pmoves/services/showtime-api/health_probe.py
@@ -32,7 +32,7 @@ SERVICE_CATALOG: list[dict[str, Any]] = [
     {"name": "TensorZero UI", "url": "http://localhost:4000", "tier": 7, "type": "UI"},
     {"name": "TensorZero GW", "url": f"http://localhost:{os.environ.get('TENSORZERO_PORT', '3030')}", "tier": 2, "type": "API"},
     {"name": "Open Notebook", "url": "http://localhost:8503", "tier": 1, "type": "Data"},
-    {"name": "Cipher Memory", "url": "http://localhost:8096/health", "tier": 1, "type": "Data"},
+    {"name": "Cipher Memory", "url": "http://localhost:8105/health", "tier": 1, "type": "Data"},
     {"name": "BoTZ Gateway", "url": "http://localhost:8054/healthz", "tier": 6, "type": "Agent"},
     {"name": "DeepResearch", "url": "http://localhost:8098/healthz", "tier": 3, "type": "LLM"},
     {"name": "Flute-Gateway", "url": "http://localhost:8055/healthz", "tier": 2, "type": "API"},

--- a/pmoves/tools/analyze_beats.py
+++ b/pmoves/tools/analyze_beats.py
@@ -74,7 +74,7 @@ class SenseMode(str, enum.Enum):
 DEFAULT_INPUT   = os.environ.get("BEATS_INPUT",    "pmoves/data/beats/soundcloud/darkxside")
 DEFAULT_OUTPUT  = os.environ.get("BEATS_OUTPUT",   "pmoves/data/beats/playlists")
 DEFAULT_NATS    = os.environ.get("NATS_URL",        "")
-DEFAULT_CIPHER  = os.environ.get("CIPHER_URL",      "http://localhost:8096")
+DEFAULT_CIPHER  = os.environ.get("CIPHER_URL",      "http://localhost:8105")
 DEFAULT_GLANCES = os.environ.get("GLANCES_URL",     "http://localhost:61208")
 DEFAULT_OLLAMA  = os.environ.get("OLLAMA_API_BASE", "http://localhost:11434")
 DEFAULT_HIRAG   = os.environ.get("HIRAG_GPU_URL",   "http://localhost:8087")

--- a/pmoves/tools/cross_reference_validator.py
+++ b/pmoves/tools/cross_reference_validator.py
@@ -42,7 +42,7 @@ KNOWN_SERVICES: Dict[str, int] = {
     "jellyfin-bridge": 8093,
     "publisher-discord": 8094,
     "notebook-sync": 8095,
-    "cipher-memory": 8096,
+    "cipher-memory": 8105,
     "channel-monitor": 8097,
     "deepresearch": 8098,
     "supaserch": 8099,

--- a/pmoves/tools/docs_content_audit.py
+++ b/pmoves/tools/docs_content_audit.py
@@ -90,7 +90,7 @@ KNOWN_PORTS: Dict[str, int] = {
     "jellyfin-bridge": 8093,
     "publisher-discord": 8094,
     "notebook-sync": 8095,
-    "cipher-memory": 8096,
+    "cipher-memory": 8105,
     "channel-monitor": 8097,
     "prometheus": 9090,
     "grafana": 3000,


### PR DESCRIPTION
## Summary

Reassigns cipher_memory (cipher-api) host port from 8096 to 8105 to resolve the port collision with headscale, consciousness-service, and HF MCP server.

### Why 8105
Per pr-gap-analysis-2026-03-14.md recommendation: "8105+ which are unallocated".

### Scope — Source of Truth (PR A)

19 files changed, 29 insertions, 29 deletions — pure mechanical port swap.

| Category | Files |
|----------|-------|
| Docker Compose | docker-compose.yml, docker-compose.agents.yml, docker-compose.media.yml, docker-compose.vps.override.yml |
| Registry | agent_registry.yaml |
| Services Catalog | services-catalog.md (cipher section only — headscale 8096 preserved) |
| MCP Config | .claude/mcp.json |
| CLAUDE.md | .claude/CLAUDE.md |
| Cipher Commands | .claude/commands/cipher/{reasoning,search,store}.md |
| DevContainer | .devcontainer/devcontainer.json |
| Gateway Agent | app.py, README.md |
| Health Probe | showtime-api/health_probe.py |
| Tools | analyze_beats.py, cross_reference_validator.py, docs_content_audit.py |
| Verify Script | deploy/scripts/verify-services.sh |

### NOT Changed (intentional)
- Headscale 8096 — correct per upstream docs
- Jellyfin 8096 — internal container port (host uses 9096)
- Consciousness-service 8096 — separate issue
- HF MCP Server 8096 — separate issue

### Follow-up PRs
- **PR B**: claws configs, TAC trees, agent-teams.yaml
- **PR C**: documentation files (docs/, research/, pbnj/)
- **Submodule PR**: pmoves-cipher-mcp/ default URL

### SPARK Pre-Push Review

Code-reviewer caught a false positive: services-catalog.md line 458 (Headscale section) was incorrectly changed from 8096→8105. Fixed before push. This validates the SPARK review process — the catch prevented a regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cipher Memory service port from 8096 to 8105 across all configuration and deployment documentation.

* **Chores**
  * Updated service configurations, deployment files, and connection URLs to reflect the new Cipher Memory service port (8105).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->