### PR TITLE
fix(ports): reassign cipher_memory 8096→8105 — claws, TAC trees, agent-teams configs

### DIFF
--- a/pmoves/configs/agent-teams.yaml
+++ b/pmoves/configs/agent-teams.yaml
@@ -36,7 +36,7 @@ teams:
       - notebook_sync     # Port 8095 — Open Notebook sync
       - dox               # Document intelligence
       - open_notebook     # Knowledge base (SurrealDB)
-      - cipher_memory     # Port 8096 — Knowledge graph memory
+      - cipher_memory     # Port 8105 — Knowledge graph memory
 
   media:
     name: "Media & Voice"

--- a/pmoves/configs/claws/claude-md/4090.md
+++ b/pmoves/configs/claws/claude-md/4090.md
@@ -71,7 +71,7 @@ You are 4090-claude, the active GPU contributor and UI specialist. You may:
 
 | Server | Type | Endpoint | Purpose |
 |--------|------|----------|---------|
-| pmoves-cipher | SSE | `http://${TS_Z890}:8096/sse` | Agent memory |
+| pmoves-cipher | SSE | `http://${TS_Z890}:8105/sse` | Agent memory |
 | agent-zero | HTTP | `http://${TS_Z890}:8080/mcp` | Orchestrator |
 | gpu-mesh | NATS | `mesh.gpu.*` subjects | GPU mesh integration |
 
