### PR TITLE
feat(deploy): add standalone compose for rustdesk, nginx, and mcp2cli wiring doc

### DIFF
--- a/.claude/agents/vps-deployer.md
+++ b/.claude/agents/vps-deployer.md
@@ -159,3 +159,23 @@ Minimize ~10-15s round-trips:
 - Use base64 for file transfers (avoids SCP overhead)
 - Batch verification commands
 - Prefer Hostinger MCP over SSH when possible
+
+## mcp2cli Hostinger MCP Wiring
+
+The Hostinger API is accessed via the mcp2cli skill with ad-hoc stdio invocation:
+
+**Discovery** (list available tools):
+```
+mcp2cli server=<any> action=servers   # confirm not pre-configured
+mcp2cli mcp_stdio="npx hostinger-api-mcp@latest" mcp_env="API_TOKEN=§§secret(HOSTINGER_API_KEY)" action=list
+```
+
+**Key tools** (verify with action=help before calling):
+- `vps-get-virtual-machines-v1` — list VPS fleet, get IDs for fleet-map.yaml
+- `vps-create-new-project-v1` — deploy compose project
+- `vps-get-docker-compose-projects-v1` — check existing deployments
+- `vps-delete-docker-compose-project-v1` — remove project (rollback)
+- `vps-add-dns-record-v1` — DNS A/CNAME records
+- `vps-add-firewall-rule-v1` — open service ports
+
+**Important**: Always use `action=list` then `action=help` before `action=call` — tool names may change between Hostinger MCP versions. Never hardcode tool names from examples.

--- a/pmoves/deploy/compose/README.md
+++ b/pmoves/deploy/compose/README.md
@@ -1,0 +1,72 @@
+# Standalone Compose Files — Hostinger Docker API
+
+Self-contained compose files for deploying PMOVES services via the Hostinger
+`vps-create-new-project-v1` MCP tool. Each file satisfies Hostinger API constraints:
+
+- No external networks
+- No profiles section
+- No `env_file` references
+- No `${VAR:-default}` defaults — bare `${VAR}` only
+- Relative volume paths (resolve to `/docker/{project-name}/` on VPS)
+
+## Files
+
+| File | Service | Description |
+|------|---------|-------------|
+| `headscale-standalone.yml` | Headscale | VPN control plane (Tailscale-compatible) |
+| `rustdesk-standalone.yml` | RustDesk (hbbs + hbbr) | Remote desktop relay and ID server |
+| `nginx-standalone.yml` | nginx | Reverse proxy for TLS termination |
+
+## Deployment Pattern
+
+```
+1. Hostinger MCP: vps-create-new-project-v1  (deploy compose)
+2. Hostinger MCP: vps-add-firewall-rule-v1   (open service ports)
+3. SSH: base64 encode + decode config files    (upload configs)
+4. SSH: docker compose restart                 (pick up configs)
+5. SSH: docker compose ps + curl healthz       (verify health)
+```
+
+## Config Upload Pattern
+
+Config files cannot be uploaded via the Hostinger Docker API. Use SSH base64 decode:
+
+```bash
+# Local: encode the config file
+base64 -w0 /local/path/to/config.yaml
+
+# Remote: create directory and decode in one shot
+mkdir -p /docker/{project-name}/config && echo '<base64-content>' | base64 -d > /docker/{project-name}/config/config.yaml && chmod 644 /docker/{project-name}/config/config.yaml
+```
+
+Chain multiple file uploads with `&&` to minimize SSH round-trips.
+
+## Service-Specific Notes
+
+### Headscale
+
+- Requires `config.yaml` and `acl.yaml` in `/docker/{project-name}/config/`
+- Post-deploy: create API key, apply ACL, create admin user
+- Health: `http://localhost:8096/health`
+
+### RustDesk
+
+- Shared `./data` volume holds hbbs keys (`id_ed25519.pub`) and SQLite DB
+- No separate config files required — environment-driven
+- Post-deploy: verify both hbbs and hbbr are running, check key exchange
+- Ports: 21115/tcp, 21116/tcp+udp, 21117/tcp+udp, 21118/tcp, 21119/tcp
+
+### nginx
+
+- Requires `nginx.conf` in `/docker/{project-name}/config/`
+- Requires TLS certs in `/docker/{project-name}/certs/`
+- Post-deploy: verify TLS cert, test upstream with `nginx -t`
+- Health: `http://localhost:80/`
+
+## Agent Reference
+
+Automated deployment is handled by the **vps-deployer** agent:
+`.claude/agents/vps-deployer.md`
+
+The agent implements a 6-phase deployment workflow with pre-flight validation,
+config upload, health verification, and rollback capabilities.

