### PR TITLE
fix(headscale): restore in-tree configs and fix headscale-agent image

### DIFF
--- a/pmoves/config/headscale/acl.yaml
+++ b/pmoves/config/headscale/acl.yaml
@@ -1,1 +1,169 @@
-# DEPRECATED — authoritative ACL lives in vendor/PMOVES-Headscale/pmoves/acl.yaml
+# Mirrored from PMOVES-Headscale submodule (PMOVES.AI-Edition-Hardened branch)
+#
+# Deny-by-default: only explicitly accepted traffic is permitted.
+# Tags can be used directly as src/dst (not only groups).
+# autogroup:internet:* requires the :* suffix in this format.
+#
+# Two ACL styles coexist:
+#   1. Group-level (groups + acls): coarse-grained, for human operators
+#   2. Tag-level  (tag:X as src/dst): fine-grained, for infrastructure nodes
+# Tags exit/rdna4/dgx/monitoring/pmoves/pve use tag-level ACLs only
+# and are intentionally NOT members of any group.
+
+# ── Tag Owners ──────────────────────────────────────────────
+# Authoritative: controls who may assign each tag to a node.
+# The legacy 'owners' key (Tailscale) is NOT recognized by Headscale.
+tagowners:
+  tag:admin: [group:admin]
+  tag:support: [group:admin, group:support]
+  tag:infra: [group:admin]
+  tag:server: [group:admin]
+  tag:user: [group:admin, group:support]
+  # Infrastructure tags — tag-level ACLs only (not group members)
+  tag:exit: [group:admin]
+  tag:rdna4: [group:admin]
+  tag:dgx: [group:admin]          # preparatory — no ACL rules yet
+  tag:monitoring: [group:admin]
+  tag:pmoves: [group:admin]
+  tag:pve: [group:admin]
+
+# ── Groups ──────────────────────────────────────────────────
+# Coarse-grained membership for human operator roles.
+groups:
+  admin: ["tag:admin"]
+  support: ["tag:support"]
+  infrastructure: ["tag:infra", "tag:server"]
+  users: ["tag:user"]
+
+# ── Group-Level ACLs ────────────────────────────────────────
+acls:
+  # ── Admin: unrestricted access to all groups ─────────────
+  - action: accept
+    src: [group:admin]
+    dst: [group:*]
+
+  # ── Support: triage access to infra and users ────────────
+  - action: accept
+    src: [group:support]
+    dst: [group:infrastructure, group:users]
+
+  # ── Infrastructure: full mesh for inter-node communication
+  - action: accept
+    src: [group:infrastructure]
+    dst: [group:infrastructure]
+
+  # ── Users → Infrastructure: explicit service ports only ──
+
+  # Agent coordination (Agent Zero API/UI, Archon API/UI)
+  - action: accept
+    src: [group:users]
+    dst: [group:infrastructure]
+    ports: [8080, 8081, 8091, 3737]
+
+  # Retrieval & knowledge (Hi-RAG CPU/GPU, SupaSerch, DeepResearch)
+  - action: accept
+    src: [group:users]
+    dst: [group:infrastructure]
+    ports: [8086, 8087, 8099, 8098]
+
+  # Voice & speech (Flute-Gateway HTTP/WS, TTS-Studio, Voice Relay)
+  - action: accept
+    src: [group:users]
+    dst: [group:infrastructure]
+    ports: [8055, 8056, 7861, 8121]
+
+  # Media processing (YT, Whisper, Video/Audio, Extract, LangExtract, Transcribe)
+  - action: accept
+    src: [group:users]
+    dst: [group:infrastructure]
+    ports: [8077, 8078, 8079, 8082, 8083, 8084, 8074]
+
+  # Document processing (PDF Ingest)
+  - action: accept
+    src: [group:users]
+    dst: [group:infrastructure]
+    ports: [8092]
+
+  # Utilities (Presign, Notebook Sync, Open Notebook UI/API, Health/wger)
+  - action: accept
+    src: [group:users]
+    dst: [group:infrastructure]
+    ports: [8088, 8095, 8503, 5055, 8000]
+
+  # Remote desktop (RustDesk relay and signaling)
+  - action: accept
+    src: [group:users]
+    dst: [group:infrastructure]
+    ports: [21115, 21116, 21117, 21118, 21119]
+
+  # ── Users → Users: peer-to-peer ──────────────────────────
+  - action: accept
+    src: [group:users]
+    dst: [group:users]
+
+  # ── Tag-Level ACLs: infrastructure nodes ─────────────────
+
+  # Exit node egress: tailnet clients authorized to route via exit nodes
+  # src = client principals who USE the exit node (not tag:exit itself)
+  # dst = autogroup:internet:* = public IP ranges advertised by exit nodes
+  - action: accept
+    src:
+      - group:admin
+      - group:support
+      - group:infrastructure
+      - group:users
+    dst:
+      - "autogroup:internet:*"
+
+  # PVE: Proxmox VE web UI — admin-only access
+  - action: accept
+    src: [group:admin]
+    dst: [tag:pve]
+    ports: [8006]
+
+  # RDNA4 GPU node: admin full access
+  - action: accept
+    src: [group:admin]
+    dst: [tag:rdna4]
+
+  # RDNA4: monitoring scrapes rocm-smi exporter (metrics only)
+  # Defense-in-depth: monitoring CANNOT reach GPU Orchestrator (tag:pmoves:8200)
+  - action: accept
+    src: [tag:monitoring]
+    dst: [tag:rdna4]
+    ports: [9835]
+
+  # DGX: preparatory — add ACL rules when hardware is provisioned
+
+  # Monitoring stack: admin access to Prometheus/Grafana/Loki dashboards
+  - action: accept
+    src: [group:admin]
+    dst: [tag:monitoring]
+
+  # Monitoring: scrape all infrastructure ports for /metrics endpoints
+  # Safe because tag:pmoves (GPU Orchestrator) is isolated at tag level
+  - action: accept
+    src: [tag:monitoring]
+    dst: [group:infrastructure]
+
+  # GPU Orchestrator: admin-only — model load/unload is a sensitive operation
+  - action: accept
+    src: [group:admin]
+    dst: [tag:pmoves]
+    ports: [8200]
+
+# ── SSH ─────────────────────────────────────────────────────
+ssh:
+  # Admin: unrestricted SSH to all groups
+  - action: accept
+    src: [group:admin]
+    dst: [group:*]
+  # Support: SSH to infrastructure nodes for troubleshooting
+  - action: accept
+    src: [group:support]
+    dst: [group:infrastructure]
+
+# ── Auto-Approvers ──────────────────────────────────────────
+autoApprovers:
+  # Nodes tagged 'exit' are auto-approved as exit nodes
+  exitNode: ["tag:exit"]