@@ -106,7 +106,7 @@ NVENC encode profiles:
 | Agent Zero | `http://${TS_Z890}:8080` | Orchestrator (MCP API at /mcp/*) |
 | TensorZero | `http://${TS_Z890}:3030` | LLM gateway |
 | NATS | `nats://${TS_Z890}:4222` | Message bus |
-| Cipher Memory | `http://${TS_Z890}:8096` | Agent memory |
+| Cipher Memory | `http://${TS_Z890}:8105` | Agent memory |
 
 ## AGNOTE4482 Workstreams
 

--- a/pmoves/configs/claws/claude-md/5090.md
+++ b/pmoves/configs/claws/claude-md/5090.md
@@ -34,7 +34,7 @@ You are 5090-claude, the GPU inference specialist. You may:
 | Archon | `http://${TS_Z890}:8091` | Agent service (prompts/forms) |
 | TensorZero | `http://${TS_Z890}:3030` | LLM gateway |
 | NATS | `nats://${TS_Z890}:4222` | Message bus |
-| Cipher Memory | `http://${TS_Z890}:8096` | Agent memory |
+| Cipher Memory | `http://${TS_Z890}:8105` | Agent memory |
 | Ollama (Z890) | `http://${TS_Z890}:11434` | Z890 model serving |
 
 ## AGNOTE4482 Workstreams

--- a/pmoves/configs/claws/claude-md/kvm4-1.md
+++ b/pmoves/configs/claws/claude-md/kvm4-1.md
@@ -41,7 +41,7 @@ You may NOT: run docker, make, ssh to other nodes, or access storage services di
 | Archon | `http://${TS_Z890}:8091` | Agent service (prompts/forms) |
 | TensorZero | `http://${TS_Z890}:3030` | LLM gateway |
 | NATS | `nats://${TS_Z890}:4222` | Message bus |
-| Cipher Memory | `http://${TS_Z890}:8096` | Agent memory |
+| Cipher Memory | `http://${TS_Z890}:8105` | Agent memory |
 | Ollama (Z890) | `http://${TS_Z890}:11434` | GPU model serving |
 
 ## Health Check Commands

--- a/pmoves/configs/claws/claude-md/kvm4-2.md
+++ b/pmoves/configs/claws/claude-md/kvm4-2.md
@@ -24,7 +24,7 @@ You may NOT: run docker, make, ssh to other nodes, or manage network/proxy servi
 | Qdrant | 6333 | Vector embeddings |
 | Meilisearch | 7700 | Full-text search |
 | Neo4j | 7474/7687 | Graph database (HTTP/Bolt) |
-| Cipher Memory | 8096 | Agent memory |
+| Cipher Memory | 8105 | Agent memory |
 
 ## Common Queries
 

--- a/pmoves/configs/claws/opencode-4090.json
+++ b/pmoves/configs/claws/opencode-4090.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://${TS_Z890}:8096/sse",
+      "url": "http://${TS_Z890}:8105/sse",
       "description": "Agent memory (Neo4j knowledge graph) via Tailscale"
     },
     "agent-zero": {

--- a/pmoves/configs/claws/opencode-5090.json
+++ b/pmoves/configs/claws/opencode-5090.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://${TS_Z890}:8096/sse",
+      "url": "http://${TS_Z890}:8105/sse",
       "description": "Agent memory (Neo4j knowledge graph) via Tailscale"
     },
     "agent-zero": {

--- a/pmoves/configs/claws/opencode-kvm4-1.json
+++ b/pmoves/configs/claws/opencode-kvm4-1.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://${TS_Z890}:8096/sse",
+      "url": "http://${TS_Z890}:8105/sse",
       "description": "Agent memory (Neo4j knowledge graph) via Tailscale"
     },
     "agent-zero": {

--- a/pmoves/configs/claws/opencode-kvm4-2.json
+++ b/pmoves/configs/claws/opencode-kvm4-2.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://cipher-memory:8096/sse",
+      "url": "http://cipher-memory:8105/sse",
       "description": "Agent memory (Neo4j knowledge graph)"
     }
   },

--- a/pmoves/configs/claws/opencode-nemotron-claw.json
+++ b/pmoves/configs/claws/opencode-nemotron-claw.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://${TS_Z890}:8096/sse",
+      "url": "http://${TS_Z890}:8105/sse",
       "description": "Agent memory via Tailscale"
     },
     "agent-zero": {

--- a/pmoves/configs/claws/scopes/4090.json
+++ b/pmoves/configs/claws/scopes/4090.json
@@ -35,7 +35,7 @@
   "mcp_servers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://${TS_Z890}:8096/sse"
+      "url": "http://${TS_Z890}:8105/sse"
     },
     "agent-zero": {
       "type": "http",

--- a/pmoves/configs/claws/scopes/5090.json
+++ b/pmoves/configs/claws/scopes/5090.json
@@ -33,7 +33,7 @@
   "mcp_servers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://${TS_Z890}:8096/sse"
+      "url": "http://${TS_Z890}:8105/sse"
     },
     "agent-zero": {
       "type": "http",

--- a/pmoves/configs/claws/scopes/kvm4-1.json
+++ b/pmoves/configs/claws/scopes/kvm4-1.json
@@ -30,7 +30,7 @@
   "mcp_servers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://${TS_Z890}:8096/sse"
+      "url": "http://${TS_Z890}:8105/sse"
     },
     "agent-zero": {
       "type": "http",

--- a/pmoves/configs/claws/scopes/kvm4-2.json
+++ b/pmoves/configs/claws/scopes/kvm4-2.json
@@ -26,7 +26,7 @@
   "mcp_servers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://cipher-memory:8096/sse"
+      "url": "http://cipher-memory:8105/sse"
     }
   },
   "damage_control_hooks": true,

--- a/pmoves/configs/claws/scopes/nemotron-claw.json
+++ b/pmoves/configs/claws/scopes/nemotron-claw.json
@@ -59,7 +59,7 @@
   "mcp_servers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://${TS_Z890}:8096/sse"
+      "url": "http://${TS_Z890}:8105/sse"
     },
     "agent-zero": {
       "type": "http",

--- a/pmoves/configs/claws/scopes/z890.json
+++ b/pmoves/configs/claws/scopes/z890.json
@@ -35,7 +35,7 @@
   "mcp_servers": {
     "pmoves-cipher": {
       "type": "sse",
-      "url": "http://localhost:8096/sse"
+      "url": "http://localhost:8105/sse"
     },
     "docker": {
       "command": "docker",

--- a/pmoves/configs/tac_trees/agent-teams-taxonomy.tac.yaml
+++ b/pmoves/configs/tac_trees/agent-teams-taxonomy.tac.yaml
@@ -88,7 +88,7 @@ root:
             notebook_sync   — Port 8095 — Open Notebook sync
             dox             — Document intelligence
             open_notebook   — Knowledge base (SurrealDB)
-            cipher_memory   — Port 8096 — Knowledge graph memory (Neo4j)
+            cipher_memory   — Port 8105 — Knowledge graph memory (Neo4j)
           agent_hint: codex
 
         - id: team.research.node_affinity

--- a/pmoves/configs/tac_trees/firefly-iii.tac.yaml
+++ b/pmoves/configs/tac_trees/firefly-iii.tac.yaml
@@ -23,7 +23,7 @@ root:
             target: "pmoves/docs/TAC/TAC_WEALTH.md"
             pattern: "8075"
             expect: "Port 8075 referenced (FIREFLY_PORT)"
-          context: "Port 8096 is Cipher Memory, Firefly uses FIREFLY_PORT=8075"
+          context: "Port 8105 is Cipher Memory, Firefly uses FIREFLY_PORT=8075"
           agent_hint: codex
 
         - id: firefly-iii.docs.branded-defaults

--- a/pmoves/configs/tac_trees/mcp-topology.tac.yaml
+++ b/pmoves/configs/tac_trees/mcp-topology.tac.yaml
@@ -141,7 +141,7 @@ root:
     # =========================================================================
     - id: mcp.cipher-memory
       task: "Cipher Memory MCP server"
-      context: "SSE transport at :8096/sse, Neo4j-backed knowledge-graph memory"
+      context: "SSE transport at :8105/sse, Neo4j-backed knowledge-graph memory"
       agent_hint: codex
       children:
         - id: mcp.cipher-memory.transport
@@ -149,8 +149,8 @@ root:
           action:
             type: grep
             target: ".claude/mcp.json"
-            pattern: "pmoves-cipher.*sse|8096/sse"
-            expect: "SSE transport at http://localhost:8096/sse"
+            pattern: "pmoves-cipher.*sse|8105/sse"
+            expect: "SSE transport at http://localhost:8105/sse"
           context: "Configured in .claude/mcp.json as pmoves-cipher server"
           agent_hint: codex
 
@@ -159,9 +159,9 @@ root:
           action:
             type: grep
             target: "pmoves/docker-compose.yml"
-            pattern: "cipher.*health|8096.*health"
-            expect: "GET http://localhost:8096/health"
-          context: "Healthcheck: GET http://localhost:8096/health"
+            pattern: "cipher.*health|8105.*health"
+            expect: "GET http://localhost:8105/health"
+          context: "Healthcheck: GET http://localhost:8105/health"
           agent_hint: codex
 
         - id: mcp.cipher-memory.submodule
@@ -411,7 +411,7 @@ root:
         Server inventory (transport | port | tool_count | auth | healthcheck):
         -----------------------------------------------------------------------
         Agent Zero MCP     | HTTP  | :8080/mcp/*  |  ~9 | Bearer MCP_CLIENT_SECRET | GET /mcp/health
-        Cipher Memory MCP  | SSE   | :8096/sse    |   4 | Service-level (Neo4j)    | GET /health
+        Cipher Memory MCP  | SSE   | :8105/sse    |   4 | Service-level (Neo4j)    | GET /health
         BoTZ MCP Gateway   | HTTP  | compose      |  ~6 | JWT (P1 fail-open audit) | compose healthcheck
         Airtable           | Cloud | plugin       |   8 | OAuth (Claude)           | ping tool
         Cloudflare         | Cloud | plugin       |  22 | OAuth (Claude)           | accounts_list


### PR DESCRIPTION
## Summary

PR B following #1344 — updates config files referencing cipher-memory at port 8096.

### Files Changed (19)

| Category | Count | Files |
|----------|-------|-------|
| CLAWS opencode JSON | 5 | kvm4-2, 4090, 5090, kvm4-1, nemotron-claw |
| CLAWS scopes JSON | 6 | kvm4-2, 4090, 5090, kvm4-1, nemotron-claw, z890 |
| CLAWS claude-md | 4 | kvm4-2, kvm4-1, 4090 (2 refs), 5090 |
| TAC trees | 3 | agent-teams-taxonomy, mcp-topology (7 refs), firefly-iii |
| Agent teams | 1 | agent-teams.yaml |

### Verification
`grep -rn cipher.memory:8096|cipher-memory:8096 pmoves/configs/` → zero results.

### Not Changed (intentional)
- Headscale 8096, jellyfin 8096, consciousness-service 8096, HF MCP 8096

### Follow-up
- PR C: documentation files (docs/, research/, pbnj/)
- Submodule PR: pmoves-cipher-mcp/ default URL