### PR TITLE
feat(jetson): JetPack 7.0 reflow infrastructure for Nemoton/NemoClaw fleet

### DIFF
--- a/deploy/provision/jetson/jetpack7-reflash.sh
+++ b/deploy/provision/jetson/jetpack7-reflash.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 
 DEVICE=""
 SKIP_FLASH=0
+JETSON_USER="${JETSON_USER:-pmovesnvme}"
 JETPACK_VERSION="${JETPACK_VERSION:-7.0}"
 SDKM_CLI="${SDKM_CLI:-/usr/local/bin/sdkmanager}"
 
@@ -161,23 +162,23 @@ done
 if [[ -z "$JETSON_HOST" ]]; then
   log "⚠ Could not reach $DEVICE via ping. Manual deploy required:"
   log "  1. Connect to Jetson over USB-C ethernet (192.168.55.1) or LAN"
-  log "  2. Run: scp deploy/provision/jetson/post-flash-bootstrap.sh user@\$JETSON_IP:/tmp/"
-  log "  3. Run: ssh user@\$JETSON_IP 'sudo DEVICE=$DEVICE bash /tmp/post-flash-bootstrap.sh'"
+  log "  2. Run: scp deploy/provision/jetson/post-flash-bootstrap.sh ${JETSON_USER}@\$JETSON_IP:/tmp/"
+  log "  3. Run: ssh ${JETSON_USER}@\$JETSON_IP 'sudo DEVICE=$DEVICE bash /tmp/post-flash-bootstrap.sh'"
   exit 0
 fi
 
 log "Copying post-flash-bootstrap.sh + nemotron-branding/ to Jetson..."
 scp -o StrictHostKeyChecking=accept-new \
   "$(dirname "${BASH_SOURCE[0]}")/post-flash-bootstrap.sh" \
-  "$JETSON_HOST:/tmp/post-flash-bootstrap.sh"
+  "${JETSON_USER}@${JETSON_HOST}:/tmp/post-flash-bootstrap.sh"
 scp -o StrictHostKeyChecking=accept-new -r \
   "$(dirname "${BASH_SOURCE[0]}")/nemotron-branding" \
-  "$JETSON_HOST:/tmp/"
+  "${JETSON_USER}@${JETSON_HOST}:/tmp/"
 
-log "Running post-flash-bootstrap on $JETSON_HOST..."
-ssh "$JETSON_HOST" \
+log "Running post-flash-bootstrap on ${JETSON_USER}@${JETSON_HOST}..."
+ssh "${JETSON_USER}@${JETSON_HOST}"\
   "sudo DEVICE=${DEVICE} TAILSCALE_AUTHKEY=${TAILSCALE_AUTHKEY:-} bash /tmp/post-flash-bootstrap.sh" || {
-    log "WARN: post-flash ran with errors — check manually via ssh $JETSON_HOST"
+    log "WARN: post-flash ran with errors — check manually via ssh ${JETSON_USER}@${JETSON_HOST}"
   }
 
 log "═══════════════════════════════════════════"

--- a/deploy/provision/jetson/post-flash-bootstrap.sh
+++ b/deploy/provision/jetson/post-flash-bootstrap.sh
@@ -96,7 +96,7 @@ else
     --auth-key "$TAILSCALE_AUTHKEY" \
     --hostname "pmoves-${DEVICE}" \
     --accept-routes --accept-dns \
-    --tag=tag:pmoves --tag=tag:jetson --tag=tag:nemotron --tag=tag:edge --tag=tag:arm64 --tag=tag:production
+    --advertise-tags=tag:pmoves,tag:jetson,tag:nemotron,tag:edge,tag:arm64,tag:production
   sleep 3
   log "Tailscale: $(tailscale ip -4 2>/dev/null || echo pending) / $(tailscale status | head -1 || echo unknown)"
 fi

--- a/deploy/provision/jetson/verify-jetson-fleet.sh
+++ b/deploy/provision/jetson/verify-jetson-fleet.sh
@@ -64,8 +64,9 @@ else
 fi
 
 ssh_jetson() {
+  local target="${ip:-$JETSON_HOST}"
   ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new \
-    "${SSH_USER}@${JETSON_HOST}" "$@"
+    "${SSH_USER}@${target}" "$@"
 }
 
 section "1. JetPack 7.0 / L4T r37"


### PR DESCRIPTION
## Summary
Add Jetson Orin Nano reflow runbook targeting JetPack 7.0 (L4T r37, CUDA 12.8)
for Nemoton/NemoClaw edge fleet. Supports SDK Manager-driven reflow from x86 host
and post-flash fleet integration.

**New Makefile Targets (pmoves/Makefile):**
- `jetson-reflash`: Drive SDK Manager to reflash Jetson (DEVICE=nemoton-1|nemoton-2)
- `jetson-post-flash`: Copy and run post-flash-bootstrap.sh on already-flashed Jetson
- `jetson-verify`: Verify fleet integration (tailscale, docker, arm64 compose, NATS)

**Bootstrap Scripts (deploy/provision/jetson/):**
- `jetpack7-reflash.sh`: SDK Manager automation (45 min per device)
- `post-flash-bootstrap.sh`: Fleet enrollment, Docker install, repo clone
- `nemoton-branding/`: MOTD colorization, hostname (pmoves-nemoton-N)
- `verify-jetson-fleet.sh`: Fleet integration verification sweep
- `arm64-jetpack7-compose-fragment.yaml`: arm64 compose override for CUDA 12.8

**Service Registry (pmoves/bootstrap/registry.json):**
- `jetson-fleet`: Per-device metadata group
  - `JETSON_DEVICE_NAME`: nemoton-1 | nemoton-2
  - `NEMOTRON_VARIANT`: nemoton | nemoclaw
  - `JETPACK_VERSION`: 7.0 (matches 5090 CUDA 12.8 stack)

**Documentation:**
- `deploy/provision/jetson/README.md`: Full reflow runbook
- `pmoves/docs/operations/HARDWARE_PROFILES_JETPACK7_ADDENDUM.md`: JetPack 7 hardware notes

**Topology Updates (separate PR):**
- TOPOLOGY.md: Jetson entries updated with Nemoton naming, JetPack 7 reflow notes

## Test plan
- [ ] Review `deploy/provision/jetson/README.md` for full runbook
- [ ] Verify `jetpack7-reflash.sh` has correct SDK Manager paths
- [ ] Test `post-flash-bootstrap.sh` on non-Jetson Linux machine (dry-run mode)
- [ ] Check registry.json jetson-fleet variable definitions
- [ ] Verify arm64 compose fragment syntax
- [ ] Do NOT execute reflow during UNFCU demos (~45 min per device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)