--- a/pmoves/config/headscale/config.yaml
+++ b/pmoves/config/headscale/config.yaml
@@ -1,1 +1,77 @@
-# DEPRECATED — authoritative config lives in vendor/PMOVES-Headscale/pmoves/config.yaml
+# Mirrored from PMOVES-Headscale submodule (PMOVES.AI-Edition-Hardened branch)
+# PMOVES.AI Headscale Configuration — v0.28.0
+# =============================================================================
+# Self-hosted Tailscale control server for VPN mesh networking
+# Fork: github.com/POWERFULMOVES/PMOVES-headscale
+# =============================================================================
+
+server_url: https://headscale.pmoves.local
+listen_addr: 0.0.0.0:8096
+metrics_listen_addr: 0.0.0.0:9090
+grpc_listen_addr: 127.0.0.1:50443
+grpc_allow_insecure: false
+disable_check_updates: true
+randomize_client_port: false
+
+noise:
+  private_key_path: /var/lib/headscale/noise_private.key
+
+prefixes:
+  v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48
+  allocation: sequential
+
+derp:
+  server:
+    enabled: false
+  urls:
+    - https://controlplane.tailscale.com/derpmap/default
+  auto_update_enabled: true
+  update_frequency: 3h
+
+node:
+  expiry: 0
+  ephemeral:
+    inactivity_timeout: 30m
+  routes:
+    ha:
+      probe_interval: 10s
+      probe_timeout: 5s
+
+database:
+  type: sqlite
+  debug: false
+  gorm:
+    prepare_stmt: true
+    parameterized_queries: true
+    skip_err_record_not_found: true
+    slow_threshold: 1000
+  sqlite:
+    path: /var/lib/headscale/db.sqlite
+    write_ahead_log: true
+    wal_autocheckpoint: 1000
+
+policy:
+  mode: file
+  path: /etc/headscale/acl.yaml
+
+dns:
+  base_domain: ts.pmoves.net
+  override_local_dns: true
+  nameservers:
+    global:
+      - 1.1.1.1
+      - 1.0.0.1
+
+unix_socket: /var/run/headscale/headscale.sock
+unix_socket_permission: "0770"
+
+log:
+  level: info
+  format: text
+
+logtail:
+  enabled: false
+
+taildrop:
+  enabled: true

