### PR TITLE
feat(observability): add specialist agents for MOF observability layer

### DIFF
--- a/pmoves/config/agent_registry.yaml
+++ b/pmoves/config/agent_registry.yaml
@@ -1967,6 +1967,193 @@ agents:
       compose_profile: null
     description: "MCP bridge for E2B sandboxed code execution"
 
+  metrics_specialist:
+    name: "Prometheus Metrics Specialist"
+    class: specialized
+    primary_type: data
+    secondary_type: api
+    port: null                         # CLI agent — queries Prometheus HTTP API
+    health: null
+    layers: [L4, L5, L6]
+    evolution_stage: active
+    signature: "claude-opus"
+    nats:
+      publishes:
+        - "observability.metrics.anomaly.v1"
+        - "observability.metrics.trend.v1"
+      subscribes:
+        - "mesh.node.announce.v1"
+        - "observability.query.request.v1"
+    chit_toggles:
+      delta_sensitive: true            # metric rate changes → delta
+      kappa_sensitive: false
+      hz_sensitive: false
+      swarm_participant: true
+      attribution_gated: true
+    resilience:
+      context_budget: medium
+      checkpoint_frequency: per_query
+      recovery_strategy: none
+      cipher_categories: [metrics_analysis, anomaly_detection]
+    topology:
+      node_affinity: [kvm4-1, z890]
+      team: observability
+      ci_runner: ai-lab
+      compose_profile: monitoring
+    tool_path: "pmoves/tools/observability/metrics_specialist.py"
+    runtime: "uv run"
+    description: "Prometheus metrics analysis, anomaly detection, performance trending"
+
+  dashboard_specialist:
+    name: "Grafana Dashboard Specialist"
+    class: specialized
+    primary_type: ui
+    secondary_type: data
+    port: null                         # CLI agent — manages Grafana via HTTP API
+    health: null
+    layers: [L4, L5, L6, L7]
+    evolution_stage: active
+    signature: "claude-opus"
+    nats:
+      publishes:
+        - "observability.dashboard.updated.v1"
+        - "observability.alert.configured.v1"
+      subscribes:
+        - "observability.metrics.anomaly.v1"
+        - "observability.query.request.v1"
+    chit_toggles:
+      delta_sensitive: false
+      kappa_sensitive: false
+      hz_sensitive: false
+      swarm_participant: false
+      attribution_gated: true
+    resilience:
+      context_budget: medium
+      checkpoint_frequency: per_dashboard
+      recovery_strategy: none
+      cipher_categories: [dashboard_management, alert_configuration]
+    topology:
+      node_affinity: [kvm4-1, z890]
+      team: observability
+      ci_runner: ai-lab
+      compose_profile: monitoring
+    tool_path: "pmoves/tools/observability/dashboard_specialist.py"
+    runtime: "uv run"
+    description: "Grafana dashboard creation, metric visualization, alert configuration"
+
+  logs_specialist:
+    name: "Loki Logs Specialist"
+    class: specialized
+    primary_type: data
+    secondary_type: worker
+    port: null                         # CLI agent — queries Loki HTTP API
+    health: null
+    layers: [L4, L5, L6]
+    evolution_stage: active
+    signature: "claude-opus"
+    nats:
+      publishes:
+        - "observability.logs.pattern.v1"
+        - "observability.logs.error.v1"
+        - "observability.logs.correlation.v1"
+      subscribes:
+        - "ingest.file.added.v1"
+        - "observability.query.request.v1"
+    chit_toggles:
+      delta_sensitive: false
+      kappa_sensitive: false
+      hz_sensitive: false
+      swarm_participant: true
+      attribution_gated: true
+    resilience:
+      context_budget: large
+      checkpoint_frequency: per_analysis
+      recovery_strategy: cipher_resumable
+      cipher_categories: [log_analysis, error_detection]
+    topology:
+      node_affinity: [kvm4-1, kvm4-2, z890]
+      team: observability
+      ci_runner: vps
+      compose_profile: monitoring
+    tool_path: "pmoves/tools/observability/logs_specialist.py"
+    runtime: "uv run"
+    description: "Loki log pattern analysis, error detection, cross-service correlation"
+
+  tracing_specialist:
+    name: "Jaeger Tracing Specialist"
+    class: specialized
+    primary_type: data
+    secondary_type: api
+    port: null                         # CLI agent — queries Jaeger HTTP API
+    health: null
+    layers: [L4, L5, L6]
+    evolution_stage: active
+    signature: "claude-opus"
+    nats:
+      publishes:
+        - "observability.trace.bottleneck.v1"
+        - "observability.trace.correlation.v1"
+      subscribes:
+        - "observability.query.request.v1"
+        - "agent.tool.executed.v1"
+    chit_toggles:
+      delta_sensitive: true            # latency changes → delta
+      kappa_sensitive: false
+      hz_sensitive: false
+      swarm_participant: true
+      attribution_gated: true
+    resilience:
+      context_budget: medium
+      checkpoint_frequency: per_trace
+      recovery_strategy: none
+      cipher_categories: [trace_analysis, bottleneck_detection]
+    topology:
+      node_affinity: [kvm4-1, z890]
+      team: observability
+      ci_runner: ai-lab
+      compose_profile: monitoring
+    tool_path: "pmoves/tools/observability/tracing_specialist.py"
+    runtime: "uv run"
+    description: "Jaeger distributed tracing, performance bottleneck identification"
+
+  llm_observability:
+    name: "TensorZero LLM Observability Specialist"
+    class: specialized
+    primary_type: llm
+    secondary_type: data
+    port: null                         # CLI agent — queries TensorZero ClickHouse
+    health: null
+    layers: [L3, L4, L5, L6]
+    evolution_stage: active
+    signature: "claude-opus"
+    nats:
+      publishes:
+        - "observability.llm.performance.v1"
+        - "observability.llm.cost.v1"
+        - "observability.llm.model_comparison.v1"
+      subscribes:
+        - "mesh.gpu.model.loaded.v1"
+        - "observability.query.request.v1"
+    chit_toggles:
+      delta_sensitive: true            # token usage changes → delta
+      kappa_sensitive: true            # latency patterns → kappa
+      hz_sensitive: true               # throughput → Hz
+      swarm_participant: true
+      attribution_gated: true
+    resilience:
+      context_budget: medium
+      checkpoint_frequency: per_analysis
+      recovery_strategy: cipher_resumable
+      cipher_categories: [llm_performance, cost_optimization]
+    topology:
+      node_affinity: [z890, 5090]      # GPU nodes preferred
+      team: observability
+      ci_runner: ai-lab
+      compose_profile: monitoring
+    tool_path: "pmoves/tools/observability/llm_observability_specialist.py"
+    runtime: "uv run"
+    description: "TensorZero LLM performance analysis, cost optimization, model comparison"
+
   cipher_beats_analyst:
     name: "Cipher Beats Analyst"
     class: specialized

--- a/pmoves/configs/agent-teams.yaml
+++ b/pmoves/configs/agent-teams.yaml
@@ -166,6 +166,19 @@ teams:
       - wealth            # Firefly III finance tracking
       - health            # wger fitness tracking
 
+  observability:
+    name: "Observability & Monitoring"
+    description: "Metrics, logs, traces, dashboards, and alerting for MOF surface area"
+    node_affinity: [kvm4-1, z890]
+    ci_runner: ai-lab
+    compose_profiles: [monitoring]
+    agents:
+      - metrics_specialist      # Prometheus metrics analysis
+      - dashboard_specialist    # Grafana dashboard management
+      - logs_specialist         # Loki log analysis
+      - tracing_specialist      # Jaeger distributed tracing
+      - llm_observability       # TensorZero LLM performance
+
 # Validation: all agents from agent_registry.yaml must appear in exactly one team
 # Run: python -c "
 # import yaml

