### PR TITLE
feat(z890): multi-boot bootstrap infrastructure (Win11/Ubuntu/Pop/Fedora/Cachy/Nix)

### DIFF
--- a/deploy/provision/z890/common/10-tailscale-enroll.sh
+++ b/deploy/provision/z890/common/10-tailscale-enroll.sh
@@ -72,17 +72,19 @@ main() {
 
   log "Joining tailnet as: $hostname"
 
+  # Build tags list
+  local tags="tag:pmoves,tag:z890,tag:workstation,tag:multiboot"
+  case "$distro" in
+    ubuntu|popos|fedora|nobara|cachyos|nixos) tags+=",tag:${distro}" ;;
+  esac
+
   local ts_args=(
     --auth-key "$TAILSCALE_AUTHKEY"
     --hostname "$hostname"
     --accept-routes
     --accept-dns
-    --tag=tag:pmoves --tag=tag:z890 --tag=tag:workstation --tag=tag:multiboot
+    --advertise-tags="$tags"
   )
-  # Distro-specific tag for ACL differentiation
-  case "$distro" in
-    ubuntu|popos|fedora|nobara|cachyos|nixos) ts_args+=(--tag="tag:${distro}") ;;
-  esac
 
   if [[ -n "${TAILSCALE_EXTRA_ARGS:-}" ]]; then
     # shellcheck disable=SC2086

--- a/deploy/provision/z890/media/prepare-usb.sh
+++ b/deploy/provision/z890/media/prepare-usb.sh
@@ -55,17 +55,8 @@ fi
 # Portable YAML extraction without python deps in extracted values
 yaml_get() {
   # Extract a scalar value from distros.<distro>.<key>
+  # Uses awk-based parser (works for flat scalar fields)
   local distro="$1" key="$2"
-  python3 - "$distro" "$key" <<'PYEOF' 2>/dev/null
-import sys
-try:
-    import yaml  # PyYAML
-except Exception:
-    sys.exit(2)
-with open(sys.argv[0].replace("-","").replace("_","").replace("manifest",""),"r") as _:
-    pass
-PYEOF
-  # Fallback: awk-based extractor (works for flat scalar fields)
   awk -v d="$distro" -v k="$key" '
     $0 ~ ("^  " d ":") { inblock=1; next }
     inblock && /^  [a-z0-9_-]+:/ && !/^    / { inblock=0 }


### PR DESCRIPTION
## Summary
Add Z890-specific makefile targets and bootstrap scripts for 6-slot multi-boot
workstation. Supports fresh install flows via USB media or PXE netboot.

**New Makefile Targets:**
- `z890-media-usb`: Prepare per-device USB installer (DISTRO=ubuntu-24.04 DEVICE=/dev/sdX)
- `z890-media-nvme`: Partition external NVMe as multi-boot target (DEVICE=/dev/nvme0n1)
- `z890-pxe-serve`: Serve netboot.xyz custom menu on 5090
- `z890-post-install`: Auto-detects running distro via profile.yaml, runs post-install script
- `z890-verify`: Full verification sweep (profile, tailscale, docker, nvidia, NATS, Hi-RAG)

**Bootstrap Scripts (`deploy/provision/z890/`):**
- `media/prepare-usb.sh`: USB installer creation
- `media/prepare-nvme-target.sh`: NVMe partitioning
- `pxe/netboot-menu-pmoves.ipxe`: Custom netboot.xyz menu
- `pxe/distro-manifest.yaml`: Distro catalog (ubuntu-24.04, pop-os-22.04, fedora, cachyos, nixos)
- `ubuntu-24.04-post.sh`, `pop-os-22.04-post.sh`, `fedora-nobara-post.sh`, `cachyos-post.sh`: Per-distro post-install
- `nixos-post.nix`: NixOS declarative config
- `windows11-post.ps1`: Windows slot configuration
- `common/99-verify.sh`: Verification sweep

**Claw Config:**
- `pmoves/configs/claws/claude-md/z890.md`: Multi-boot awareness section, slot detection table

**Related Documentation:**
- `deploy/provision/z890/README.md`: Full operator runbook
- `pmoves/docs/operations/TOPOLOGY.md`: Updated with multi-boot reference (separate commit)

## Test plan
- [ ] Review `deploy/provision/z890/README.md` for full runbook
- [ ] Test `make -C pmoves z890-media-usb DISTRO=ubuntu-24.04 DEVICE=/dev/sdX` on test machine
- [ ] Verify `z890-post-install` auto-detection logic on each distro
- [ ] Run `z890-verify` sweep on healthy Z890 node
- [ ] Check z890 claw config multi-boot awareness section

🤖 Generated with [Claude Code](https://claude.com/claude-code)