--- a/pmoves/deploy/compose/headscale-standalone.yml
+++ b/pmoves/deploy/compose/headscale-standalone.yml
@@ -1,1 +1,49 @@
-# DEPRECATED — authoritative compose lives in vendor/PMOVES-Headscale/pmoves/docker-compose.hostinger.yml
+# Mirrored from PMOVES-Headscale submodule (PMOVES.AI-Edition-Hardened branch)
+# PMOVES Headscale — Hostinger Docker API Variant
+# =============================================================================
+# Fork: github.com/POWERFULMOVES/PMOVES-headscale
+# Derived from upstream official compose + PMOVES hardening requirements
+#
+# Hostinger API constraints satisfied:
+#   - No external networks
+#   - No profiles section
+#   - No env_file references
+#   - No ${VAR:-default} — bare ${VAR} only
+#   - Absolute volume paths
+#
+# Docker hardening applied:
+#   - read_only: true (immutable filesystem)
+#   - tmpfs: /var/run/headscale (unix socket — required with read_only)
+#   - Config volume mounted :ro
+#   - command: serve (REQUIRED — #1 Docker deployment error)
+#   - Version-pinned image (never :latest)
+#
+# Config files (config.yaml, acl.yaml) uploaded via SSH base64 decode
+# to /docker/headscale/config/ before or after compose deployment.
+# =============================================================================
+
+services:
+  headscale:
+    image: ghcr.io/juanfont/headscale:v0.28.0
+    container_name: pmoves-headscale
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /var/run/headscale
+    command: serve
+    environment:
+      - DOCKED_MODE=${DOCKED_MODE}
+      - PARENT_SYSTEM=${PARENT_SYSTEM}
+      - PARENT_VERSION=${PARENT_VERSION}
+    ports:
+      - "8096:8096"
+      - "9091:9090"
+    volumes:
+      - /docker/headscale/config:/etc/headscale:ro
+      - /docker/headscale/data:/var/lib/headscale
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8096/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/pmoves/docker-compose.remote.yml
+++ b/pmoves/docker-compose.remote.yml
@@ -132,11 +132,10 @@ services:
   # =============================================================================
   headscale-agent:
     <<: *vpn-tier
-    image: ghcr.io/juanfont/headscale:v0.28.0
+    image: tailscale/tailscale:stable
     container_name: pmoves-headscale-agent
     restart: unless-stopped
-    command: up
-    privileged: true
+    command: sh -c "tailscaled --state=/var/lib/tailscale/tailscaled.state & sleep 2 && tailscale up --login-server=$HEADSCALE_ADDR --authkey=$HEADSCALE_AUTH_KEY --hostname=$HEADSCALE_HOSTNAME --accept-routes=$HEADSCALE_ACCEPT_ROUTES --ssh=$HEADSCALE_SSH --advertise-tags=$HEADSCALE_TAGS && tail -f /dev/null"
     network_mode: host
     environment:
       - HEADSCALE_ADDR=${HEADSCALE_ADDR:-headscale:8096}
@@ -150,7 +149,7 @@ services:
       - PARENT_VERSION=${PARENT_VERSION:-1.0.0-hardened}
     volumes:
       - /dev/net/tun:/dev/net/tun
-      - headscale-agent-state:/var/lib/headscale
+      - headscale-agent-state:/var/lib/tailscale
     profiles:
       - remote
 


### PR DESCRIPTION
## Summary
- Restore config.yaml, acl.yaml, headscale-standalone.yml with v0.28.0 content mirrored from PMOVES-Headscale submodule (replacing deprecation pointers that broke compose mounts)
- Fix headscale-agent: replace headscale server image with tailscale/tailscale:stable, fix command from unsupported "headscale up" to proper tailscaled+tailscale up invocation, fix volume path /var/lib/headscale → /var/lib/tailscale

## Addresses PR #1348 Review Comments
- Codex P1: restore standalone compose for documented deploy flow
- Codex P1: restore config for docker-compose.remote.yml mount at /etc/headscale
- CodeRabbit Critical: fix headscale-agent image/command (pre-existing bug)
- CodeRabbit Major x3: casing — confirmed already fixed in amended commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Configured Headscale network infrastructure with access control policies, organizational grouping, and traffic routing rules.
  * Added Docker Compose deployment configuration for standalone Headscale services with health monitoring and security hardening.
  * Updated remote agent service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->