--- a/pmoves/tools/observability/dashboard_specialist.py
+++ b/pmoves/tools/observability/dashboard_specialist.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""
+Grafana Dashboard Specialist - Observability Layer Agent
+
+Manages Grafana dashboards, datasources, and alert configurations.
+Creates and updates visualizations based on system metrics and observability data.
+
+Usage:
+    python pmoves/tools/observability/dashboard_specialist.py list
+    python pmoves/tools/observability/dashboard_specialist.py create <dashboard_title> --template <template_name>
+    python pmoves/tools/observability/dashboard_specialist.py update <dashboard_uid> --metrics
+    python pmoves/tools/observability/dashboard_specialist.py alert <dashboard_uid> --threshold <value>
+
+Environment:
+    GRAFANA_URL - Grafana server URL (default: http://localhost:3002)
+    GRAFANA_API_KEY - Grafana API key (optional, for authenticated requests)
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests
+
+# Add repo root to path
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class GrafanaDashboardSpecialist:
+    """Specialist agent for Grafana dashboard management and visualization."""
+
+    def __init__(
+        self,
+        grafana_url: str | None = None,
+        api_key: str | None = None
+    ):
+        """Initialize Grafana client.
+
+        Args:
+            grafana_url: Grafana server URL (default from env or localhost:3002)
+            api_key: Grafana API key (optional)
+        """
+        self.grafana_url = grafana_url or os.getenv(
+            "GRAFANA_URL", "http://localhost:3002"
+        )
+        self.api_key = api_key or os.getenv("GRAFANA_API_KEY")
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        })
+        if self.api_key:
+            self.session.headers.update({
+                "Authorization": f"Bearer {self.api_key}"
+            })
+
+    def list_dashboards(self, folder_filter: str | None = None) -> List[Dict[str, Any]]:
+        """List all Grafana dashboards.
+
+        Args:
+            folder_filter: Optional folder name filter
+
+        Returns:
+            List of dashboard metadata
+        """
+        params = {}
+        if folder_filter:
+            params["folderIds"] = folder_filter
+
+        response = self.session.get(
+            f"{self.grafana_url}/api/search",
+            params=params,
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_dashboard(self, dashboard_uid: str) -> Dict[str, Any]:
+        """Get dashboard details by UID.
+
+        Args:
+            dashboard_uid: Dashboard UID
+
+        Returns:
+            Dashboard configuration
+        """
+        response = self.session.get(
+            f"{self.grafana_url}/api/dashboards/uid/{dashboard_uid}",
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def create_dashboard(
+        self,
+        title: str,
+        template: str = "default",
+        metrics: List[Dict[str, Any]] | None = None
+    ) -> Dict[str, Any]:
+        """Create a new dashboard.
+
+        Args:
+            title: Dashboard title
+            template: Dashboard template name (default, service, overview)
+            metrics: List of metric queries to visualize
+
+        Returns:
+            Created dashboard details
+        """
+        dashboard_config = self._build_dashboard_template(title, template, metrics)
+
+        payload = {
+            "dashboard": dashboard_config,
+            "message": f"Created dashboard '{title}' via Observability Agent",
+            "overwrite": False
+        }
+
+        response = self.session.post(
+            f"{self.grafana_url}/api/dashboards/db",
+            json=payload,
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def update_dashboard(
+        self,
+        dashboard_uid: str,
+        metrics: List[Dict[str, Any]] | None = None
+    ) -> Dict[str, Any]:
+        """Update existing dashboard with new metrics.
+
+        Args:
+            dashboard_uid: Dashboard UID
+            metrics: List of metric queries to add
+
+        Returns:
+            Updated dashboard details
+        """
+        # Get existing dashboard
+        current = self.get_dashboard(dashboard_uid)
+        dashboard_config = current["dashboard"]
+
+        # Add new metric panels
+        if metrics:
+            for i, metric in enumerate(metrics):
+                panel = self._build_panel_from_metric(metric, i)
+                dashboard_config["panels"].append(panel)
+
+        payload = {
+            "dashboard": dashboard_config,
+            "message": "Updated dashboard via Observability Agent",
+            "overwrite": True
+        }
+
+        response = self.session.post(
+            f"{self.grafana_url}/api/dashboards/db",
+            json=payload,
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def configure_alert(
+        self,
+        dashboard_uid: str,
+        panel_id: int,
+        threshold: float,
+        condition: str = "greater"
+    ) -> Dict[str, Any]:
+        """Configure alert on a dashboard panel.
+
+        Args:
+            dashboard_uid: Dashboard UID
+            panel_id: Panel ID to alert on
+            threshold: Alert threshold value
+            condition: Alert condition (greater, less, equal)
+
+        Returns:
+            Alert configuration result
+        """
+        # Get current dashboard
+        current = self.get_dashboard(dashboard_uid)
+        dashboard_config = current["dashboard"]
+
+        # Find target panel
+        panel = None
+        for p in dashboard_config.get("panels", []):
+            if p.get("id") == panel_id:
+                panel = p
+                break
+
+        if not panel:
+            raise ValueError(f"Panel {panel_id} not found in dashboard")
+
+        # Add alert configuration
+        panel["alert"] = {
+            "conditions": [
+                {
+                    "evaluator": {
+                        "params": [threshold],
+                        "type": condition
+                    },
+                    "operator": {
+                        "type": "and"
+                    },
+                    "query": {
+                        "params": ["A", "5m", "now"]
+                    },
+                    "reducer": {
+                        "params": [],
+                        "type": "avg"
+                    },
+                    "type": "query"
+                }
+            ],
+            "executionErrorState": "alerting",
+            "frequency": "60s",
+            "handler": 1,
+            "message": f"Alert: {panel.get('title', 'Panel')} has exceeded threshold {threshold}",
+            "name": f"{panel.get('title', 'Panel')} Alert",
+            "noDataState": "no_data",
+            "notifications": []
+        }
+
+        # Update dashboard
+        payload = {
+            "dashboard": dashboard_config,
+            "message": "Added alert configuration via Observability Agent",
+            "overwrite": True
+        }
+
+        response = self.session.post(
+            f"{self.grafana_url}/api/dashboards/db",
+            json=payload,
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _build_dashboard_template(
+        self,
+        title: str,
+        template: str,
+        metrics: List[Dict[str, Any]] | None
+    ) -> Dict[str, Any]:
+        """Build dashboard configuration from template.
+
+        Args:
+            title: Dashboard title
+            template: Template name
+            metrics: Optional metric queries
+
+        Returns:
+            Dashboard configuration
+        """
+        config = {
+            "title": title,
+            "tags": ["observability", "pmoves"],
+            "timezone": "browser",
+            "refresh": "30s",
+            "panels": [],
+            "schemaVersion": 38,
+            "version": 1
+        }
+
+        # Add template-specific panels
+        if template == "service":
+            config["panels"].extend([
+                self._build_panel_from_metric({
+                    "title": "Request Rate",
+                    "query": 'rate(http_requests_total[5m])',
+                    "type": "graph"
+                }, 1),
+                self._build_panel_from_metric({
+                    "title": "Error Rate",
+                    "query": 'rate(http_errors_total[5m])',
+                    "type": "graph"
+                }, 2),
+                self._build_panel_from_metric({
+                    "title": "Latency (p95)",
+                    "query": 'histogram_quantile(0.95, http_request_duration_seconds_bucket)',
+                    "type": "graph"
+                }, 3),
+            ])
+        elif template == "overview":
+            config["panels"].extend([
+                self._build_panel_from_metric({
+                    "title": "Service Health",
+                    "query": 'up{job="pmoves"}',
+                    "type": "stat"
+                }, 1),
+                self._build_panel_from_metric({
+                    "title": "Container CPU",
+                    "query": 'rate(container_cpu_usage_seconds_total[5m])',
+                    "type": "graph"
+                }, 2),
+                self._build_panel_from_metric({
+                    "title": "Container Memory",
+                    "query": 'container_memory_usage_bytes',
+                    "type": "graph"
+                }, 3),
+            ])
+
+        # Add custom metric panels if provided
+        if metrics:
+            for i, metric in enumerate(metrics, start=len(config["panels"]) + 1):
+                config["panels"].append(
+                    self._build_panel_from_metric(metric, i)
+                )
+
+        return config
+
+    def _build_panel_from_metric(self, metric: Dict[str, Any], panel_id: int) -> Dict[str, Any]:
+        """Build Grafana panel from metric definition.
+
+        Args:
+            metric: Metric definition with title, query, type
+            panel_id: Panel ID
+
+        Returns:
+            Panel configuration
+        """
+        panel_type = metric.get("type", "graph")
+
+        panel = {
+            "id": panel_id,
+            "title": metric.get("title", f"Panel {panel_id}"),
+            "type": panel_type,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": (panel_id - 1) % 2 * 12,
+                "y": ((panel_id - 1) // 2) * 8
+            },
+            "targets": [
+                {
+                    "expr": metric.get("query", "up"),
+                    "refId": "A",
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "PD8C576611E679907"
+                    }
+                }
+            ]
+        }
+
+        if panel_type == "stat":
+            panel["gridPos"]["w"] = 6
+            panel["options"] = {
+                "graphMode": "area",
+                "colorMode": "value"
+            }
+        elif panel_type == "graph":
+            panel["options"] = {
+                "legend": {
+                    "displayMode": "table",
+                    "placement": "bottom"
+                }
+            }
+
+        return panel
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Grafana Dashboard Specialist - Observability Layer Agent"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # List command
+    list_parser = subparsers.add_parser("list", help="List dashboards")
+    list_parser.add_argument("--folder", help="Filter by folder name")
+
+    # Create command
+    create_parser = subparsers.add_parser("create", help="Create dashboard")
+    create_parser.add_argument("title", help="Dashboard title")
+    create_parser.add_argument("--template", default="default", help="Dashboard template")
+    create_parser.add_argument("--metrics", help="JSON file with metric definitions")
+
+    # Update command
+    update_parser = subparsers.add_parser("update", help="Update dashboard")
+    update_parser.add_argument("dashboard_uid", help="Dashboard UID")
+    update_parser.add_argument("--metrics", help="JSON file with metric definitions")
+
+    # Alert command
+    alert_parser = subparsers.add_parser("alert", help="Configure alert")
+    alert_parser.add_argument("dashboard_uid", help="Dashboard UID")
+    alert_parser.add_argument("--panel-id", type=int, required=True, help="Panel ID")
+    alert_parser.add_argument("--threshold", type=float, required=True, help="Alert threshold")
+    alert_parser.add_argument("--condition", default="greater", help="Alert condition")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    specialist = GrafanaDashboardSpecialist()
+
+    try:
+        if args.command == "list":
+            dashboards = specialist.list_dashboards(args.folder)
+            print(f"[+] Found {len(dashboards)} dashboards:")
+            for db in dashboards[:20]:
+                print(f"  - {db.get('title')} (UID: {db.get('uid')})")
+            if len(dashboards) > 20:
+                print(f"  ... and {len(dashboards) - 20} more")
+
+        elif args.command == "create":
+            metrics = None
+            if args.metrics:
+                with open(args.metrics) as f:
+                    metrics = json.load(f)
+
+            result = specialist.create_dashboard(args.title, args.template, metrics)
+            uid = result.get("uid", "N/A")
+            url = f"{specialist.grafana_url}/d/{uid}"
+            print(f"[+] Dashboard created: {url}")
+
+        elif args.command == "update":
+            metrics = None
+            if args.metrics:
+                with open(args.metrics) as f:
+                    metrics = json.load(f)
+
+            result = specialist.update_dashboard(args.dashboard_uid, metrics)
+            print(f"[+] Dashboard updated: {args.dashboard_uid}")
+
+        elif args.command == "alert":
+            result = specialist.configure_alert(
+                args.dashboard_uid,
+                args.panel_id,
+                args.threshold,
+                args.condition
+            )
+            print(f"[+] Alert configured on panel {args.panel_id}")
+
+        return 0
+
+    except requests.RequestException as e:
+        print(f"[!] Grafana API request failed: {e}")
+        return 1
+    except FileNotFoundError as e:
+        print(f"[!] Metrics file not found: {e}")
+        return 1
+    except KeyboardInterrupt:
+        print("\n[!] Interrupted")
+        return 130
+    except Exception as e:
+        print(f"[!] Unexpected error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pmoves/tools/observability/llm_observability_specialist.py
+++ b/pmoves/tools/observability/llm_observability_specialist.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+TensorZero LLM Observability Specialist - Observability Layer Agent
+
+Analyzes LLM performance metrics, costs, and model usage patterns from TensorZero ClickHouse.
+Provides insights for model selection optimization and cost management.
+
+Usage:
+    python pmoves/tools/observability/llm_observability_specialist.py query <sql>
+    python pmoves/tools/observability/llm_observability_specialist.py performance --model <model_name>
+    python pmoves/tools/observability/llm_observability_specialist.py cost --hours 24
+    python pmoves/tools/observability/llm_observability_specialist.py compare <model1> <model2>
+
+Environment:
+    TENSORZERO_CLICKHOUSE_URL - ClickHouse URL (default: http://localhost:8123)
+    TENSORZERO_CLICKHOUSE_USER - ClickHouse user (default: tensorzero)
+    TENSORZERO_CLICKHOUSE_PASSWORD - ClickHouse password (default: tensorzero)
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests
+
+# Add repo root to path
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class TensorZeroObservabilitySpecialist:
+    """Specialist agent for TensorZero LLM performance and cost analysis."""
+
+    def __init__(
+        self,
+        clickhouse_url: str | None = None,
+        user: str | None = None,
+        password: str | None = None
+    ):
+        """Initialize ClickHouse client.
+
+        Args:
+            clickhouse_url: ClickHouse server URL
+            user: ClickHouse username
+            password: ClickHouse password
+        """
+        self.clickhouse_url = clickhouse_url or os.getenv(
+            "TENSORZERO_CLICKHOUSE_URL", "http://localhost:8123"
+        )
+        self.user = user or os.getenv("TENSORZERO_CLICKHOUSE_USER", "tensorzero")
+        self.password = password or os.getenv("TENSORZERO_CLICKHOUSE_PASSWORD", "tensorzero")
+
+    def query(self, sql: str) -> List[Dict[str, Any]]:
+        """Execute SQL query on ClickHouse.
+
+        Args:
+            sql: SQL query
+
+        Returns:
+            Query results as list of dicts
+        """
+        params = {
+            "query": sql,
+            "database": "default",
+            "format": "JSON"
+        }
+
+        response = requests.get(
+            self.clickhouse_url,
+            params=params,
+            auth=(self.user, self.password),
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json().get("data", [])
+
+    def get_model_performance(
+        self,
+        model: str | None = None,
+        hours: int = 24
+    ) -> Dict[str, Any]:
+        """Get LLM performance metrics.
+
+        Args:
+            model: Optional model name filter
+            hours: Analysis period in hours
+
+        Returns:
+            Performance metrics
+        """
+        end = datetime.now()
+        start = end - timedelta(hours=hours)
+
+        model_filter = f"AND model_name = '{model}'" if model else ""
+
+        sql = f"""
+        SELECT
+            model_name,
+            count() as total_requests,
+            avg(latency) as avg_latency_ms,
+            quantile(0.50)(latency) as p50_latency_ms,
+            quantile(0.95)(latency) as p95_latency_ms,
+            quantile(0.99)(latency) as p99_latency_ms,
+            sum(prompt_tokens) as total_prompt_tokens,
+            sum(completion_tokens) as total_completion_tokens
+        FROM requests
+        WHERE start_time >= now() - INTERVAL {hours} HOUR
+          {model_filter}
+        GROUP BY model_name
+        ORDER BY total_requests DESC
+        """
+
+        results = self.query(sql)
+
+        if not results:
+            return {"error": "No data found for the specified period"}
+
+        return {
+            "period_hours": hours,
+            "models": results
+        }
+
+    def get_cost_analysis(self, hours: int = 24) -> Dict[str, Any]:
+        """Analyze LLM costs by model and provider.
+
+        Args:
+            hours: Analysis period in hours
+
+        Returns:
+            Cost breakdown
+        """
+        sql = f"""
+        SELECT
+            model_name,
+            provider_name,
+            count() as total_requests,
+            sum(prompt_tokens) as total_prompt_tokens,
+            sum(completion_tokens) as total_completion_tokens,
+            sum(prompt_tokens + completion_tokens) as total_tokens
+        FROM requests
+        WHERE start_time >= now() - INTERVAL {hours} HOUR
+        GROUP BY model_name, provider_name
+        ORDER BY total_tokens DESC
+        """
+
+        results = self.query(sql)
+
+        # Estimate costs (approximate pricing)
+        # These are placeholder rates - actual rates vary by provider
+        cost_per_1k_tokens = {
+            "claude-opus-4-5": 15.0,
+            "claude-sonnet-4-5": 3.0,
+            "claude-haiku-4-5": 0.25,
+            "gpt-4": 30.0,
+            "gpt-3.5-turbo": 0.5,
+            "default": 1.0
+        }
+
+        total_estimated_cost = 0.0
+
+        for row in results:
+            model = row.get("model_name", "default")
+            total_tokens = row.get("total_tokens", 0)
+
+            # Get cost rate (use default if not found)
+            rate = cost_per_1k_tokens.get(model, cost_per_1k_tokens["default"])
+
+            # Calculate estimated cost
+            estimated_cost = (total_tokens / 1000) * rate
+            row["estimated_cost_usd"] = estimated_cost
+            total_estimated_cost += estimated_cost
+
+        return {
+            "period_hours": hours,
+            "total_estimated_cost_usd": total_estimated_cost,
+            "models": results
+        }
+
+    def compare_models(
+        self,
+        model1: str,
+        model2: str,
+        hours: int = 24
+    ) -> Dict[str, Any]:
+        """Compare performance between two models.
+
+        Args:
+            model1: First model name
+            model2: Second model name
+            hours: Analysis period
+
+        Returns:
+            Model comparison
+        """
+        sql = f"""
+        SELECT
+            model_name,
+            count() as total_requests,
+            avg(latency) as avg_latency_ms,
+            quantile(0.95)(latency) as p95_latency_ms,
+            sum(prompt_tokens) as total_prompt_tokens,
+            sum(completion_tokens) as total_completion_tokens,
+            sum(prompt_tokens + completion_tokens) as total_tokens
+        FROM requests
+        WHERE start_time >= now() - INTERVAL {hours} HOUR
+          AND model_name IN ('{model1}', '{model2}')
+        GROUP BY model_name
+        """
+
+        results = self.query(sql)
+
+        comparison = {
+            "model1": model1,
+            "model2": model2,
+            "period_hours": hours,
+            "models": {}
+        }
+
+        for row in results:
+            model = row.get("model_name", "unknown")
+            comparison["models"][model] = row
+
+        # Calculate differences
+        if len(results) == 2:
+            m1_data = comparison["models"].get(model1, {})
+            m2_data = comparison["models"].get(model2, {})
+
+            comparison["comparison"] = {
+                "latency_diff_ms": m2_data.get("avg_latency_ms", 0) - m1_data.get("avg_latency_ms", 0),
+                "token_diff": m2_data.get("total_tokens", 0) - m1_data.get("total_tokens", 0),
+                "request_count_diff": m2_data.get("total_requests", 0) - m1_data.get("total_requests", 0)
+            }
+
+        return comparison
+
+    def get_slowest_requests(self, limit: int = 10) -> List[Dict[str, Any]]:
+        """Get slowest LLM requests.
+
+        Args:
+            limit: Number of results
+
+        Returns:
+            Slowest requests
+        """
+        sql = f"""
+        SELECT
+            model_name,
+            latency,
+            prompt_tokens,
+            completion_tokens,
+            substring(request_payload, 1, 100) as request_preview
+        FROM requests
+        ORDER BY latency DESC
+        LIMIT {limit}
+        """
+
+        return self.query(sql)
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="TensorZero LLM Observability Specialist - Observability Layer Agent"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Query command
+    query_parser = subparsers.add_parser("query", help="Execute SQL query")
+    query_parser.add_argument("sql", help="SQL query")
+
+    # Performance command
+    perf_parser = subparsers.add_parser("performance", help="Get model performance")
+    perf_parser.add_argument("--model", help="Model name filter")
+    perf_parser.add_argument("--hours", type=int, default=24, help="Analysis period")
+
+    # Cost command
+    cost_parser = subparsers.add_parser("cost", help="Analyze costs")
+    cost_parser.add_argument("--hours", type=int, default=24, help="Analysis period")
+
+    # Compare command
+    compare_parser = subparsers.add_parser("compare", help="Compare models")
+    compare_parser.add_argument("model1", help="First model")
+    compare_parser.add_argument("model2", help="Second model")
+    compare_parser.add_argument("--hours", type=int, default=24, help="Analysis period")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    specialist = TensorZeroObservabilitySpecialist()
+
+    try:
+        if args.command == "query":
+            results = specialist.query(args.sql)
+            print(f"[+] Query results ({len(results)} rows):")
+            for row in results[:20]:
+                print(f"  {row}")
+            if len(results) > 20:
+                print(f"  ... and {len(results) - 20} more")
+
+        elif args.command == "performance":
+            perf = specialist.get_model_performance(args.model, args.hours)
+            if "error" in perf:
+                print(f"[!] {perf['error']}")
+            else:
+                print(f"[+] Model Performance (last {perf['period_hours']}h):")
+                for model in perf['models']:
+                    print(f"\n  Model: {model['model_name']}")
+                    print(f"    Requests: {model['total_requests']}")
+                    print(f"    Avg Latency: {model['avg_latency_ms']:.2f}ms")
+                    print(f"    P95 Latency: {model['p95_latency_ms']:.2f}ms")
+                    print(f"    P99 Latency: {model['p99_latency_ms']:.2f}ms")
+                    print(f"    Total Tokens: {model['total_prompt_tokens'] + model['total_completion_tokens']}")
+
+        elif args.command == "cost":
+            cost = specialist.get_cost_analysis(args.hours)
+            print(f"[+] Cost Analysis (last {cost['period_hours']}h):")
+            print(f"\n  Total Estimated Cost: ${cost['total_estimated_cost_usd']:.2f} USD")
+            print("\n  Breakdown by Model:")
+            for model in cost['models']:
+                model_name = model['model_name']
+                provider = model.get('provider_name', 'unknown')
+                requests = model['total_requests']
+                tokens = model['total_tokens']
+                est_cost = model['estimated_cost_usd']
+                print(f"    {model_name} ({provider}):")
+                print(f"      Requests: {requests}")
+                print(f"      Tokens: {tokens:,}")
+                print(f"      Est Cost: ${est_cost:.4f} USD")
+
+        elif args.command == "compare":
+            comp = specialist.compare_models(args.model1, args.model2, args.hours)
+            print(f"[+] Model Comparison (last {comp['period_hours']}h):")
+
+            for model_name, data in comp.get("models", {}).items():
+                print(f"\n  {model_name}:")
+                print(f"    Requests: {data['total_requests']}")
+                print(f"    Avg Latency: {data['avg_latency_ms']:.2f}ms")
+                print(f"    P95 Latency: {data['p95_latency_ms']:.2f}ms")
+                print(f"    Total Tokens: {data['total_tokens']:,}")
+
+            if "comparison" in comp:
+                c = comp['comparison']
+                print(f"\n  Differences:")
+                print(f"    Latency: {c['latency_diff_ms']:+.2f}ms")
+                print(f"    Tokens: {c['token_diff']:+,}")
+                print(f"    Requests: {c['request_count_diff']:+,}")
+
+        return 0
+
+    except requests.RequestException as e:
+        print(f"[!] ClickHouse query failed: {e}")
+        return 1
+    except KeyboardInterrupt:
+        print("\n[!] Interrupted")
+        return 130
+    except Exception as e:
+        print(f"[!] Unexpected error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pmoves/tools/observability/logs_specialist.py
+++ b/pmoves/tools/observability/logs_specialist.py
@@ -18,6 +18,7 @@ Environment:
 import argparse
 import os
 import re
+import json
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path

--- a/pmoves/tools/observability/logs_specialist.py
+++ b/pmoves/tools/observability/logs_specialist.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""
+Loki Logs Specialist - Observability Layer Agent
+
+Analyzes Loki logs to extract patterns, detect errors, and correlate events across services.
+Feeds insights back to Agent Zero for debugging and system optimization.
+
+Usage:
+    python pmoves/tools/observability/logs_specialist.py query <logql>
+    python pmoves/tools/observability/logs_specialist.py errors <service_name> --hours 1
+    python pmoves/tools/observability/logs_specialist.py correlate --trace <trace_id>
+    python pmoves/tools/observability/logs_specialist.py pattern <regex_pattern>
+
+Environment:
+    LOKI_URL - Loki server URL (default: http://localhost:3100)
+"""
+
+import argparse
+import os
+import re
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests
+
+# Add repo root to path
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class LokiLogsSpecialist:
+    """Specialist agent for Loki log analysis and pattern detection."""
+
+    def __init__(self, loki_url: str | None = None):
+        """Initialize Loki client.
+
+        Args:
+            loki_url: Loki server URL (default from env or localhost:3100)
+        """
+        self.loki_url = loki_url or os.getenv(
+            "LOKI_URL", "http://localhost:3100"
+        )
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        })
+
+    def query(self, logql: str, limit: int = 100) -> Dict[str, Any]:
+        """Execute LogQL query.
+
+        Args:
+            logql: LogQL expression
+            limit: Maximum number of results
+
+        Returns:
+            Query result as dict
+        """
+        params = {
+            "query": logql,
+            "limit": str(limit)
+        }
+
+        response = self.session.get(
+            f"{self.loki_url}/loki/api/v1/query_range",
+            params=params,
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def query_range(
+        self,
+        logql: str,
+        start: datetime,
+        end: datetime,
+        limit: int = 1000
+    ) -> Dict[str, Any]:
+        """Execute LogQL range query.
+
+        Args:
+            logql: LogQL expression
+            start: Start time
+            end: End time
+            limit: Maximum number of results
+
+        Returns:
+            Range query result as dict
+        """
+        params = {
+            "query": logql,
+            "start": start.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "end": end.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "limit": str(limit)
+        }
+
+        response = self.session.get(
+            f"{self.loki_url}/loki/api/v1/query_range",
+            params=params,
+            timeout=60
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def extract_errors(self, service: str, hours: int = 1) -> List[Dict[str, Any]]:
+        """Extract error logs for a service.
+
+        Args:
+            service: Service name
+            hours: Lookback period in hours
+
+        Returns:
+            List of error log entries with context
+        """
+        end = datetime.now()
+        start = end - timedelta(hours=hours)
+
+        # LogQL for error logs
+        logql = f'{{{{service="{service}"}}}} |~ "(?i)(error|exception|fatal|panic)"'
+
+        result = self.query_range(logql, start, end, limit=500)
+
+        errors = []
+        for stream in result.get("data", {}).get("result", []):
+            service_name = stream.get("stream", {}).get("service", service)
+            host = stream.get("stream", {}).get("host", "unknown")
+
+            for entry in stream.get("values", []):
+                timestamp_ns, line = entry
+                timestamp = datetime.fromtimestamp(int(timestamp_ns) / 1e9)
+
+                errors.append({
+                    "timestamp": timestamp.isoformat(),
+                    "service": service_name,
+                    "host": host,
+                    "line": line,
+                    "level": self._extract_log_level(line)
+                })
+
+        return sorted(errors, key=lambda e: e["timestamp"], reverse=True)
+
+    def correlate_logs(
+        self,
+        trace_id: str | None = None,
+        request_id: str | None = None,
+        hours: int = 1
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Correlate logs across services by trace or request ID.
+
+        Args:
+            trace_id: Optional trace ID
+            request_id: Optional request ID
+            hours: Lookback period
+
+        Returns:
+            Correlated logs grouped by service
+        """
+        if not trace_id and not request_id:
+            raise ValueError("Must provide either trace_id or request_id")
+
+        end = datetime.now()
+        start = end - timedelta(hours=hours)
+
+        if trace_id:
+            logql = f'|~ "{trace_id}"'
+        else:
+            logql = f'|~ "{request_id}"'
+
+        result = self.query_range(logql, start, end, limit=1000)
+
+        correlated = {}
+        for stream in result.get("data", {}).get("result", []):
+            service = stream.get("stream", {}).get("service", "unknown")
+            if service not in correlated:
+                correlated[service] = []
+
+            for entry in stream.get("values", []):
+                timestamp_ns, line = entry
+                timestamp = datetime.fromtimestamp(int(timestamp_ns) / 1e9)
+
+                correlated[service].append({
+                    "timestamp": timestamp.isoformat(),
+                    "line": line
+                })
+
+        # Sort each service's logs chronologically
+        for service in correlated:
+            correlated[service].sort(key=lambda e: e["timestamp"])
+
+        return correlated
+
+    def detect_patterns(
+        self,
+        pattern: str,
+        service: str | None = None,
+        hours: int = 24
+    ) -> List[Dict[str, Any]]:
+        """Detect regex patterns in logs.
+
+        Args:
+            pattern: Regular expression pattern
+            service: Optional service filter
+            hours: Lookback period
+
+        Returns:
+            List of matching log entries
+        """
+        end = datetime.now()
+        start = end - timedelta(hours=hours)
+
+        logql = f'{{{{service="{service}"}}}}' if service else ""
+        logql += f' |~ "{pattern}"'
+
+        result = self.query_range(logql, start, end, limit=1000)
+
+        matches = []
+        for stream in result.get("data", {}).get("result", []):
+            stream_info = stream.get("stream", {})
+            service_name = stream_info.get("service", "unknown")
+            container = stream_info.get("container", "unknown")
+
+            for entry in stream.get("values", []):
+                timestamp_ns, line = entry
+                timestamp = datetime.fromtimestamp(int(timestamp_ns) / 1e9)
+
+                # Extract pattern matches
+                regex_matches = re.findall(pattern, line, re.IGNORECASE)
+
+                matches.append({
+                    "timestamp": timestamp.isoformat(),
+                    "service": service_name,
+                    "container": container,
+                    "line": line,
+                    "matches": regex_matches
+                })
+
+        return sorted(matches, key=lambda e: e["timestamp"], reverse=True)
+
+    def _extract_log_level(self, line: str) -> str:
+        """Extract log level from log line.
+
+        Args:
+            line: Log line content
+
+        Returns:
+            Log level (info, warn, error, debug)
+        """
+        line_upper = line.upper()
+
+        if "ERROR" in line_upper or "EXCEPTION" in line_upper or "FATAL" in line_upper:
+            return "error"
+        elif "WARN" in line_upper:
+            return "warn"
+        elif "DEBUG" in line_upper:
+            return "debug"
+        else:
+            return "info"
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Loki Logs Specialist - Observability Layer Agent"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Query command
+    query_parser = subparsers.add_parser("query", help="Execute LogQL query")
+    query_parser.add_argument("logql", help="LogQL expression")
+    query_parser.add_argument("--limit", type=int, default=100, help="Result limit")
+
+    # Errors command
+    errors_parser = subparsers.add_parser("errors", help="Extract error logs")
+    errors_parser.add_argument("service", help="Service name")
+    errors_parser.add_argument("--hours", type=int, default=1, help="Lookback period")
+
+    # Correlate command
+    correlate_parser = subparsers.add_parser("correlate", help="Correlate logs")
+    correlate_parser.add_argument("--trace", help="Trace ID")
+    correlate_parser.add_argument("--request", help="Request ID")
+    correlate_parser.add_argument("--hours", type=int, default=1, help="Lookback period")
+
+    # Pattern command
+    pattern_parser = subparsers.add_parser("pattern", help="Detect patterns")
+    pattern_parser.add_argument("regex", help="Regular expression pattern")
+    pattern_parser.add_argument("--service", help="Filter by service")
+    pattern_parser.add_argument("--hours", type=int, default=24, help="Lookback period")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    specialist = LokiLogsSpecialist()
+
+    try:
+        if args.command == "query":
+            result = specialist.query(args.logql, args.limit)
+            print(f"[+] Query results:")
+            print(json.dumps(result, indent=2))
+
+        elif args.command == "errors":
+            errors = specialist.extract_errors(args.service, args.hours)
+            print(f"[+] Found {len(errors)} error logs for {args.service}:")
+            for error in errors[:20]:  # Show first 20
+                level = error.get("level", "info").upper()
+                print(f"  [{level}] {error['timestamp']} - {error['line'][:100]}")
+            if len(errors) > 20:
+                print(f"  ... and {len(errors) - 20} more errors")
+
+        elif args.command == "correlate":
+            correlated = specialist.correlate_logs(args.trace, args.request, args.hours)
+            print(f"[+] Correlated logs across {len(correlated)} services:")
+            for service, logs in correlated.items():
+                print(f"\n  {service}: {len(logs)} entries")
+                for log in logs[:3]:  # Show first 3 per service
+                    print(f"    {log['timestamp']} - {log['line'][:80]}")
+                if len(logs) > 3:
+                    print(f"    ... and {len(logs) - 3} more")
+
+        elif args.command == "pattern":
+            matches = specialist.detect_patterns(args.regex, args.service, args.hours)
+            print(f"[+] Found {len(matches)} matches for pattern '{args.regex}':")
+            for match in matches[:20]:
+                print(f"  {match['timestamp']} ({match['service']}): {match['line'][:80]}")
+            if len(matches) > 20:
+                print(f"  ... and {len(matches) - 20} more matches")
+
+        return 0
+
+    except requests.RequestException as e:
+        print(f"[!] Loki query failed: {e}")
+        return 1
+    except KeyboardInterrupt:
+        print("\n[!] Interrupted")
+        return 130
+    except Exception as e:
+        print(f"[!] Unexpected error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pmoves/tools/observability/logs_specialist.py
+++ b/pmoves/tools/observability/logs_specialist.py
@@ -120,7 +120,7 @@ class LokiLogsSpecialist:
         start = end - timedelta(hours=hours)
 
         # LogQL for error logs
-        logql = f'{{{{service="{service}"}}}} |~ "(?i)(error|exception|fatal|panic)"'
+        logql = f'{{service="{service}"}} |~ "(?i)(error|exception|fatal|panic)"'
 
         result = self.query_range(logql, start, end, limit=500)
 
@@ -212,7 +212,7 @@ class LokiLogsSpecialist:
         end = datetime.now()
         start = end - timedelta(hours=hours)
 
-        logql = f'{{{{service="{service}"}}}}' if service else ""
+        logql = f'{{service="{service}"}}' if service else ""
         logql += f' |~ "{pattern}"'
 
         result = self.query_range(logql, start, end, limit=1000)

--- a/pmoves/tools/observability/metrics_specialist.py
+++ b/pmoves/tools/observability/metrics_specialist.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""
+Prometheus Metrics Specialist - Observability Layer Agent
+
+Analyzes Prometheus metrics to detect anomalies, trends, and performance issues.
+Feeds insights back to Agent Zero for task assignment and system optimization.
+
+Usage:
+    python pmoves/tools/observability/metrics_specialist.py query <metric_name>
+    python pmoves/tools/observability/metrics_specialist.py anomaly <service_name>
+    python pmoves/tools/observability/metrics_specialist.py trend <metric_name> --hours 24
+
+Environment:
+    PROMETHEUS_URL - Prometheus server URL (default: http://localhost:9090)
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests
+
+# Add repo root to path
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class PrometheusMetricsSpecialist:
+    """Specialist agent for Prometheus metrics analysis and anomaly detection."""
+
+    def __init__(self, prometheus_url: str | None = None):
+        """Initialize Prometheus client.
+
+        Args:
+            prometheus_url: Prometheus server URL (default from env or localhost:9090)
+        """
+        self.prometheus_url = prometheus_url or os.getenv(
+            "PROMETHEUS_URL", "http://localhost:9090"
+        )
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
+
+    def query(self, query: str, time: str | None = None) -> Dict[str, Any]:
+        """Execute PromQL query.
+
+        Args:
+            query: PromQL expression
+            time: Optional timestamp (RFC3339 or Unix timestamp)
+
+        Returns:
+            Query result as dict
+        """
+        params = {"query": query}
+        if time:
+            params["time"] = time
+
+        response = self.session.get(
+            f"{self.prometheus_url}/api/v1/query",
+            params=params,
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def query_range(
+        self,
+        query: str,
+        start: datetime,
+        end: datetime,
+        step: str = "15s"
+    ) -> Dict[str, Any]:
+        """Execute PromQL range query.
+
+        Args:
+            query: PromQL expression
+            start: Start time
+            end: End time
+            step: Query resolution step
+
+        Returns:
+            Range query result as dict
+        """
+        params = {
+            "query": query,
+            "start": start.timestamp(),
+            "end": end.timestamp(),
+            "step": step
+        }
+
+        response = self.session.get(
+            f"{self.prometheus_url}/api/v1/query_range",
+            params=params,
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def detect_anomalies(self, service: str, hours: int = 1) -> List[Dict[str, Any]]:
+        """Detect metric anomalies for a service.
+
+        Args:
+            service: Service name to analyze
+            hours: Lookback period in hours
+
+        Returns:
+            List of detected anomalies
+        """
+        end = datetime.now()
+        start = end - timedelta(hours=hours)
+
+        anomalies = []
+
+        # Check for high error rate
+        error_rate_query = f'rate({{service}}_errors_total[5m]) > 0.05'
+        try:
+            result = self.query_range(error_rate_query, start, end)
+            if result["data"]["result"]:
+                anomalies.append({
+                    "type": "high_error_rate",
+                    "severity": "critical",
+                    "service": service,
+                    "description": f"Error rate exceeding 5% threshold",
+                    "metric": "error_rate",
+                    "value": result["data"]["result"]
+                })
+        except Exception as e:
+            print(f"[WARN] Error rate check failed: {e}")
+
+        # Check for high latency
+        latency_query = f'rate({{service}}_latency_seconds_bucket[5m])'
+        try:
+            result = self.query_range(latency_query, start, end)
+            if result["data"]["result"]:
+                anomalies.append({
+                    "type": "high_latency",
+                    "severity": "warning",
+                    "service": service,
+                    "description": f"Latency percentile p95 above threshold",
+                    "metric": "latency_p95",
+                    "value": result["data"]["result"]
+                })
+        except Exception as e:
+            print(f"[WARN] Latency check failed: {e}")
+
+        # Check for resource saturation (CPU, memory)
+        cpu_query = f'rate(process_cpu_seconds_total{{{{service="{service}"}}}[5m])) > 0.8'
+        try:
+            result = self.query_range(cpu_query, start, end)
+            if result["data"]["result"]:
+                anomalies.append({
+                    "type": "cpu_saturation",
+                    "severity": "warning",
+                    "service": service,
+                    "description": f"CPU usage above 80%",
+                    "metric": "cpu_usage",
+                    "value": result["data"]["result"]
+                })
+        except Exception as e:
+            print(f"[WARN] CPU check failed: {e}")
+
+        return anomalies
+
+    def trend_analysis(
+        self,
+        metric: str,
+        hours: int = 24
+    ) -> Dict[str, Any]:
+        """Analyze metric trends over time.
+
+        Args:
+            metric: Metric name or PromQL expression
+            hours: Analysis period in hours
+
+        Returns:
+            Trend analysis results
+        """
+        end = datetime.now()
+        start = end - timedelta(hours=hours)
+
+        result = self.query_range(metric, start, end, step="1h")
+
+        if not result["data"]["result"]:
+            return {"error": "No data returned for metric"}
+
+        # Extract values for trend analysis
+        values = []
+        for series in result["data"]["result"]:
+            for value in series.get("values", []):
+                timestamp, value = value
+                try:
+                    values.append(float(value))
+                except (ValueError, TypeError):
+                    continue
+
+        if not values:
+            return {"error": "No valid values in result"}
+
+        # Calculate trend statistics
+        avg_value = sum(values) / len(values)
+        min_value = min(values)
+        max_value = max(values)
+
+        # Simple trend detection (first half vs second half)
+        mid = len(values) // 2
+        first_half_avg = sum(values[:mid]) / mid if mid > 0 else avg_value
+        second_half_avg = sum(values[mid:]) / (len(values) - mid) if len(values) > mid else avg_value
+
+        trend_direction = "stable"
+        if second_half_avg > first_half_avg * 1.1:
+            trend_direction = "increasing"
+        elif second_half_avg < first_half_avg * 0.9:
+            trend_direction = "decreasing"
+
+        return {
+            "metric": metric,
+            "period_hours": hours,
+            "avg": avg_value,
+            "min": min_value,
+            "max": max_value,
+            "trend": trend_direction,
+            "change_percent": ((second_half_avg - first_half_avg) / first_half_avg * 100) if first_half_avg > 0 else 0
+        }
+
+    def list_service_metrics(self, service: str) -> List[str]:
+        """List available metrics for a service.
+
+        Args:
+            service: Service name pattern
+
+        Returns:
+            List of metric names matching the service
+        """
+        # Use label values to find matching metrics
+        response = self.session.get(
+            f"{self.prometheus_url}/api/v1/label/__name__/values",
+            timeout=30
+        )
+        response.raise_for_status()
+
+        all_metrics = response.json().get("data", [])
+
+        # Filter for service-specific metrics
+        service_pattern = service.lower().replace("-", "_")
+        matching_metrics = [
+            m for m in all_metrics
+            if service_pattern in m.lower()
+        ]
+
+        return matching_metrics[:50]  # Limit to prevent overwhelming output
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Prometheus Metrics Specialist - Observability Layer Agent"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Query command
+    query_parser = subparsers.add_parser("query", help="Execute PromQL query")
+    query_parser.add_argument("promql", help="PromQL expression")
+    query_parser.add_argument("--time", help="Optional timestamp")
+
+    # Anomaly detection command
+    anomaly_parser = subparsers.add_parser("anomaly", help="Detect anomalies")
+    anomaly_parser.add_argument("service", help="Service name to analyze")
+    anomaly_parser.add_argument("--hours", type=int, default=1, help="Lookback period")
+
+    # Trend analysis command
+    trend_parser = subparsers.add_parser("trend", help="Analyze metric trends")
+    trend_parser.add_argument("metric", help="Metric name or PromQL expression")
+    trend_parser.add_argument("--hours", type=int, default=24, help="Analysis period")
+
+    # List metrics command
+    list_parser = subparsers.add_parser("list", help="List service metrics")
+    list_parser.add_argument("service", help="Service name pattern")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    specialist = PrometheusMetricsSpecialist()
+
+    try:
+        if args.command == "query":
+            result = specialist.query(args.promql, args.time)
+            print(f"[+] Query result:")
+            print(result)
+
+        elif args.command == "anomaly":
+            anomalies = specialist.detect_anomalies(args.service, args.hours)
+            if anomalies:
+                print(f"[!] Found {len(anomalies)} anomalies for {args.service}:")
+                for anomaly in anomalies:
+                    print(f"  - {anomaly['type']} ({anomaly['severity']}): {anomaly['description']}")
+            else:
+                print(f"[+] No anomalies detected for {args.service}")
+
+        elif args.command == "trend":
+            trend = specialist.trend_analysis(args.metric, args.hours)
+            if "error" in trend:
+                print(f"[!] {trend['error']}")
+            else:
+                print(f"[+] Trend analysis for {trend['metric']}:")
+                print(f"  Period: {trend['period_hours']}h")
+                print(f"  Average: {trend['avg']:.2f}")
+                print(f"  Range: [{trend['min']:.2f}, {trend['max']:.2f}]")
+                print(f"  Trend: {trend['trend']} ({trend['change_percent']:+.1f}%)")
+
+        elif args.command == "list":
+            metrics = specialist.list_service_metrics(args.service)
+            print(f"[+] Found {len(metrics)} metrics for {args.service}:")
+            for metric in metrics[:20]:  # Show first 20
+                print(f"  - {metric}")
+            if len(metrics) > 20:
+                print(f"  ... and {len(metrics) - 20} more")
+
+        return 0
+
+    except requests.RequestException as e:
+        print(f"[!] Prometheus query failed: {e}")
+        return 1
+    except KeyboardInterrupt:
+        print("\n[!] Interrupted")
+        return 130
+    except Exception as e:
+        print(f"[!] Unexpected error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pmoves/tools/observability/metrics_specialist.py
+++ b/pmoves/tools/observability/metrics_specialist.py
@@ -147,7 +147,7 @@ class PrometheusMetricsSpecialist:
             print(f"[WARN] Latency check failed: {e}")
 
         # Check for resource saturation (CPU, memory)
-        cpu_query = f'rate(process_cpu_seconds_total{{{{service="{service}"}}}[5m])) > 0.8'
+        cpu_query = f'rate(process_cpu_seconds_total{{service="{service}"}}[5m]) > 0.8'
         try:
             result = self.query_range(cpu_query, start, end)
             if result["data"]["result"]:

--- a/pmoves/tools/observability/tracing_specialist.py
+++ b/pmoves/tools/observability/tracing_specialist.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Jaeger Tracing Specialist - Observability Layer Agent
+
+Analyzes distributed traces from Jaeger to identify performance bottlenecks,
+cross-service correlations, and latency issues.
+
+Usage:
+    python pmoves/tools/observability/tracing_specialist.py query <service_name>
+    python pmoves/tools/observability/tracing_specialist.py trace <trace_id>
+    python pmoves/tools/observability/tracing_specialist.py bottleneck <service_name> --hours 1
+    python pmoves/tools/observability/tracing_specialist.py compare <trace_id1> <trace_id2>
+
+Environment:
+    JAEGER_URL - Jaeger UI URL (default: http://localhost:16686)
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List
+
+import requests
+
+# Add repo root to path
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+class JaegerTracingSpecialist:
+    """Specialist agent for Jaeger distributed trace analysis."""
+
+    def __init__(self, jaeger_url: str | None = None):
+        """Initialize Jaeger client.
+
+        Args:
+            jaeger_url: Jaeger UI URL (default from env or localhost:16686)
+        """
+        self.jaeger_url = jaeger_url or os.getenv(
+            "JAEGER_URL", "http://localhost:16686"
+        )
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Accept": "application/json"
+        })
+
+    def query_traces(
+        self,
+        service: str,
+        limit: int = 20,
+        lookback_hours: int = 1
+    ) -> List[Dict[str, Any]]:
+        """Query traces for a service.
+
+        Args:
+            service: Service name
+            limit: Maximum number of traces
+            lookbackHours: Lookback period in hours
+
+        Returns:
+            List of trace metadata
+        """
+        end = datetime.now()
+        start = end - timedelta(hours=lookback_hours)
+
+        params = {
+            "service": service,
+            "limit": str(limit),
+            "lookback": f"{lookbackHours}h"
+        }
+
+        response = self.session.get(
+            f"{self.jaeger_url}/api/traces",
+            params=params,
+            timeout=30
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        return data.get("data", [])
+
+    def get_trace(self, trace_id: str) -> Dict[str, Any]:
+        """Get detailed trace information.
+
+        Args:
+            trace_id: Trace ID
+
+        Returns:
+            Trace details with spans
+        """
+        response = self.session.get(
+            f"{self.jaeger_url}/api/traces/{trace_id}",
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def analyze_bottlenecks(
+        self,
+        service: str,
+        hours: int = 1,
+        threshold_ms: float = 500.0
+    ) -> List[Dict[str, Any]]:
+        """Identify performance bottlenecks in traces.
+
+        Args:
+            service: Service name
+            hours: Lookback period
+            threshold_ms: Latency threshold in milliseconds
+
+        Returns:
+            List of bottleneck spans
+        """
+        traces = self.query_traces(service, limit=100, lookback_hours=hours)
+
+        bottlenecks = []
+
+        for trace_data in traces:
+            trace_id = trace_data.get("traceID", "unknown")
+            trace = self.get_trace(trace_id)
+
+            for span in trace.get("data", {}).get("spans", []):
+                duration = span.get("duration", 0) / 1000  # Convert microseconds to ms
+
+                if duration > threshold_ms:
+                    operation = span.get("operationName", "unknown")
+                    process = span.get("processID", "unknown")
+
+                    bottlenecks.append({
+                        "trace_id": trace_id,
+                        "span_id": span.get("spanID", "unknown"),
+                        "service": service,
+                        "operation": operation,
+                        "process": process,
+                        "duration_ms": duration,
+                        "threshold_ms": threshold_ms,
+                        "excess_ms": duration - threshold_ms
+                    })
+
+        # Sort by excess latency descending
+        bottlenecks.sort(key=lambda b: b["excess_ms"], reverse=True)
+
+        return bottlenecks
+
+    def compare_traces(self, trace_id1: str, trace_id2: str) -> Dict[str, Any]:
+        """Compare two traces to identify performance differences.
+
+        Args:
+            trace_id1: First trace ID
+            trace_id2: Second trace ID
+
+        Returns:
+            Comparison results
+        """
+        trace1 = self.get_trace(trace_id1)
+        trace2 = self.get_trace(trace_id2)
+
+        spans1 = trace1.get("data", {}).get("spans", [])
+        spans2 = trace2.get("data", {}).get("spans", [])
+
+        # Calculate total duration
+        duration1 = max(s.get("duration", 0) for s in spans1) / 1000
+        duration2 = max(s.get("duration", 0) for s in spans2) / 1000
+
+        # Group by operation
+        operations1 = {}
+        operations2 = {}
+
+        for span in spans1:
+            op = span.get("operationName", "unknown")
+            duration = span.get("duration", 0) / 1000
+            operations1[op] = operations1.get(op, 0) + duration
+
+        for span in spans2:
+            op = span.get("operationName", "unknown")
+            duration = span.get("duration", 0) / 1000
+            operations2[op] = operations2.get(op, 0) + duration
+
+        # Compare operations
+        comparison = {
+            "trace_id1": trace_id1,
+            "trace_id2": trace_id2,
+            "total_duration_ms": {
+                "trace1": duration1,
+                "trace2": duration2,
+                "diff_ms": duration2 - duration1,
+                "diff_percent": ((duration2 - duration1) / duration1 * 100) if duration1 > 0 else 0
+            },
+            "operation_comparison": []
+        }
+
+        all_ops = set(operations1.keys()) | set(operations2.keys())
+
+        for op in sorted(all_ops):
+            duration_op1 = operations1.get(op, 0)
+            duration_op2 = operations2.get(op, 0)
+
+            comparison["operation_comparison"].append({
+                "operation": op,
+                "trace1_ms": duration_op1,
+                "trace2_ms": duration_op2,
+                "diff_ms": duration_op2 - duration_op1,
+                "diff_percent": ((duration_op2 - duration_op1) / duration_op1 * 100) if duration_op1 > 0 else float('inf')
+            })
+
+        return comparison
+
+    def find_slow_spans(
+        self,
+        trace_id: str,
+        threshold_percent: float = 10.0
+    ) -> List[Dict[str, Any]]:
+        """Find spans that contribute most to trace duration.
+
+        Args:
+            trace_id: Trace ID
+            threshold_percent: Minimum duration percentage to include
+
+        Returns:
+            List of slow spans
+        """
+        trace = self.get_trace(trace_id)
+        spans = trace.get("data", {}).get("spans", [])
+
+        if not spans:
+            return []
+
+        total_duration = max(s.get("duration", 0) for s in spans)
+
+        slow_spans = []
+        for span in spans:
+            duration = span.get("duration", 0)
+            duration_percent = (duration / total_duration * 100) if total_duration > 0 else 0
+
+            if duration_percent >= threshold_percent:
+                slow_spans.append({
+                    "span_id": span.get("spanID", "unknown"),
+                    "operation": span.get("operationName", "unknown"),
+                    "service": span.get("process", {}).get("serviceName", "unknown"),
+                    "duration_ms": duration / 1000,
+                    "duration_percent": duration_percent
+                })
+
+        slow_spans.sort(key=lambda s: s["duration_percent"], reverse=True)
+
+        return slow_spans
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Jaeger Tracing Specialist - Observability Layer Agent"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Query command
+    query_parser = subparsers.add_parser("query", help="Query traces for service")
+    query_parser.add_argument("service", help="Service name")
+    query_parser.add_argument("--limit", type=int, default=20, help="Result limit")
+    query_parser.add_argument("--hours", type=int, default=1, help="Lookback period")
+
+    # Trace command
+    trace_parser = subparsers.add_parser("trace", help="Get trace details")
+    trace_parser.add_argument("trace_id", help="Trace ID")
+
+    # Bottleneck command
+    bottleneck_parser = subparsers.add_parser("bottleneck", help="Find bottlenecks")
+    bottleneck_parser.add_argument("service", help="Service name")
+    bottleneck_parser.add_argument("--hours", type=int, default=1, help="Lookback period")
+    bottleneck_parser.add_argument("--threshold", type=float, default=500.0, help="Latency threshold (ms)")
+
+    # Compare command
+    compare_parser = subparsers.add_parser("compare", help="Compare two traces")
+    compare_parser.add_argument("trace_id1", help="First trace ID")
+    compare_parser.add_argument("trace_id2", help="Second trace ID")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    specialist = JaegerTracingSpecialist()
+
+    try:
+        if args.command == "query":
+            traces = specialist.query_traces(args.service, args.limit, args.hours)
+            print(f"[+] Found {len(traces)} traces for {args.service}:")
+            for trace in traces[:10]:
+                trace_id = trace.get("traceID", "unknown")[:8]
+                print(f"  - Trace {trace_id}...")
+            if len(traces) > 10:
+                print(f"  ... and {len(traces) - 10} more")
+
+        elif args.command == "trace":
+            trace = specialist.get_trace(args.trace_id)
+            spans = trace.get("data", {}).get("spans", [])
+            total_duration = max(s.get("duration", 0) for s in spans) / 1000 if spans else 0
+
+            print(f"[+] Trace {args.trace_id}:")
+            print(f"  Total duration: {total_duration:.2f}ms")
+            print(f"  Spans: {len(spans)}")
+            print("\n  Top 5 spans by duration:")
+            for span in sorted(spans, key=lambda s: s.get("duration", 0), reverse=True)[:5]:
+                duration = span.get("duration", 0) / 1000
+                operation = span.get("operationName", "unknown")
+                print(f"    {duration:.2f}ms - {operation}")
+
+        elif args.command == "bottleneck":
+            bottlenecks = specialist.analyze_bottlenecks(
+                args.service,
+                args.hours,
+                args.threshold
+            )
+            print(f"[+] Found {len(bottlenecks)} bottlenecks for {args.service}:")
+            for bottleneck in bottlenecks[:10]:
+                print(f"  - {bottleneck['operation']}: {bottleneck['duration_ms']:.2f}ms "
+                      f"(threshold: {bottleneck['threshold_ms']:.2f}ms, "
+                      f"excess: +{bottleneck['excess_ms']:.2f}ms)")
+            if len(bottlenecks) > 10:
+                print(f"  ... and {len(bottlenecks) - 10} more")
+
+        elif args.command == "compare":
+            comparison = specialist.compare_traces(args.trace_id1, args.trace_id2)
+            print(f"[+] Trace Comparison:")
+            print(f"\n  Total Duration:")
+            print(f"    Trace 1: {comparison['total_duration_ms']['trace1']:.2f}ms")
+            print(f"    Trace 2: {comparison['total_duration_ms']['trace2']:.2f}ms")
+            print(f"    Difference: {comparison['total_duration_ms']['diff_ms']:+.2f}ms "
+                  f"({comparison['total_duration_ms']['diff_percent']:+.1f}%)")
+
+            print(f"\n  Operation Breakdown:")
+            for op_comp in comparison['operation_comparison']:
+                print(f"    {op_comp['operation']}:")
+                print(f"      Trace 1: {op_comp['trace1_ms']:.2f}ms")
+                print(f"      Trace 2: {op_comp['trace2_ms']:.2f}ms")
+                print(f"      Difference: {op_comp['diff_ms']:+.2f}ms "
+                      f"({op_comp['diff_percent']:+.1f}%)")
+
+        return 0
+
+    except requests.RequestException as e:
+        print(f"[!] Jaeger API request failed: {e}")
+        return 1
+    except KeyboardInterrupt:
+        print("\n[!] Interrupted")
+        return 130
+    except Exception as e:
+        print(f"[!] Unexpected error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pmoves/tools/observability/tracing_specialist.py
+++ b/pmoves/tools/observability/tracing_specialist.py
@@ -69,7 +69,7 @@ class JaegerTracingSpecialist:
         params = {
             "service": service,
             "limit": str(limit),
-            "lookback": f"{lookbackHours}h"
+            "lookback": f"{lookback_hours}h"
         }
 
         response = self.session.get(


### PR DESCRIPTION
## Summary

Add five specialist agents for the MOF (Metal-Organic Framework) observability layer - high-surface-area consciousness framework.

**Five Specialist Agents:**
1. metrics_specialist - Prometheus anomaly detection & trend analysis
2. dashboard_specialist - Grafana dashboard management & alerts
3. logs_specialist - Loki log pattern analysis & error correlation
4. tracing_specialist - Jaeger bottleneck identification & trace comparison
5. llm_observability - TensorZero LLM performance & cost optimization

**Agent Tools:** tools/observability/*_specialist.py (5 Python tools)
**Agent Registry:** config/agent_registry.yaml, configs/agent-teams.yaml

## Architecture Context

The observability layer is the "surface area" of the MOF architecture - full observability "pores" for agent intelligence adsorption and collective learning.

## Testing
```bash
# Test metrics specialist
python pmoves/tools/observability/metrics_specialist.py query up

# Test tracing specialist
python pmoves/tools/observability/tracing_specialist.py query tensorzero-gateway
```

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>