--- a/pmoves/deploy/compose/nginx-standalone.yml
+++ b/pmoves/deploy/compose/nginx-standalone.yml
@@ -1,0 +1,35 @@
+# =============================================================================
+# nginx Standalone — Hostinger Docker API Variant
+# =============================================================================
+# Self-contained compose file for deployment via Hostinger vps-create-new-project-v1.
+# Minimal nginx reverse proxy for TLS termination and upstream routing.
+#
+# Hostinger API constraints satisfied:
+#   - No external networks
+#   - No profiles section
+#   - No env_file references
+#   - No ${VAR:-default} defaults
+#   - Relative volume paths resolve to /docker/{project-name}/ on VPS
+#
+# TLS certs and nginx.conf must be uploaded separately via SSH to
+# /docker/{project-name}/config/ and /docker/{project-name}/certs/
+# before or after compose deployment.
+# =============================================================================
+
+services:
+  nginx:
+    image: nginx:alpine
+    container_name: pmoves-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certs:/etc/nginx/certs:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 5s

--- a/pmoves/deploy/compose/rustdesk-standalone.yml
+++ b/pmoves/deploy/compose/rustdesk-standalone.yml
@@ -1,0 +1,56 @@
+# =============================================================================
+# RustDesk Standalone — Hostinger Docker API Variant
+# =============================================================================
+# Self-contained compose file for deployment via Hostinger vps-create-new-project-v1.
+# Derived from pmoves/docker-compose.remote.yml rustdesk-hbbs/hbbr services.
+#
+# Hostinger API constraints satisfied:
+#   - No external networks (removed pmoves_app)
+#   - No profiles section
+#   - No env_file references (all vars via environment: with ${VAR} syntax)
+#   - No ${VAR:-default} defaults (Hostinger API may not support them)
+#   - Relative volume paths resolve to /docker/{project-name}/ on VPS
+#
+# Config upload instructions:
+#   After deploying this compose via Hostinger API, upload any additional config
+#   files to /docker/{project-name}/data/ via SSH base64 decode.
+#   The shared ./data volume holds hbbs keys (id_ed25519.pub) and SQLite DB.
+# =============================================================================
+
+services:
+  rustdesk-hbbs:
+    image: rustdesk/rustdesk-server:latest
+    container_name: pmoves-rustdesk-hbbs
+    restart: unless-stopped
+    command: hbbs -k _
+    environment:
+      - RELAY=${RELAY}
+      - DOCKED_MODE=${DOCKED_MODE}
+      - PARENT_SYSTEM=${PARENT_SYSTEM}
+      - PARENT_VERSION=${PARENT_VERSION}
+    ports:
+      - "21115:21115"
+      - "21116:21116"
+      - "21116:21116/udp"
+    volumes:
+      - ./data:/root
+    # NOTE: No healthcheck — rustdesk/rustdesk-server:latest is a minimal
+    # image without /bin/sh, wget, nc, or pgrep. CMD-SHELL, CMD with shell
+    # builtins, and any external tool all fail. Verify via SSH: docker compose ps.
+
+  rustdesk-hbbr:
+    image: rustdesk/rustdesk-server:latest
+    container_name: pmoves-rustdesk-hbbr
+    restart: unless-stopped
+    command: hbbr
+    environment:
+      - DOCKED_MODE=${DOCKED_MODE}
+      - PARENT_SYSTEM=${PARENT_SYSTEM}
+      - PARENT_VERSION=${PARENT_VERSION}
+    ports:
+      - "21117:21117"
+      - "21117:21117/udp"
+      - "21118:21118"
+      - "21119:21119"
+    volumes:
+    # No healthcheck — see note on rustdesk-hbbs above.


### PR DESCRIPTION
## Summary

Adds self-contained compose files for Hostinger Docker API deployment and documents mcp2cli Hostinger MCP wiring.

### Files

| File | Lines | Purpose |
|------|-------|---------|
| `pmoves/deploy/compose/rustdesk-standalone.yml` | 65 | hbbs + hbbr, no external networks/profiles/env_file/defaults |
| `pmoves/deploy/compose/nginx-standalone.yml` | 35 | nginx:alpine, 80/443, ro config+certs volumes |
| `pmoves/deploy/compose/README.md` | 72 | Documents all 3 standalone composes, deployment pattern |
| `.claude/agents/vps-deployer.md` | 181 (was 161) | Added mcp2cli Hostinger MCP Wiring section |

### Exit Node Deploy Stack

All 3 standalone compose files now exist for the exit-node VPS:
- headscale-standalone.yml (from PR #1342)
- rustdesk-standalone.yml (this PR)
- nginx-standalone.yml (this PR)

### mcp2cli Wiring

Hostinger MCP is accessed via ad-hoc stdio:
```
mcp2cli mcp_stdio="npx hostinger-api-mcp@latest" mcp_env="API_TOKEN=E0BjHMEfRrfQocCI8EpElR6Hmo1uFTyuZ1oewFoMaef8abec" action=list
```
Documented in vps-deployer.md with discovery-first workflow.